### PR TITLE
Jokerdisplay Additions/Fixes

### DIFF
--- a/functions/energyfunctions.lua
+++ b/functions/energyfunctions.lua
@@ -261,8 +261,7 @@ energize = function(card, etype, evolving, silent)
   end
 end
 
-can_increase_energy = function(card)
-  if pokermon_config.unlimited_energy then return true end
+get_total_energy = function(card)
   local curr_energy_count = nil
   local curr_c_energy_count = nil
   if card.ability.extra and type(card.ability.extra) == "table" then
@@ -272,7 +271,12 @@ can_increase_energy = function(card)
     curr_energy_count = card.ability.energy_count or 0
     curr_c_energy_count = card.ability.c_energy_count or 0
   end
-  return curr_energy_count + curr_c_energy_count < energy_max + (G.GAME.energy_plus or 0)
+  return curr_energy_count + curr_c_energy_count
+end
+
+can_increase_energy = function(card)
+  if pokermon_config.unlimited_energy then return true end
+  return get_total_energy(card) < energy_max + (G.GAME.energy_plus or 0)
 end
 
 increment_energy = function(card, etype)

--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -835,21 +835,10 @@ jd_def["j_poke_jigglypuff"] = {
 
 jd_def["j_poke_wigglytuff"] = {
     text = {
-        { ref_table = "card.joker_display_values", ref_value = "count", retrigger_type = "mult" },
-        { text = "x(",                              scale = 0.35 },
-        {ref_table = "card.ability.extra", ref_value = "mult", colour = G.C.MULT},
-        { text = " ",                              scale = 0.35 },
-        {ref_table = "card.ability.extra", ref_value = "chips", colour = G.C.CHIPS},
-        { text = ")",                              scale = 0.35 },
-        { text = " +", colour = G.C.CHIPS,         scale = 0.35 },
+        { text = "+",                              colour = G.C.CHIPS },
         { ref_table = "card.joker_display_values", ref_value = "chips", colour = G.C.CHIPS, retrigger_type = "mult" },
-    },
-    extra = {
-        {
-            { ref_table = "card.joker_display_values", ref_value = "count", retrigger_type = "mult" },
-        { text = "x",                              scale = 0.35 },
-        {ref_table = "card.ability.extra", ref_value = "chips", colour = G.C.CHIPS},
-        }
+        { text = " +",                             colour = G.C.MULT },
+        { ref_table = "card.joker_display_values", ref_value = "mult",  colour = G.C.MULT,  retrigger_type = "mult" }
     },
     reminder_text = {
         { text = "(" },
@@ -858,7 +847,7 @@ jd_def["j_poke_wigglytuff"] = {
     },
 
     calc_function = function(card)
-        local count = 0
+        local mult = 0
         local chips = 0
         if G.play then
             local text, _, scoring_hand = JokerDisplay.evaluate_hand()
@@ -866,15 +855,13 @@ jd_def["j_poke_wigglytuff"] = {
                 for _, scoring_card in pairs(scoring_hand) do
                     if scoring_card:is_suit("Spades") then
                         local retriggers = JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
-                        count = count + retriggers
-                        chips = chips + poke_total_chips(scoring_card) * retriggers
+                        mult = mult + card.ability.extra.mult * retriggers
+                        chips = chips + (card.ability.extra.chips + poke_total_chips(scoring_card)) * retriggers
                     end
                 end
             end
-        else
-            count = 3
         end
-        card.joker_display_values.count = count
+        card.joker_display_values.mult = mult
         card.joker_display_values.chips = chips
         card.joker_display_values.localized_text = localize("Spades", 'suits_plural')
     end,

--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -836,8 +836,13 @@ jd_def["j_poke_jigglypuff"] = {
 jd_def["j_poke_wigglytuff"] = {
     text = {
         { ref_table = "card.joker_display_values", ref_value = "count", retrigger_type = "mult" },
-        { text = "x",                              scale = 0.35 },
+        { text = "x(",                              scale = 0.35 },
         {ref_table = "card.ability.extra", ref_value = "mult", colour = G.C.MULT},
+        { text = " ",                              scale = 0.35 },
+        {ref_table = "card.ability.extra", ref_value = "chips", colour = G.C.CHIPS},
+        { text = ")",                              scale = 0.35 },
+        { text = " +", colour = G.C.CHIPS,         scale = 0.35 },
+        { ref_table = "card.joker_display_values", ref_value = "chips", colour = G.C.CHIPS, retrigger_type = "mult" },
     },
     extra = {
         {
@@ -854,13 +859,15 @@ jd_def["j_poke_wigglytuff"] = {
 
     calc_function = function(card)
         local count = 0
+        local chips = 0
         if G.play then
             local text, _, scoring_hand = JokerDisplay.evaluate_hand()
             if text ~= 'Unknown' then
                 for _, scoring_card in pairs(scoring_hand) do
                     if scoring_card:is_suit("Spades") then
-                        count = count +
-                            JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
+                        local retriggers = JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
+                        count = count + retriggers
+                        chips = chips + poke_total_chips(scoring_card) * retriggers
                     end
                 end
             end
@@ -868,8 +875,9 @@ jd_def["j_poke_wigglytuff"] = {
             count = 3
         end
         card.joker_display_values.count = count
+        card.joker_display_values.chips = chips
         card.joker_display_values.localized_text = localize("Spades", 'suits_plural')
-    end
+    end,
 }
 
 jd_def["j_poke_zubat"] = {

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -179,27 +179,45 @@ jd_def["j_poke_furret"] = {
 }
 
 --	Hoothoot
--- jd_def["j_poke_hoothoot"] = { 
---     text = {
---         { text = "+" },
---         { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" }
---     },
---     text_config = { colour = G.C.CHIPS },
--- calc_function = function(card)
---     local chips = 0
---     if G.scry_view then
---         for k, v in pairs(G.scry_view.cards) do
---             local total_chips = poke_total_chips(v)
---             chips = chips + total_chips
---         end
---         card.joker_display_values.chips = chips
---     else
---         card.joker_display_values.chips = 0
---     end
--- end
---}
+jd_def["j_poke_hoothoot"] = { 
+    text = {
+        { text = "+" },
+        { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" }
+    },
+    text_config = { colour = G.C.CHIPS },
+calc_function = function(card)
+    local chips = 0
+    if G.scry_view then
+        for k, v in pairs(G.scry_view.cards) do
+            chips = chips + poke_total_chips(v) * (v:get_seal() == 'Red' and 2 or 1)
+        end
+        card.joker_display_values.chips = chips
+    else
+        card.joker_display_values.chips = 0
+    end
+end
+}
 
 --	Noctowl
+jd_def["j_poke_noctowl"] = { 
+    text = {
+        { text = "+" },
+        { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" }
+    },
+    text_config = { colour = G.C.CHIPS },
+calc_function = function(card)
+    local chips = 0
+    if G.scry_view then
+        for k, v in pairs(G.scry_view.cards) do
+            chips = chips + poke_total_chips(v) * (v:get_seal() == 'Red' and 2 or 1)
+        end
+        card.joker_display_values.chips = chips
+    else
+        card.joker_display_values.chips = 0
+    end
+end
+}
+
 --	Ledyba
 jd_def["j_poke_ledyba"] = { 
     text = {
@@ -784,7 +802,51 @@ end
 }
 
 --	Remoraid
+jd_def["j_poke_remoraid"] = {
+    text = {
+        { ref_table = "card.joker_display_values", ref_value = "status", retrigger_type = "mult" },
+        { text = " Left" },
+    },
+    text_config = { colour = G.C.GREY },
+    calc_function = function(card)
+        card.joker_display_values.status = card.ability.extra.card_max - card.ability.extra.cards
+    end,
+    retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
+        if held_in_hand then return 0 end
+        local remaining = joker_card.ability.extra.card_max - joker_card.ability.extra.cards
+        if remaining >= #scoring_hand then return 1 end
+
+        for i = 1, remaining do
+            if playing_card == scoring_hand[i] then
+                return 1
+            end
+        end
+        return 0
+    end,
+}
 --	Octillery
+jd_def["j_poke_octillery"] = {
+    text = {
+        { ref_table = "card.joker_display_values", ref_value = "status", retrigger_type = "mult" },
+        { text = " Left" },
+    },
+    text_config = { colour = G.C.GREY },
+    calc_function = function(card)
+        card.joker_display_values.status = card.ability.extra.card_max - card.ability.extra.cards
+    end,
+    retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
+        if held_in_hand then return 0 end
+        local remaining = joker_card.ability.extra.card_max - joker_card.ability.extra.cards
+        if remaining >= #scoring_hand then return 1 end
+
+        for i = 1, remaining do
+            if playing_card == scoring_hand[i] then
+                return 1
+            end
+        end
+        return 0
+    end,
+}
 --	Delibird
 --	Mantine
 jd_def["j_poke_mantine"] = { 

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -2712,8 +2712,9 @@ return {
             j_poke_jirachi_power = {
                 name = 'Jirachi',
                 text = {
-                    "Every {C:attention}#2# {C:inactive}[#3#]{} hands, played cards",
+                    "Every {C:attention}#2# hands{}, played cards",
                     "give {X:mult,C:white}X#1#{} Mult when scored",
+                    "{C:inactive}(#3#){}",
                 }
             },
             j_poke_jirachi_negging = {

--- a/localization/it.lua
+++ b/localization/it.lua
@@ -2497,8 +2497,9 @@ return {
             j_poke_jirachi_power = {
                 name = 'Jirachi',
                 text = {
-                    "Ogni{C:attention}#2# {C:inactive}[#3#]{} mano, le carte giocate",
+                    "Ogni{C:attention}#2# mano{}, le carte giocate",
                     "danno {X:mult,C:white}X#1#{} Mult quando assegnano punti",
+                    "{C:inactive}(#3#){}",
                 }
             },
             j_poke_jirachi_negging = {

--- a/localization/vi.lua
+++ b/localization/vi.lua
@@ -2457,8 +2457,9 @@ return {
             j_poke_jirachi_power = {
                 name = 'Jirachi',
                 text = {
-                    "Mỗi {C:attention}#2# {C:inactive}[#3#]{} tay, lá đã chơi",
+                    "Mỗi {C:attention}#2# tay{}, lá đã chơi",
                     "cho {X:mult,C:white}X#1#{} Nhân khi tính điểm",
+                    "{C:inactive}(#3#){}",
                 }
             },
             j_poke_jirachi_negging = {

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -2644,8 +2644,9 @@ return {
             j_poke_jirachi_power = {
                 name = '基拉祈',
                 text = {
-                    "每第{}{C:attention}#2# {C:inactive}[#3#]{}次出牌時",
+                    "每第{}{C:attention}#2#次出牌時",
                     "每張打出的卡牌在得分時給予{X:mult,C:white}X#1#{}倍數",
+                    "{C:inactive}(#3#){}",
                 }
             },
             j_poke_jirachi_negging = {

--- a/pokemon/pokejokers_13.lua
+++ b/pokemon/pokejokers_13.lua
@@ -435,10 +435,10 @@ local jirachi_power = {
   name = "jirachi_power", 
   pos = { x = 4, y = 0 },
   soul_pos = { x = 5, y = 0 },
-  config = {extra = {Xmult_multi = 2.4, every = 3, loyalty_remaining = 3}},
+  config = {extra = {Xmult_multi = 2.4, every = 3, loyalty_remaining = 2}},
   loc_vars = function(self, info_queue, card)
     type_tooltip(self, info_queue, card)
-    return {vars = {card.ability.extra.Xmult_multi, card.ability.extra.every, card.ability.extra.loyalty_remaining, }}
+    return {vars = {card.ability.extra.Xmult_multi, card.ability.extra.every, localize{type = 'variable', key = (card.ability.extra.loyalty_remaining == 0 and 'loyalty_active' or 'loyalty_inactive'), vars = {card.ability.extra.loyalty_remaining}}}}
   end,
   rarity = 4,
   cost = 20,
@@ -451,17 +451,15 @@ local jirachi_power = {
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.cardarea == G.jokers and context.scoring_hand then
-      if context.before then
-        if card.ability.extra.loyalty_remaining > 0 then
-          card.ability.extra.loyalty_remaining = card.ability.extra.loyalty_remaining - 1
+      if context.after then
+        if card.ability.extra.loyalty_remaining == 0 then
+          card.ability.extra.loyalty_remaining = card.ability.extra.every
         end
-        if card.ability.extra.loyalty_remaining == 1 then
-          local eval = function(card) return (card.ability.extra.loyalty_remaining == 1) and not G.RESET_JIGGLES end
+        card.ability.extra.loyalty_remaining = card.ability.extra.loyalty_remaining - 1
+        if card.ability.extra.loyalty_remaining == 0 then
+          local eval = function(card) return (card.ability.extra.loyalty_remaining == 0) and not G.RESET_JIGGLES end
           juice_card_until(card, eval, true)
         end
-      end
-      if context.after and card.ability.extra.loyalty_remaining == 0 then
-        card.ability.extra.loyalty_remaining = card.ability.extra.every
       end
     end
     if context.individual and not context.end_of_round and context.cardarea == G.play and not context.other_card.debuff then


### PR DESCRIPTION
Added the following Joker Displays:
- Wigglytuff (shows total chips and mults given)
- Hoothoot/Noctowl (shows total chips from foreseen cards with Red Seal retriggers)
- Remoraid/Octillery (shows retriggers remaining)
- Metagross (shows total Xmult given by cards)
- Jirachi_Power (matches Loyalty Card Joker Display)
- Jirachi_Copy (creates a duplicate of targeted card and increases the energy count)
   - may have weird bugs

Modified the following:
- Changed Jirachi_Power's description to match Loyalty Card's "X remaining"
- Added `get_total_energy` util function