### PR TITLE
Fixed Collection sizing problem on leaving Pokedex

### DIFF
--- a/pokeui.lua
+++ b/pokeui.lua
@@ -606,7 +606,7 @@ end
 
 G.FUNCS.pokedex_back = function()
   G.FUNCS.your_collection_jokers()
-  G.FUNCS.your_collection_joker_page({cycle_config = {current_option = poke_joker_page}})
+  G.FUNCS.SMODS_card_collection_page({cycle_config = {current_option = poke_joker_page}})
   local page = G.OVERLAY_MENU:get_UIE_by_ID('cycle_shoulders').children[1].children[1]
   page.config.ref_table.current_option = poke_joker_page
   page.config.ref_table.current_option_val = page.config.ref_table.options[poke_joker_page]


### PR DESCRIPTION
Previously, we used `your_collection_joker_page` to move the collection page back to where it was. However, that's the default page movement, which doesn't filter `no_collection` or sub-collections like just Pokermon Additions

I replaced it with `SMODS_card_collection_page` which is created upon collection creation (if you're using SMODS) and will redirect to the correct page contents