### PR TITLE
Add Shinx line

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -99,6 +99,7 @@ family = {
     {"mudkip", "marshtomp", "swampert"},
     {"shroomish", "breloom"},
     {"aron","lairon","aggron"},
+    {"shinx", "luxio", "luxray"},
     {"buizel", "floatzel"},
     {"gothita", "gothorita", "gothitelle"},
     {"vanillite", "vanillish", "vanilluxe"},

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2719,6 +2719,35 @@ return {
                     "{C:attention}destroy{} it",
                 }
             },
+            j_poke_shinx = {
+                name = 'Shinx',
+                text = {
+                    "{C:green}#1# in #2#{} cards are drawn face down",
+                    "Earn {C:money}$#3#{} for each",
+                    "scored face down card",
+                    "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#4#{C:inactive,s:0.8} rounds)"
+                }
+            },
+            j_poke_luxio = {
+                name = 'Luxio',
+                text = {
+                    "{C:green}#1# in #2#{} cards are drawn face down",
+                    "Earn {C:money}$#3#{} and {C:mult}+#4#{} Mult for each",
+                    "scored face down card",
+                    "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#5#{C:inactive,s:0.8} rounds)"
+                }
+            },
+            j_poke_luxray = {
+                name = 'Luxray',
+                text = {
+                    "{C:green}#1# in #2#{} cards are drawn face down",
+                    "Earn {C:money}$#3#{} and {X:red,C:white}X#4#{} Mult for each",
+                    "scored face down card",
+                    "{br:3}ERROR - CONTACT STEAK",
+                    "Hand type preview treats",
+                    "face down cards as face up"
+                }
+            },
             j_poke_buizel = {
                 name = 'Buizel',
                 text = {

--- a/lovely.toml
+++ b/lovely.toml
@@ -598,6 +598,35 @@ payload = "elseif _c.effect == 'Lucky Card' then loc_vars = {math.pow(3, #find_j
 match_indent = true
 overwrite = true
 
+# Shinx line card flipping
+[[patches]]
+[patches.pattern]
+target = "cardarea.lua"
+pattern = "self:emplace(card, nil, stay_flipped)"
+position = "before"
+payload="""
+for i, pokemon in ipairs({"shinx", "luxio", "luxray"}) do
+  for j, joker in ipairs(find_joker(pokemon)) do
+    flip_num = joker.ability.extra.flip_num
+    flip_in = joker.ability.extra.flip_in
+    if pseudorandom(pseudoseed("shinx")) < G.GAME.probabilities.normal*flip_num/flip_in then
+      stay_flipped = true
+    end
+  end
+end
+"""
+match_indent = true
+
+# Luxray gleam eyes
+[[patches]]
+[patches.pattern]
+target = "cardarea.lua"
+pattern = "if backwards then"
+position = "at"
+payload = "if backwards and not next(find_joker('luxray')) then"
+overwrite = true
+match_indent = true
+
 # Controller support for reserving
 [[patches]]
 [patches.pattern]

--- a/pokemon/pokejokers_14.lua
+++ b/pokemon/pokejokers_14.lua
@@ -11,8 +11,128 @@
 -- Kricketot 401
 -- Kricketune 402
 -- Shinx 403
+local shinx={
+  name = "shinx",
+  pos = {x = 2, y = 1},
+  config = {extra = {flip_num = 1, flip_in = 8, money = 1, known_flipped = {}, rounds = 3}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    return {vars = {
+      center.ability.extra.flip_num * G.GAME.probabilities.normal,
+      center.ability.extra.flip_in,
+      center.ability.extra.money,
+      center.ability.extra.rounds
+    }}
+  end,
+  rarity = 1,
+  cost = 4,
+  stage = "Basic",
+  atlas = "Pokedex4",
+  ptype = "Lightning",
+  blueprint_compat = true,
+  calculate = function(self, card, context)
+    if context.hand_drawn and context.cardarea == G.jokers then
+      for _, drawn in pairs(context.hand_drawn) do
+        if drawn.ability.wheel_flipped then
+          card.ability.extra.known_flipped[drawn.ID] = true
+        end
+      end
+    end
+    if context.individual and context.cardarea == G.play and not context.other_card.debuff then
+      if card.ability.extra.known_flipped[context.other_card.ID] then
+        return {dollars = card.ability.extra.money}
+      end
+    end
+    if context.end_of_round and context.cardarea == G.jokers then
+      card.ability.extra.known_flipped = {}
+    end
+    return level_evo(self, card, context, "j_poke_luxio")
+  end
+}
 -- Luxio 404
+local luxio={
+  name = "luxio",
+  pos = {x = 3, y = 1},
+  config = {extra = {flip_num = 1, flip_in = 6, money = 1, mult = 2, known_flipped = {}, rounds = 3}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    return {vars = {
+      center.ability.extra.flip_num * G.GAME.probabilities.normal,
+      center.ability.extra.flip_in,
+      center.ability.extra.money,
+      center.ability.extra.mult,
+      center.ability.extra.rounds
+    }}
+  end,
+  rarity = 2,
+  cost = 6,
+  stage = "Basic",
+  atlas = "Pokedex4",
+  ptype = "Lightning",
+  blueprint_compat = true,
+  calculate = function(self, card, context)
+    if context.hand_drawn and context.cardarea == G.jokers then
+      for _, drawn in pairs(context.hand_drawn) do
+        if drawn.ability.wheel_flipped then
+          card.ability.extra.known_flipped[drawn.ID] = true
+        end
+      end
+    end
+    if context.individual and context.cardarea == G.play and not context.other_card.debuff then
+      if card.ability.extra.known_flipped[context.other_card.ID] then
+        return {
+          dollars = card.ability.extra.money,
+          mult = card.ability.extra.mult
+        }
+      end
+    end
+    if context.end_of_round and context.cardarea == G.jokers then
+      card.ability.extra.known_flipped = {}
+    end
+    return level_evo(self, card, context, "j_poke_luxray")
+  end
+}
 -- Luxray 405
+local luxray={
+  name = "luxray",
+  pos = {x = 4, y = 1},
+  config = {extra = {flip_num = 1, flip_in = 2, money = 1, Xmult = 1.1, known_flipped = {}}},
+  loc_vars = function(self, info_queue, center)
+    type_tooltip(self, info_queue, center)
+    return {vars = {
+      center.ability.extra.flip_num * G.GAME.probabilities.normal,
+      center.ability.extra.flip_in,
+      center.ability.extra.money,
+      center.ability.extra.Xmult
+    }}
+  end,
+  rarity = "poke_safari",
+  cost = 8,
+  stage = "Basic",
+  atlas = "Pokedex4",
+  ptype = "Lightning",
+  blueprint_compat = true,
+  calculate = function(self, card, context)
+    if context.hand_drawn and context.cardarea == G.jokers then
+      for _, drawn in pairs(context.hand_drawn) do
+        if drawn.ability.wheel_flipped then
+          card.ability.extra.known_flipped[drawn.ID] = true
+        end
+      end
+    end
+    if context.individual and context.cardarea == G.play and not context.other_card.debuff then
+      if card.ability.extra.known_flipped[context.other_card.ID] then
+        return {
+          dollars = card.ability.extra.money,
+          xmult = card.ability.extra.Xmult
+        }
+      end
+    end
+    if context.end_of_round and context.cardarea == G.jokers then
+      card.ability.extra.known_flipped = {}
+    end
+  end
+}
 -- Budew 406
 -- Roserade 407
 -- Cranidos 408
@@ -88,5 +208,5 @@ local floatzel={
 }
 -- Cherubi 420
 return {name = "Pokemon Jokers 391-420", 
-        list = {buizel, floatzel},
+        list = {shinx, luxio, luxray, buizel, floatzel},
 }


### PR DESCRIPTION
Based on idea by @catra1234 on discord, with slight modifications.

Every 1/8, 1/6 or 1/2 cards (for Shinx, Luxio and Luxray respectively) are drawn face down (like the wheel boss blind).
Shinx (common) gives $1 per scored face down card.
Luxio (uncommon) gives $1 and +2 Mult.
Luxray (safari) gives $1 and X1.1 Mult. Additionally, the hand type preview shows even if face down cards are selected. (Reference to Luxray's x-ray vision)

Both shinx and luxio evolve after 3 rounds.

Tested:
- Works with Oops all 6s
- Works with energy

Something i noticed: When drawing cards for booster packs in the shop, cards can still be drawn face down. Should maybe be fixed because the face down cards don't give any advantage there.

This is my first time modding balatro, please let me know if anything seems wrong or can be done in a better way.

Open to suggestions about tweaking the numbers of course, they might need to be tweaked a bit to fit in with the balance of the rest of the jokers.