### PR TITLE
Hoothoot line Stone Card fix & Mantine Visual Fix

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1142,7 +1142,10 @@ volatile_active = function(self, card, direction)
 end
 
 poke_total_chips = function(card)
-  local total_chips = (card.base.nominal) + (card.ability.bonus) + (card.ability.perma_bonus or 0) 
+  local total_chips = (card.ability.bonus) + (card.ability.perma_bonus or 0)
+  if card.ability.effect ~= 'Stone Card' and not card.config.center.replace_base_card then
+    total_chips = total_chips + (card.base.nominal)
+  end
   if card.edition then
     total_chips = total_chips + (card.edition.chips or 0)
   end

--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -364,14 +364,13 @@ local mantine={
         card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_mod
         if context.cardarea == G.play then
           return {
-            extra = {focus = card, message = localize('k_upgrade_ex'), colour = G.C.CHIPS},
             card = card,
-            colour = G.C.CHIPS
+            colour = G.C.CHIPS,
+            message = localize('k_upgrade_ex'),
           }
         else
-          card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("k_upgrade_ex"), colour = G.C.CHIPS})
           return {
-              message = '',
+              message = localize("k_upgrade_ex"),
               colour = G.C.CHIPS,
               card = card
           }


### PR DESCRIPTION
Hoothoot will give chips equal to `nominal + bonus + perma_bonus` for all card types, including Stone Cards.
For Stone Cards, the `nominal` chips should be ignored.
This fixes that

ALSO:
Mantine previously has a double "square" appear when a gold card in hand is triggered.
This removes that extra square