### PR TITLE
Hoppip Line & Conversion Util

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -76,6 +76,7 @@ family = {
     {"beldum", "metang", "metagross"},
     {"jirachi", "jirachi_banker", "jirachi_booster", "jirachi_power", "jirachi_copy", "jirachi_fixer"},
     {"sentret", "furret"},
+    {"hoppip", "skiploom", "jumpluff"},
     {"mantyke", "mantine"},
     {"treecko", "grovyle", "sceptile"},
     {"torchic", "combusken", "blaziken"},

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -324,7 +324,7 @@ end
 
 local poke_id_to_rank = {'A','2','3','4','5','6','7','8','9','T','J','K','Q','A'}
 poke_convert_cards_to = function(cards, t)
-  if cards:is(Card) then cards = {cards} end
+  if cards and cards.is and cards:is(Card) then cards = {cards} end
   if not t.seal then
     for i = 1, #cards do
       poke_conversion_event_helper(function() cards[i]:flip(); cards[i]:juice_up(0.3, 0.3) end)

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -354,10 +354,10 @@ poke_convert_cards_to = function(cards, t)
   end
   if not t.seal then
     for i = 1, #cards do
-      poke_conversion_event_helper(function() cards[i]:flip(); cards[i]:juice_up(0.3, 0.3) end)
+      poke_conversion_event_helper(function() cards[i]:flip(); cards[i]:juice_up(0.3, 0.3) end, 0.2)
     end
   end
-  delay(0.5)
+  delay(0.3)
   if cards == G.hand.highlighted then
     poke_conversion_event_helper(function() G.hand:unhighlight_all() end)
   end

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1997,7 +1997,7 @@ return {
                 name = 'Jumpluff',
                 text = {
                     "{C:attention}+#1#{} hand size",
-                    "First two {C:attention}discarded cards{} becomes {C:dark_edition}Wild{}",
+                    "First two {C:attention}discarded cards{} become {C:dark_edition}Wild{}",
                     "{S:1.1,C:red,E:2}self destructs{} on discard",
                 }
             },

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1975,6 +1975,32 @@ return {
                     "{s:0.8}Suit cycles after scoring {C:inactive,s:0.8}(#3#, #4#, #5#, #6#)",
                 } 
             },
+            j_poke_hoppip = {
+                name = 'Hoppip',
+                text = {
+                    "{C:attention}+#1#{} hand size",
+                    "First {C:attention}discarded card{} becomes {C:dark_edition}Wild{}",
+                    "{S:1.1,C:red,E:2}self destructs{} on discard",
+                    "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
+                }
+            },
+            j_poke_skiploom = {
+                name = 'Skiploom',
+                text = {
+                    "{C:attention}+#1#{} hand size",
+                    "First {C:attention}discarded card{} becomes {C:dark_edition}Wild{}",
+                    "{S:1.1,C:red,E:2}self destructs{} on discard",
+                    "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
+                }
+            },
+            j_poke_jumpluff = {
+                name = 'Jumpluff',
+                text = {
+                    "{C:attention}+#1#{} hand size",
+                    "First two {C:attention}discarded cards{} becomes {C:dark_edition}Wild{}",
+                    "{S:1.1,C:red,E:2}self destructs{} on discard",
+                }
+            },
             j_poke_espeon = {
                 name = 'Espeon',
                 text = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -3764,6 +3764,10 @@ return {
             poke_tangela_bonus = "All!",
             --Golbat And Crobat thingy
             poke_screech_ex = "Skree!",
+            --Hoppip Line
+            poke_hop_ex = "Hop!",
+            poke_skip_ex = "Skip!",
+            poke_jump_ex = "Jump!",
             --From Bellossom
             poke_petal_dance_ex = "Petal!",
             poke_petal_dance = "Petal",

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -141,8 +141,125 @@ local politoed={
   end,
 }
 -- Hoppip 187
+local hoppip={
+  name = "hoppip",
+  pos = {x = 5, y = 3},
+  config = {extra = {h_size = 2, rounds = 5}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    info_queue[#info_queue+1] = G.P_CENTERS.m_wild
+    return {vars = {center.ability.extra.h_size, center.ability.extra.rounds}}
+  end,
+  rarity = 1,
+  cost = 3,
+  stage = "Basic",
+  ptype = "Grass",
+  atlas = "Pokedex2",
+  blueprint_compat = false,
+  calculate = function(self, card, context)
+    if context.pre_discard and context.full_hand and #context.full_hand > 0 --[[ and not context.hook --]] then
+      local target = context.full_hand[1]
+      poke_convert_cards_to(target, {mod_conv = 'm_wild'})
+      G.E_MANAGER:add_event(Event({
+        func = function()
+          remove(self, card, context)
+          return true
+        end
+      }))
+      return {
+        message = localize("poke_screech_ex"),
+      }
+    end
+    return level_evo(self, card, context, "j_poke_skiploom")
+  end,
+  add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end
+}
 -- Skiploom 188
+local skiploom={
+  name = "skiploom",
+  pos = {x = 6, y = 3},
+  config = {extra = {h_size = 3, rounds = 5}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    info_queue[#info_queue+1] = G.P_CENTERS.m_wild
+    return {vars = {center.ability.extra.h_size, center.ability.extra.rounds}}
+  end,
+  rarity = 2,
+  cost = 5,
+  stage = "One",
+  ptype = "Grass",
+  atlas = "Pokedex2",
+  blueprint_compat = false,
+  calculate = function(self, card, context)
+    if context.pre_discard and context.cardarea == G.play --[[ and not context.hook --]] then
+      if context.full_hand and #context.full_hand > 0 then
+        local target = context.full_hand[1]
+        poke_convert_cards_to(target, {mod_conv = 'm_wild'})
+        G.E_MANAGER:add_event(Event({
+          func = function()
+            remove(self, card, context)
+            return true
+          end
+        }))
+        return {
+          message = localize("poke_screech_ex"),
+        }
+      end
+    end
+    return level_evo(self, card, context, "j_poke_jumpluff")
+  end,
+  add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end
+}
 -- Jumpluff 189
+local jumpluff={
+  name = "jumpluff",
+  pos = {x = 7, y = 3},
+  config = {extra = {h_size = 4}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    info_queue[#info_queue+1] = G.P_CENTERS.m_wild
+    return {vars = {center.ability.extra.h_size}}
+  end,
+  rarity = "poke_safari",
+  cost = 9,
+  stage = "Two",
+  ptype = "Grass",
+  atlas = "Pokedex2",
+  blueprint_compat = false,
+  calculate = function(self, card, context)
+    if context.pre_discard and context.cardarea == G.play --[[ and not context.hook --]] then
+      if context.full_hand and #context.full_hand > 0 then
+        local target = {context.full_hand[1],context.full_hand[2]}
+        poke_convert_cards_to(target, {mod_conv = 'm_wild'})
+        G.E_MANAGER:add_event(Event({
+          func = function()
+            remove(self, card, context)
+            return true
+          end
+        }))
+        return {
+          message = localize("poke_screech_ex"),
+        }
+      end
+    end
+  end,
+  add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end
+}
 -- Aipom 190
 -- Sunkern 191
 -- Sunflora 192
@@ -400,5 +517,5 @@ local steelix={
 -- Granbull 210
 
 return {name = "Pokemon Jokers 181-210", 
-        list = {bellossom, politoed, espeon, umbreon, slowking, steelix},
+        list = {bellossom, politoed, hoppip, skiploom, jumpluff, espeon, umbreon, slowking, steelix},
 }

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -151,13 +151,15 @@ local hoppip={
     return {vars = {center.ability.extra.h_size, center.ability.extra.rounds}}
   end,
   rarity = 1,
-  cost = 3,
+  cost = 4,
   stage = "Basic",
   ptype = "Grass",
   atlas = "Pokedex2",
   blueprint_compat = false,
+  perishable_compat = false,
+  eternal_compat = false,
   calculate = function(self, card, context)
-    if context.pre_discard and context.full_hand and #context.full_hand > 0 --[[ and not context.hook --]] then
+    if context.pre_discard and context.full_hand and #context.full_hand > 0 and not context.hook then
       local target = context.full_hand[1]
       poke_convert_cards_to(target, {mod_conv = 'm_wild'})
       G.E_MANAGER:add_event(Event({
@@ -167,7 +169,7 @@ local hoppip={
         end
       }))
       return {
-        message = localize("poke_screech_ex"),
+        message = localize("poke_hop_ex"),
       }
     end
     return level_evo(self, card, context, "j_poke_skiploom")
@@ -190,26 +192,26 @@ local skiploom={
     return {vars = {center.ability.extra.h_size, center.ability.extra.rounds}}
   end,
   rarity = 2,
-  cost = 5,
+  cost = 6,
   stage = "One",
   ptype = "Grass",
   atlas = "Pokedex2",
   blueprint_compat = false,
+  perishable_compat = false,
+  eternal_compat = false,
   calculate = function(self, card, context)
-    if context.pre_discard and context.cardarea == G.play --[[ and not context.hook --]] then
-      if context.full_hand and #context.full_hand > 0 then
-        local target = context.full_hand[1]
-        poke_convert_cards_to(target, {mod_conv = 'm_wild'})
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            remove(self, card, context)
-            return true
-          end
-        }))
-        return {
-          message = localize("poke_screech_ex"),
-        }
-      end
+    if context.pre_discard and context.full_hand and #context.full_hand > 0 and not context.hook then
+      local target = context.full_hand[1]
+      poke_convert_cards_to(target, {mod_conv = 'm_wild'})
+      G.E_MANAGER:add_event(Event({
+        func = function()
+          remove(self, card, context)
+          return true
+        end
+      }))
+      return {
+        message = localize("poke_skip_ex"),
+      }
     end
     return level_evo(self, card, context, "j_poke_jumpluff")
   end,
@@ -231,26 +233,26 @@ local jumpluff={
     return {vars = {center.ability.extra.h_size}}
   end,
   rarity = "poke_safari",
-  cost = 9,
+  cost = 8,
   stage = "Two",
   ptype = "Grass",
   atlas = "Pokedex2",
   blueprint_compat = false,
+  perishable_compat = false,
+  eternal_compat = false,
   calculate = function(self, card, context)
-    if context.pre_discard and context.cardarea == G.play --[[ and not context.hook --]] then
-      if context.full_hand and #context.full_hand > 0 then
-        local target = {context.full_hand[1],context.full_hand[2]}
-        poke_convert_cards_to(target, {mod_conv = 'm_wild'})
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            remove(self, card, context)
-            return true
-          end
-        }))
-        return {
-          message = localize("poke_screech_ex"),
-        }
-      end
+    if context.pre_discard and context.full_hand and #context.full_hand > 0 and not context.hook then
+      local target = {context.full_hand[1],context.full_hand[2]}
+      poke_convert_cards_to(target, {mod_conv = 'm_wild'})
+      G.E_MANAGER:add_event(Event({
+        func = function()
+          remove(self, card, context)
+          return true
+        end
+      }))
+      return {
+        message = localize("poke_jump_ex"),
+      }
     end
   end,
   add_to_deck = function(self, card, from_debuff)


### PR DESCRIPTION
Hoppip:
> +2 Hand size
> Converts first discarded card to Wild
> Kills itself after any discard
> Evolves in 5

Skiploom:
> +3 Hand size
> Converts first discarded card to Wild
> Kills itself after any discard
> Evolves in 5

Jumpluff:
> +4 Hand size
> Converts first two discarded cards to Wild
> Kills itself after any discard
![hoppip line](https://github.com/user-attachments/assets/17b3f6c2-6f75-4e69-9461-7fc7c3ef82a1)

ALSO, added a `poke_convert_cards_to` function to the pokeutils.lua file
Basic usage: `poke_convert_cards_to(card_list, table_config)`
- Suits & Ranks:
  - table_config.suit_conv = 'Hearts'
  - table_config.up = true 
  - table_config.down = true
  - table_config.random = true
- Enhancements:
  - table_config.mod_conv = 'm_wild'
- Seals:
  - table_config.seal = 'Purple'

It will flip the card over, apply the conversion, and flip it back.
If the seal is being applied, it won't flip the card.