### PR TITLE
Pokedex Change

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2878,8 +2878,7 @@ return {
             j_poke_pokedex = {
                 name = 'Pokedex',
                 text = {
-                    "{C:mult}+#2#{} Mult for each Joker",
-                    "you have that has a {C:pink}Type{}",
+                    "{C:mult}+#2#{} Mult for each unique {C:attention}Joker{} seen",
                     "{br:3}text needs to be here to work",
                     "{C:attention}Pokemon{} from the same", 
                     "evolutionary line may appear",
@@ -3797,7 +3796,8 @@ return {
             poke_make_it_rain = "Make it Rain!",
             poke_val_down = "Value Down!",
             poke_powder_ex = "Powder Snow!",
-            poke_future_sight = "Future Sight!"
+            poke_future_sight = "Future Sight!",
+            poke_pokedex_entry = "New Entry!",
         },
         --These are the Labels
         --You know how things like seals and editions have those badges at the bottom? That's what this is for!


### PR DESCRIPTION
Pokedex:
> +1 Mult for each unique Joker seen
> Pokemon from the same evolutionary line may appear

![image](https://github.com/user-attachments/assets/6f50ddbf-b6d1-4ca5-994e-7a58d30834a2)

When a Joker is created mid scoring, it should not update the mult until after the scoring.
Pokedex observers jokers in the shops slots, joker slots, or pack slots (when a booster pack is opened) 