### PR TITLE
Fixes duplicate tooltip on cards with an edition

### DIFF
--- a/pokemon/pokejokers_4.lua
+++ b/pokemon/pokejokers_4.lua
@@ -47,7 +47,9 @@ local gastly={
   }, 
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
-    info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    if not center.edition or (center.edition and not center.edition.negative) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    end
     return {vars = {''..(G.GAME and G.GAME.probabilities.normal or 1), center.ability.extra.odds, center.ability.extra.rounds}}
   end,
   rarity = 2, 
@@ -101,7 +103,9 @@ local haunter={
   }, 
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
-    info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    if not center.edition or (center.edition and not center.edition.negative) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    end
     info_queue[#info_queue+1] = G.P_CENTERS.c_poke_linkcable
     return {vars = {''..(G.GAME and G.GAME.probabilities.normal or 1), center.ability.extra.odds}}
   end,
@@ -159,7 +163,9 @@ local gengar={
   },
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
-    info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    if not center.edition or (center.edition and not center.edition.negative) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    end
     return {vars = {''..(G.GAME and G.GAME.probabilities.normal or 1), center.ability.extra.odds}}
   end,
   rarity = "poke_safari", 

--- a/pokemon/pokejokers_5.lua
+++ b/pokemon/pokejokers_5.lua
@@ -1377,7 +1377,9 @@ local mewtwo={
   }, 
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
-    info_queue[#info_queue+1] = G.P_CENTERS.e_polychrome
+    if not center.edition or (center.edition and not center.edition.polychrome) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_polychrome
+    end
     return {vars = {center.ability.extra.Xmult_mod}}
   end,
   rarity = 4, 

--- a/pokemon/pokejokers_6.lua
+++ b/pokemon/pokejokers_6.lua
@@ -16,7 +16,9 @@ local mew ={
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
     info_queue[#info_queue+1] = {key = 'e_negative_consumable', set = 'Edition', config = {extra = 1}}
-    info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    if not center.edition or (center.edition and not center.edition.negative) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_negative
+    end
     return {vars = {''..(G.GAME and G.GAME.probabilities.normal or 1), center.ability.extra.odds}}
   end,
   rarity = 4, 

--- a/pokemon/pokejokers_9.lua
+++ b/pokemon/pokejokers_9.lua
@@ -17,8 +17,10 @@ local blissey={
   loc_vars = function(self, info_queue, center)
     type_tooltip(self, info_queue, center)
     info_queue[#info_queue+1] = G.P_CENTERS.m_lucky
-    info_queue[#info_queue+1] = G.P_CENTERS.e_polychrome
-		return {vars = {center.ability.extra.limit, center.ability.extra.triggers}}
+    if not center.edition or (center.edition and not center.edition.polychrome) then
+      info_queue[#info_queue+1] = G.P_CENTERS.e_polychrome
+    end
+    return {vars = {center.ability.extra.limit, center.ability.extra.triggers}}
   end,
   rarity = "poke_safari", 
   cost = 10,


### PR DESCRIPTION
If a card has an edition added to its `info_queue`, when an edition is applied on said card, the edition tooltip will appear twice.
This PR is made to fix that issue, making the edition tooltip appear once even if it has said edition.