### PR TITLE
Egg Joker Functionality

### DIFF
--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -316,6 +316,7 @@ local mystery_egg = {
   end,
   add_to_deck = function(self, card, from_debuff)
     if from_debuff then return end
+    if not card.ability or not card.ability.extra or not card.ability.extra.key then return end
 
     local poke_keys = {}
     for k, v in pairs(G.P_CENTERS) do


### PR DESCRIPTION
Allow setting egg target and prevent egg logic from overwriting the set value.
Can be used with Daycare Jokers to spawn specific eggs