### PR TITLE
Refactor Baby/Volatile to support SMODS.set_debuff

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1013,7 +1013,7 @@ faint_baby_poke = function(self, card, context)
         G.E_MANAGER:add_event(Event({
           func = function()
             card.ability.fainted = G.GAME.round
-            card.set_debuff()
+            card:set_debuff()
             return true
           end
         })) 

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1012,8 +1012,9 @@ faint_baby_poke = function(self, card, context)
       if not alive then
         G.E_MANAGER:add_event(Event({
           func = function()
-              card.debuff = true
-              return true
+            card.ability.fainted = G.GAME.round
+            card.set_debuff()
+            return true
           end
         })) 
         card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_faint_ex'), colour = G.C.MULT})

--- a/pokemon/pokejokers_04.lua
+++ b/pokemon/pokejokers_04.lua
@@ -426,7 +426,8 @@ local voltorb={
       if context.joker_main and volatile_active(self, card, 'right') then
         G.E_MANAGER:add_event(Event({
           func = function()
-              card.debuff = true
+              card.ability.fainted = G.GAME.round
+              card:set_debuff()
               return true
           end
         })) 
@@ -462,8 +463,9 @@ local electrode={
         ease_poke_dollars(card, "electrode", card.ability.extra.money)
         G.E_MANAGER:add_event(Event({
           func = function()
-              card.debuff = true
-              return true
+            card.ability.fainted = G.GAME.round
+            card:set_debuff()
+            return true
           end
         })) 
         

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -31,6 +31,13 @@ SMODS.UndiscoveredSprite({
 mod_dir = ''..SMODS.current_mod.path
 pokermon_config = SMODS.current_mod.config
 
+SMODS.current_mod.set_debuff = function(card)
+  if card and card.ability and card.ability.fainted == G.GAME.round then
+    return G.STATE == G.STATES.SELECTING_HAND or G.STATE == G.STATES.HAND_PLAYED or G.STATE == G.STATES.DRAW_TO_HAND
+  end
+  return false
+end
+
 --Load Custom Rarities
 SMODS.Rarity{
     key = "safari",


### PR DESCRIPTION
Create a SMODS.current_mod.set_debuff function to update fainted pokemon's statuses.

It will keep them fainted until the Cash Out screen appears, and prevent any evolution from occurring.