### PR TITLE
Shiny edition changes

### DIFF
--- a/assets/shaders/shiny.fs
+++ b/assets/shaders/shiny.fs
@@ -1,80 +1,155 @@
 #if defined(VERTEX) || __VERSION__ > 100 || defined(GL_FRAGMENT_PRECISION_HIGH)
-	#define PRECISION highp
+	#define MY_HIGHP_OR_MEDIUMP highp
 #else
-	#define PRECISION mediump
+	#define MY_HIGHP_OR_MEDIUMP mediump
 #endif
 
-// Look ionized.fs for explanation
-extern PRECISION vec2 shiny;
+//
+// GLSL textureless classic 3D noise "cnoise",
+// with an RSL-style periodic variant "pnoise".
+// Author:  Stefan Gustavson (stefan.gustavson@liu.se)
+// Version: 2024-11-07
+//
+// Many thanks to Ian McEwan of Ashima Arts for the
+// ideas for permutation and gradient selection.
+//
+// Copyright (c) 2011 Stefan Gustavson. All rights reserved.
+// Distributed under the MIT license. See LICENSE file.
+// https://github.com/stegu/webgl-noise
+//
 
-extern PRECISION number dissolve;
-extern PRECISION number time;
-// (sprite_pos_x, sprite_pos_y, sprite_width, sprite_height) [not normalized]
-extern PRECISION vec4 texture_details;
-// (width, height) for atlas texture [not normalized]
-extern PRECISION vec2 image_details;
-extern bool shadow;
-extern PRECISION vec4 burn_colour_1;
-extern PRECISION vec4 burn_colour_2;
-
-// [Util]
-// Transform color from HSL to RGB 
-vec4 RGB(vec4 c);
-
-// [Util]
-// Transform color from RGB to HSL
-vec4 HSL(vec4 c);
-
-// [Required] 
-// Apply dissolve effect (when card is being "burnt", e.g. when consumable is used)
-vec4 dissolve_mask(vec4 tex, vec2 texture_coords, vec2 uv);
-
-// This is what actually changes the look of card
-vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords )
+vec3 mod289(vec3 x)
 {
-    // Take pixel color (rgba) from `texture` at `texture_coords`, equivalent of texture2D in GLSL
-    vec4 tex = Texel(texture, texture_coords);
-    // Position of a pixel within the sprite
-	vec2 uv = (((texture_coords)*(image_details)) - texture_details.xy*texture_details.ba)/texture_details.ba;
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
 
-    float t = shiny.g + time;
-    float adjust_value = 0.1 * sin(t) + 0.5;
-    vec2 adjusted_uv = uv - vec2(adjust_value, adjust_value);
-    adjusted_uv.x = adjusted_uv.x*texture_details.b/texture_details.a;
-    adjusted_uv.y = adjusted_uv.y*texture_details.b/texture_details.a;
-    
+vec4 mod289(vec4 x)
+{
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 permute(vec4 x)
+{
+  return mod289(((x*34.0)+10.0)*x);
+}
+
+vec4 taylorInvSqrt(vec4 r)
+{
+  return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+vec3 fade(vec3 t) {
+  return t*t*t*(t*(t*6.0-15.0)+10.0);
+}
+
+// Classic Perlin noise
+float cnoise(vec3 P)
+{
+  vec3 Pi0 = floor(P); // Integer part for indexing
+  vec3 Pi1 = Pi0 + vec3(1.0); // Integer part + 1
+  Pi0 = mod289(Pi0);
+  Pi1 = mod289(Pi1);
+  vec3 Pf0 = fract(P); // Fractional part for interpolation
+  vec3 Pf1 = Pf0 - vec3(1.0); // Fractional part - 1.0
+  vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
+  vec4 iy = vec4(Pi0.yy, Pi1.yy);
+  vec4 iz0 = Pi0.zzzz;
+  vec4 iz1 = Pi1.zzzz;
+
+  vec4 ixy = permute(permute(ix) + iy);
+  vec4 ixy0 = permute(ixy + iz0);
+  vec4 ixy1 = permute(ixy + iz1);
+
+  vec4 gx0 = ixy0 * (1.0 / 7.0);
+  vec4 gy0 = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
+  gx0 = fract(gx0);
+  vec4 gz0 = vec4(0.5) - abs(gx0) - abs(gy0);
+  vec4 sz0 = step(gz0, vec4(0.0));
+  gx0 -= sz0 * (step(0.0, gx0) - 0.5);
+  gy0 -= sz0 * (step(0.0, gy0) - 0.5);
+
+  vec4 gx1 = ixy1 * (1.0 / 7.0);
+  vec4 gy1 = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
+  gx1 = fract(gx1);
+  vec4 gz1 = vec4(0.5) - abs(gx1) - abs(gy1);
+  vec4 sz1 = step(gz1, vec4(0.0));
+  gx1 -= sz1 * (step(0.0, gx1) - 0.5);
+  gy1 -= sz1 * (step(0.0, gy1) - 0.5);
+
+  vec3 g000 = vec3(gx0.x,gy0.x,gz0.x);
+  vec3 g100 = vec3(gx0.y,gy0.y,gz0.y);
+  vec3 g010 = vec3(gx0.z,gy0.z,gz0.z);
+  vec3 g110 = vec3(gx0.w,gy0.w,gz0.w);
+  vec3 g001 = vec3(gx1.x,gy1.x,gz1.x);
+  vec3 g101 = vec3(gx1.y,gy1.y,gz1.y);
+  vec3 g011 = vec3(gx1.z,gy1.z,gz1.z);
+  vec3 g111 = vec3(gx1.w,gy1.w,gz1.w);
+
+  vec4 norm0 = taylorInvSqrt(vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
+  vec4 norm1 = taylorInvSqrt(vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
+
+  float n000 = norm0.x * dot(g000, Pf0);
+  float n010 = norm0.y * dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
+  float n100 = norm0.z * dot(g100, vec3(Pf1.x, Pf0.yz));
+  float n110 = norm0.w * dot(g110, vec3(Pf1.xy, Pf0.z));
+  float n001 = norm1.x * dot(g001, vec3(Pf0.xy, Pf1.z));
+  float n011 = norm1.y * dot(g011, vec3(Pf0.x, Pf1.yz));
+  float n101 = norm1.z * dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
+  float n111 = norm1.w * dot(g111, Pf1);
+
+  vec3 fade_xyz = fade(Pf0);
+  vec4 n_z = mix(vec4(n000, n100, n010, n110), vec4(n001, n101, n011, n111), fade_xyz.z);
+  vec2 n_yz = mix(n_z.xy, n_z.zw, fade_xyz.y);
+  float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x); 
+  return abs(2.2 * n_xyz);
+}
 
 
-    vec4 hsl = HSL(tex); // convert texture to HSL values
-    vec4 bhsl = HSL(tex); // make a base copy of HSL values
+extern MY_HIGHP_OR_MEDIUMP vec2 shiny;
+extern MY_HIGHP_OR_MEDIUMP number dissolve;
+extern MY_HIGHP_OR_MEDIUMP number time;
+extern MY_HIGHP_OR_MEDIUMP vec4 texture_details;
+extern MY_HIGHP_OR_MEDIUMP vec2 image_details;
+extern bool shadow;
+extern MY_HIGHP_OR_MEDIUMP vec4 burn_colour_1;
+extern MY_HIGHP_OR_MEDIUMP vec4 burn_colour_2;
 
-    //vec2 rotater = vec2(cos(shiny.r*0.1221), sin(shiny.r*0.3512));
-
-
-    if (shiny.g > 0.0 || shiny.g < 0.0) {
-        // hsl.y = 0.02;
-        hsl.x = mod(hsl.x + .5, 1);
-        hsl.y = min(hsl.y, .7);
-        hsl.z *= (1 - adjusted_uv.x*(cos(shiny.r*0.512)));
+vec4 dissolve_mask(vec4 tex, vec2 texture_coords, vec2 uv)
+{
+    if (dissolve < 0.001) {
+        return vec4(shadow ? vec3(0.,0.,0.) : tex.xyz, shadow ? tex.a*0.3: tex.a);
     }
 
-    if (bhsl.z > 0.95){
-        hsl.a = 0;
+    float adjusted_dissolve = (dissolve*dissolve*(3.-2.*dissolve))*1.02 - 0.01; //Adjusting 0.0-1.0 to fall to -0.1 - 1.1 scale so the mask does not pause at extreme values
+
+	float t = time * 10.0 + 2003.;
+	vec2 floored_uv = (floor((uv*texture_details.ba)))/max(texture_details.b, texture_details.a);
+    vec2 uv_scaled_centered = (floored_uv - 0.5) * 2.3 * max(texture_details.b, texture_details.a);
+	
+	vec2 field_part1 = uv_scaled_centered + 50.*vec2(sin(-t / 143.6340), cos(-t / 99.4324));
+	vec2 field_part2 = uv_scaled_centered + 50.*vec2(cos( t / 53.1532),  cos( t / 61.4532));
+	vec2 field_part3 = uv_scaled_centered + 50.*vec2(sin(-t / 87.53218), sin(-t / 49.0000));
+
+    float field = (1.+ (
+        cos(length(field_part1) / 19.483) + sin(length(field_part2) / 33.155) * cos(field_part2.y / 15.73) +
+        cos(length(field_part3) / 27.193) * sin(field_part3.x / 21.92) ))/2.;
+    vec2 borders = vec2(0.2, 0.8);
+
+    float res = (.5 + .5* cos( (adjusted_dissolve) / 82.612 + ( field + -.5 ) *3.14))
+    - (floored_uv.x > borders.y ? (floored_uv.x - borders.y)*(5. + 5.*dissolve) : 0.)*(dissolve)
+    - (floored_uv.y > borders.y ? (floored_uv.y - borders.y)*(5. + 5.*dissolve) : 0.)*(dissolve)
+    - (floored_uv.x < borders.x ? (borders.x - floored_uv.x)*(5. + 5.*dissolve) : 0.)*(dissolve)
+    - (floored_uv.y < borders.x ? (borders.x - floored_uv.y)*(5. + 5.*dissolve) : 0.)*(dissolve);
+
+    if (tex.a > 0.01 && burn_colour_1.a > 0.01 && !shadow && res < adjusted_dissolve + 0.8*(0.5-abs(adjusted_dissolve-0.5)) && res > adjusted_dissolve) {
+        if (!shadow && res < adjusted_dissolve + 0.5*(0.5-abs(adjusted_dissolve-0.5)) && res > adjusted_dissolve) {
+            tex.rgba = burn_colour_1.rgba;
+        } else if (burn_colour_2.a > 0.01) {
+            tex.rgba = burn_colour_2.rgba;
+        }
     }
 
-    if (bhsl.a == 0){
-        hsl.a = 0;
-    }
-
-
-    // Mix with base texture
-    float ratio = 1;
-    tex = ratio*RGB(hsl) + (1-ratio)*RGB(bhsl);
-
-
-
-    // required
-	return dissolve_mask(tex*colour, texture_coords, uv);
+    return vec4(shadow ? vec3(0.,0.,0.) : tex.xyz, res > adjusted_dissolve ? (shadow ? tex.a*0.3: tex.a) : .0);
 }
 
 number hue(number s, number t, number h)
@@ -120,48 +195,62 @@ vec4 HSL(vec4 c)
 	return hsl;
 }
 
-vec4 dissolve_mask(vec4 tex, vec2 texture_coords, vec2 uv)
+vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords )
 {
-    if (dissolve < 0.001) {
-        return vec4(shadow ? vec3(0.,0.,0.) : tex.xyz, shadow ? tex.a*0.3: tex.a);
-    }
+    vec4 tex = Texel( texture, texture_coords);
+    vec2 uv = (((texture_coords)*(image_details)) - texture_details.xy*texture_details.ba)/texture_details.ba;
+    vec2 adjusted_uv = uv - vec2(0.5, 0.5);
+    adjusted_uv.x = adjusted_uv.x*texture_details.b/texture_details.a;
 
-    float adjusted_dissolve = (dissolve*dissolve*(3.-2.*dissolve))*1.02 - 0.01; //Adjusting 0.0-1.0 to fall to -0.1 - 1.1 scale so the mask does not pause at extreme values
+    number low = min(tex.r, min(tex.g, tex.b));
+    number high = max(tex.r, max(tex.g, tex.b));
+	number delta = min(high, max(0.5, 1. - low));
 
-	float t = time * 10.0 + 2003.;
-	vec2 floored_uv = (floor((uv*texture_details.ba)))/max(texture_details.b, texture_details.a);
-    vec2 uv_scaled_centered = (floored_uv - 0.5) * 2.3 * max(texture_details.b, texture_details.a);
+	number angle = atan(adjusted_uv.y, adjusted_uv.x);
+    number fac = max(5.*min(5.*cos(5.*angle + (shiny.r + 4.*shiny.g)) - 4.5 - max(2.-length(50.*adjusted_uv), 0.), 1.) - length(7.*adjusted_uv), 0.);
+    number fac2 = max(5.*min(5.*cos(7.*angle - (shiny.r + 4.*shiny.g)) - 4.5 - max(2.-length(50.*adjusted_uv), 0.), 1.) - length(5.*adjusted_uv), 0.);
+
+    number maxfac = max(max(fac, fac2) + 2.2*(fac+fac2) - max(0., 5.*cnoise(vec3(adjusted_uv.x*5., adjusted_uv.y*5., shiny.g))), 0.) * max(0., 0.5 + sin(shiny.g));
+	number sparkle = max(0., 50.*cnoise(vec3(adjusted_uv.x*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.);
 	
-	vec2 field_part1 = uv_scaled_centered + 50.*vec2(sin(-t / 143.6340), cos(-t / 99.4324));
-	vec2 field_part2 = uv_scaled_centered + 50.*vec2(cos( t / 53.1532),  cos( t / 61.4532));
-	vec2 field_part3 = uv_scaled_centered + 50.*vec2(sin(-t / 87.53218), sin(-t / 49.0000));
+	//left
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x+0.01)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/2.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x+0.02)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/4.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x+0.03)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/6.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x+0.04)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/8.;
+	//right
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x-0.01)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/2.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x-0.02)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/4.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x-0.03)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/6.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3((adjusted_uv.x-0.04)*25., adjusted_uv.y*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/8.;
+	//top
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y+0.01)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/2.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y+0.02)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/4.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y+0.03)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/6.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y+0.04)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/8.;
+	//bottom
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y-0.01)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/2.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y-0.02)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/4.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y-0.03)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/6.;
+	sparkle = sparkle + max(0., 50.*cnoise(vec3(adjusted_uv.x*25., (adjusted_uv.y-0.04)*25., shiny.g)) - length(40.*adjusted_uv) - 30.)/8.;
+	
+	
+	
+	
+	
+	maxfac = max(0., maxfac + sparkle * min(1., max(0., 0.75 + cos(shiny.g))));
 
-    float field = (1.+ (
-        cos(length(field_part1) / 19.483) + sin(length(field_part2) / 33.155) * cos(field_part2.y / 15.73) +
-        cos(length(field_part3) / 27.193) * sin(field_part3.x / 21.92) ))/2.;
-    vec2 borders = vec2(0.2, 0.8);
+    tex.r = tex.r-delta/2. + delta*maxfac*1.9;
+    tex.g = tex.g-delta/2. + delta*maxfac*1.5;
+    tex.b = tex.b-delta/2. + delta*maxfac*0.5;
+    tex.a = min(tex.a, 0.3*tex.a + 0.9*min(0.5, maxfac*0.1));
 
-    float res = (.5 + .5* cos( (adjusted_dissolve) / 82.612 + ( field + -.5 ) *3.14))
-    - (floored_uv.x > borders.y ? (floored_uv.x - borders.y)*(5. + 5.*dissolve) : 0.)*(dissolve)
-    - (floored_uv.y > borders.y ? (floored_uv.y - borders.y)*(5. + 5.*dissolve) : 0.)*(dissolve)
-    - (floored_uv.x < borders.x ? (borders.x - floored_uv.x)*(5. + 5.*dissolve) : 0.)*(dissolve)
-    - (floored_uv.y < borders.x ? (borders.x - floored_uv.y)*(5. + 5.*dissolve) : 0.)*(dissolve);
-
-    if (tex.a > 0.01 && burn_colour_1.a > 0.01 && !shadow && res < adjusted_dissolve + 0.8*(0.5-abs(adjusted_dissolve-0.5)) && res > adjusted_dissolve) {
-        if (!shadow && res < adjusted_dissolve + 0.5*(0.5-abs(adjusted_dissolve-0.5)) && res > adjusted_dissolve) {
-            tex.rgba = burn_colour_1.rgba;
-        } else if (burn_colour_2.a > 0.01) {
-            tex.rgba = burn_colour_2.rgba;
-        }
-    }
-
-    return vec4(shadow ? vec3(0.,0.,0.) : tex.xyz, res > adjusted_dissolve ? (shadow ? tex.a*0.3: tex.a) : .0);
+    return dissolve_mask(tex, texture_coords, uv);
 }
 
-// for transforming the card while your mouse is on it
-extern PRECISION vec2 mouse_screen_pos;
-extern PRECISION float hovering;
-extern PRECISION float screen_scale;
+extern MY_HIGHP_OR_MEDIUMP vec2 mouse_screen_pos;
+extern MY_HIGHP_OR_MEDIUMP float hovering;
+extern MY_HIGHP_OR_MEDIUMP float screen_scale;
 
 #ifdef VERTEX
 vec4 position( mat4 transform_projection, vec4 vertex_position )


### PR DESCRIPTION
Changed shiny edition to this:
( Base | Shiny w/o edition | Shiny w/ edition | Base w/ Foil )
![shiny](https://github.com/user-attachments/assets/824be01b-2160-4b2d-926c-adf83ce52251)

To apply this, the shader in `editions1.lua` would need to change to `shader = "shiny",`