### PR TITLE
Fix for Weird Logic when Shiny is Debuffed

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -73,7 +73,7 @@ target = "card.lua"
 pattern = "self.added_to_deck = true"
 position = "after"
 payload = '''
-if self.config.shiny_on_add then
+if self.config.shiny_on_add and not self.debuff then
   SMODS.change_booster_limit(1)
 end
 '''

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -451,7 +451,7 @@ end
 --To remove the booster slot from shinies
 local removed = Card.remove
 function Card:remove()
-  if self.edition and self.edition.poke_shiny and self.area and (self.area == G.jokers or self.area == G.hand or self.area == G.play) then
+  if self.edition and self.edition.poke_shiny and not self.debuff and self.area and (self.area == G.jokers or self.area == G.hand or self.area == G.play) then
     SMODS.change_booster_limit(-1)
   end
   return removed(self)


### PR DESCRIPTION
Added debuff checks for changing booster limit
Matched Balatro's behavior with negatives: Slots don't disappear when joker is debuffed