### PR TITLE
Evo Juice Load Fix

### DIFF
--- a/pokemon/pokejokers_01.lua
+++ b/pokemon/pokejokers_01.lua
@@ -208,10 +208,6 @@ local charmander={
       if context.before and not context.blueprint then
         if G.GAME.current_round.discards_left == card.ability.extra.d_remaining then
             card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
-            if card.ability.extra.mult == 16 then
-              local eval = function(card) return not card.REMOVED end
-              juice_card_until(card, eval, true)
-            end
             return {
               message = localize('k_upgrade_ex'),
               colour = G.C.MULT

--- a/pokemon/pokejokers_02.lua
+++ b/pokemon/pokejokers_02.lua
@@ -394,12 +394,6 @@ local zubat={
       for k, v in pairs(G.playing_cards) do
         if v.config.center ~= G.P_CENTERS.c_base then card.ability.extra.zubat_tally = card.ability.extra.zubat_tally+1 end
       end
-      
-      if card.ability.extra.zubat_tally >= 12 and not card.ability.extra.juiced then
-        card.ability.extra.juiced = true
-        local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-        juice_card_until(card, eval, true)
-      end
     end
   end,
   calculate = function(self, card, context)

--- a/pokemon/pokejokers_04.lua
+++ b/pokemon/pokejokers_04.lua
@@ -291,12 +291,6 @@ local drowzee={
           if v.set == 'Planet' then planets_used = planets_used + 1 end
       end
       card.ability.extra.mult = planets_used * card.ability.extra.mult_mod
-      
-      if card.ability.extra.mult >= 28 and not card.ability.extra.juiced then
-        card.ability.extra.juiced = true
-        local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-        juice_card_until(card, eval, true)
-      end
     end
   end
 }

--- a/pokemon/pokejokers_34.lua
+++ b/pokemon/pokejokers_34.lua
@@ -50,28 +50,20 @@ local gimmighoul={
   update = function(self, card, dt)
     if G.STAGE == G.STAGES.RUN then
       if not card.ability.extra.previous_money then card.ability.extra.previous_money = 0 end
+      local money_diff, actual_money_diff, zero = 0, 0, 0
+      local dollars = G.GAME.dollars
+      local prev_money = card.ability.extra.previous_money
       if (SMODS.Mods["Talisman"] or {}).can_load then
-        local money_diff = math.abs(to_number(G.GAME.dollars) - to_number(card.ability.extra.previous_money))
-        if to_big(money_diff) > to_big(0) then
-          card.ability.extra.money_seen = card.ability.extra.money_seen + money_diff
-          card.ability.extra.previous_money = G.GAME.dollars
-        end
-        if to_big(card.ability.extra.money_seen) >= to_big(card.ability.extra.money_goal) and not card.ability.extra.juiced then
-          card.ability.extra.juiced = true
-          local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-          juice_card_until(card, eval, true)
-        end
-      else
-        local money_diff = math.abs(G.GAME.dollars - card.ability.extra.previous_money)
-        if money_diff > 0 then
-          card.ability.extra.money_seen = card.ability.extra.money_seen + money_diff
-          card.ability.extra.previous_money = G.GAME.dollars
-        end
-        if card.ability.extra.money_seen >= card.ability.extra.money_goal and not card.ability.extra.juiced then
-          card.ability.extra.juiced = true
-          local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-          juice_card_until(card, eval, true)
-        end
+        dollars = to_number(G.GAME.dollars)
+        prev_money = to_number(card.ability.extra.previous_money)
+        actual_money_diff = to_big(math.abs(dollars - prev_money))
+        zero = to_big(0)
+      end
+      money_diff = math.abs(dollars - prev_money)
+
+      if actual_money_diff > zero then
+        card.ability.extra.money_seen = card.ability.extra.money_seen + money_diff
+        card.ability.extra.previous_money = dollars
       end
     end
   end

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -151,7 +151,20 @@ for _, file in ipairs(pfiles) do
           if pokermon_config.jokers_only and item.rarity == "poke_safari" then
             item.rarity = 3
           end
-          item.discovered = not pokermon_config.pokemon_discovery 
+          item.discovered = not pokermon_config.pokemon_discovery
+          local prev_load = item.load
+          item.load = function(self, card, card_table, other_card)
+            card_table.ability.extra.juiced = nil
+            G.E_MANAGER:add_event(Event({
+              func = function()
+                self.calculate(self, card, {poke_load = true})
+                return true
+              end
+            }))
+            if prev_load then
+              prev_load(self, card, card_table, other_card)
+            end
+          end
           SMODS.Joker(item)
         end
       end


### PR DESCRIPTION
Evolution jitter doesn't get loaded when restarting a run
Removed existing jitter code within a few jokers and updated pokefunctions to better track evolution logic