### PR TITLE
Resolve Inconsistent add/remove to deck logic

### DIFF
--- a/pokemon/pokejokers_01.lua
+++ b/pokemon/pokejokers_01.lua
@@ -97,9 +97,7 @@ local ivysaur={
     G.hand:change_size(card.ability.extra.h_size)
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.hand:change_size(-card.ability.extra.h_size)
-    end
+    G.hand:change_size(-card.ability.extra.h_size)
   end
 }
 
@@ -169,17 +167,16 @@ local mega_venusaur = {
   atlas = "Megas",
   blueprint_compat = true,
   add_to_deck = function(self, card, from_debuff)
-    local previous_card_limit = G.hand.config.card_limit
     G.hand:change_size(card.ability.extra.h_size)
-    if G.hand and G.hand.cards and #G.hand.cards > 0 then
+    if not from_debuff and G.hand and G.hand.cards and #G.hand.cards > 0 then
       local hand_space = math.min(#G.deck.cards, card.ability.extra.h_size - 1)
       delay(0.3)
       for i=1, hand_space do --draw cards from deck
-          if G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK then 
-              draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
-          else
-              draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
-          end
+        if G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK then 
+            draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
+        else
+            draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
+        end
       end
     end
   end,
@@ -228,10 +225,8 @@ local charmander={
     return scaling_evo(self, card, context, "j_poke_charmeleon", card.ability.extra.mult, 16)
   end,
   add_to_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
-      ease_discard(card.ability.extra.d_size)
-    end
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
@@ -275,14 +270,12 @@ local charmeleon={
     return scaling_evo(self, card, context, "j_poke_charizard", card.ability.extra.mult, 36)
   end,
   add_to_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
-      ease_discard(card.ability.extra.d_size)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
-      ease_discard(-card.ability.extra.d_size)
-    end
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
+    ease_discard(-card.ability.extra.d_size)
   end
 }
 
@@ -433,13 +426,16 @@ local squirtle={
     end
   end,
   add_to_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-      ease_hands_played(card.ability.extra.hands)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    ease_hands_played(card.ability.extra.hands)
   end,
   remove_from_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-      ease_hands_played(-card.ability.extra.hands)
-  end, 
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
+  end,
 }
 local wartortle={
   name = "wartortle", 
@@ -476,13 +472,16 @@ local wartortle={
     end
   end,
   add_to_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-      ease_hands_played(card.ability.extra.hands)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    ease_hands_played(card.ability.extra.hands)
   end,
   remove_from_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-      ease_hands_played(-card.ability.extra.hands)
-  end, 
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
+  end,
 }
 local blastoise={
   name = "blastoise", 
@@ -511,12 +510,15 @@ local blastoise={
     end
   end,
   add_to_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-      ease_hands_played(card.ability.extra.hands)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    ease_hands_played(card.ability.extra.hands)
   end,
   remove_from_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-      ease_hands_played(-card.ability.extra.hands)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
   end,
   megas = {"mega_blastoise"}
 }
@@ -540,17 +542,12 @@ local mega_blastoise = {
     ease_hands_played(card.ability.extra.hands)
   end,
   remove_from_deck = function(self, card, from_debuff)
-    local hands_to_remove = nil
-    if G.GAME.current_round.hands_left > card.ability.extra.hands then
-      hands_to_remove = card.ability.extra.hands
-    else
-      hands_to_remove = G.GAME.current_round.hands_left - 1
-    end
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    if hands_to_remove > 0 then
-      ease_hands_played(-hands_to_remove)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
     end
-  end
+  end,
 }
 local caterpie={
   name = "caterpie", 

--- a/pokemon/pokejokers_01.lua
+++ b/pokemon/pokejokers_01.lua
@@ -427,7 +427,9 @@ local squirtle={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
@@ -473,7 +475,9 @@ local wartortle={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
@@ -511,7 +515,9 @@ local blastoise={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
@@ -539,7 +545,9 @@ local mega_blastoise = {
   blueprint_compat = false,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands

--- a/pokemon/pokejokers_03.lua
+++ b/pokemon/pokejokers_03.lua
@@ -293,7 +293,10 @@ local machop={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
     ease_discard(card.ability.extra.discards)
   end
 }
@@ -334,10 +337,9 @@ local machoke={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    if G.GAME.current_round.hands_left <= 2 then
-      ease_hands_played(-G.GAME.current_round.hands_left + 1)
-    elseif G.GAME.current_round.hands_left > 2 then
-      ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
     end
     ease_discard(card.ability.extra.discards)
   end
@@ -376,10 +378,9 @@ local machamp={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    if G.GAME.current_round.hands_left <= 4 then
-      ease_hands_played(-G.GAME.current_round.hands_left + 1)
-    elseif G.GAME.current_round.hands_left > 4 then
-      ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
     end
     ease_discard(card.ability.extra.discards)
   end

--- a/pokemon/pokejokers_03.lua
+++ b/pokemon/pokejokers_03.lua
@@ -287,7 +287,9 @@ local machop={
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.discards
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
     ease_discard(-card.ability.extra.discards)
   end,
   remove_from_deck = function(self, card, from_debuff)
@@ -331,7 +333,9 @@ local machoke={
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.discards
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
     ease_discard(-card.ability.extra.discards)
   end,
   remove_from_deck = function(self, card, from_debuff)
@@ -372,7 +376,9 @@ local machamp={
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.discards
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
     ease_discard(-card.ability.extra.discards)
   end,
   remove_from_deck = function(self, card, from_debuff)

--- a/pokemon/pokejokers_04.lua
+++ b/pokemon/pokejokers_04.lua
@@ -1017,7 +1017,9 @@ local kangaskhan={
       G.consumeables.config.card_limit = G.consumeables.config.card_limit - card.ability.extra.card_limit
       return true end }))
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end, 
   megas = {"mega_kangaskhan"}
 }

--- a/pokemon/pokejokers_04.lua
+++ b/pokemon/pokejokers_04.lua
@@ -1007,7 +1007,10 @@ local kangaskhan={
       G.consumeables.config.card_limit = G.consumeables.config.card_limit + card.ability.extra.card_limit
       return true end }))
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.E_MANAGER:add_event(Event({func = function()

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -205,9 +205,7 @@ local grovyle={
     G.hand:change_size(card.ability.extra.h_size)
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.hand:change_size(-card.ability.extra.h_size)
-    end
+    G.hand:change_size(-card.ability.extra.h_size)
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
@@ -392,8 +390,8 @@ local combusken={
     return scaling_evo(self, card, context, "j_poke_blaziken", card.ability.extra.mult_earned, 150)
   end,
   add_to_deck = function(self, card, from_debuff)
-      G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
-      ease_discard(card.ability.extra.d_size)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
@@ -518,7 +516,10 @@ local mudkip={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
@@ -570,7 +571,10 @@ local marshtomp={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
@@ -622,7 +626,10 @@ local swampert={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    ease_hands_played(-card.ability.extra.hands)
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -512,7 +512,9 @@ local mudkip={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
@@ -567,7 +569,9 @@ local marshtomp={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
@@ -622,7 +626,9 @@ local swampert={
   end,
   add_to_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
-    ease_hands_played(card.ability.extra.hands)
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands

--- a/pokemon/pokejokers_13.lua
+++ b/pokemon/pokejokers_13.lua
@@ -33,14 +33,10 @@ local snorunt={
     end
   end,
   add_to_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.bankrupt_at = G.GAME.bankrupt_at - card.ability.extra.debt
-    end
+    G.GAME.bankrupt_at = G.GAME.bankrupt_at - card.ability.extra.debt
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.bankrupt_at = G.GAME.bankrupt_at + card.ability.extra.debt
-    end
+    G.GAME.bankrupt_at = G.GAME.bankrupt_at + card.ability.extra.debt
   end,
 }
 -- Glalie 362
@@ -294,16 +290,12 @@ local jirachi_booster = {
   perishable_compat = false,
   blueprint_compat = false,
   add_to_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      SMODS.change_booster_limit(card.ability.extra.bonus_packs)
-      G.GAME.extra_pocket_picks = (G.GAME.extra_pocket_picks or 0) + card.ability.extra.bonus_choices
-    end
+    SMODS.change_booster_limit(card.ability.extra.bonus_packs)
+    G.GAME.extra_pocket_picks = (G.GAME.extra_pocket_picks or 0) + card.ability.extra.bonus_choices
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      SMODS.change_booster_limit(-card.ability.extra.bonus_packs)
-      G.GAME.extra_pocket_picks = (G.GAME.extra_pocket_picks or 0) - card.ability.extra.bonus_choices
-    end
+    SMODS.change_booster_limit(-card.ability.extra.bonus_packs)
+    G.GAME.extra_pocket_picks = (G.GAME.extra_pocket_picks or 0) - card.ability.extra.bonus_choices
   end,
   custom_pool_func = true,
   in_pool = function(self)
@@ -426,16 +418,12 @@ local jirachi_negging = {
   perishable_compat = false,
   blueprint_compat = false,
   add_to_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.jokers.config.card_limit = G.jokers.config.card_limit + card.ability.extra.slots
-      G.GAME.negative_edition_rate = (G.GAME.negative_edition_rate or 1) * card.ability.extra.chance
-    end
+    G.jokers.config.card_limit = G.jokers.config.card_limit + card.ability.extra.slots
+    G.GAME.negative_edition_rate = (G.GAME.negative_edition_rate or 1) * card.ability.extra.chance
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.jokers.config.card_limit = G.jokers.config.card_limit - card.ability.extra.slots
-      G.GAME.negative_edition_rate = (G.GAME.negative_edition_rate or 1) / card.ability.extra.chance
-    end
+    G.jokers.config.card_limit = G.jokers.config.card_limit - card.ability.extra.slots
+    G.GAME.negative_edition_rate = (G.GAME.negative_edition_rate or 1) / card.ability.extra.chance
   end,
   custom_pool_func = true,
   in_pool = function(self)

--- a/pokemon/pokejokers_16.lua
+++ b/pokemon/pokejokers_16.lua
@@ -509,14 +509,10 @@ local froslass={
     end
   end,
   add_to_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.bankrupt_at = G.GAME.bankrupt_at - card.ability.extra.debt
-    end
+    G.GAME.bankrupt_at = G.GAME.bankrupt_at - card.ability.extra.debt
   end,
   remove_from_deck = function(self, card, from_debuff)
-    if not from_debuff then
-      G.GAME.bankrupt_at = G.GAME.bankrupt_at + card.ability.extra.debt
-    end
+    G.GAME.bankrupt_at = G.GAME.bankrupt_at + card.ability.extra.debt
   end,
 }
 -- Rotom 479


### PR DESCRIPTION
Some pokermons would decrease value when debuffed, but not increase them properly, leading to a permanent loss of hands/discards/hand size

Matched all the functionality to base Balatro (Troubadour, Juggler, Drunkard)