### PR TITLE
Custom Megas Compatibility Fix

### DIFF
--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -576,6 +576,7 @@ local megastone = {
   end,
   use = function(self, card, area, copier)
     local target = nil
+    local forced_key = nil
     if G.jokers.highlighted and #G.jokers.highlighted == 1 and (G.jokers.highlighted[1].config.center.megas or G.jokers.highlighted[1].config.center.rarity == "poke_mega") and
        not G.jokers.highlighted[1].debuff then
       target = G.jokers.highlighted[1]

--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -576,7 +576,6 @@ local megastone = {
   end,
   use = function(self, card, area, copier)
     local target = nil
-    -- local forced_key = nil
     if G.jokers.highlighted and #G.jokers.highlighted == 1 and (G.jokers.highlighted[1].config.center.megas or G.jokers.highlighted[1].config.center.rarity == "poke_mega") and
        not G.jokers.highlighted[1].debuff then
       target = G.jokers.highlighted[1]

--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -576,7 +576,7 @@ local megastone = {
   end,
   use = function(self, card, area, copier)
     local target = nil
-    local forced_key = nil
+    -- local forced_key = nil
     if G.jokers.highlighted and #G.jokers.highlighted == 1 and (G.jokers.highlighted[1].config.center.megas or G.jokers.highlighted[1].config.center.rarity == "poke_mega") and
        not G.jokers.highlighted[1].debuff then
       target = G.jokers.highlighted[1]
@@ -590,6 +590,10 @@ local megastone = {
         end
       end
     end
+    -- Experiment
+    local prefix = target.config.center.poke_custom_prefix or "poke"
+    local forced_mega_key = "j_"..prefix.."_"
+    -- End Experiment
     if target.config.center.megas then
       local mega = target.config.center.megas[1]
       if #target.config.center.megas > 1 then
@@ -599,7 +603,10 @@ local megastone = {
           mega = pseudorandom_element(mega, pseudoseed('megastone_'..target.config.center.name))
         end
       end
-      forced_key = "j_poke_" .. mega
+      -- forced_key = "j_poke_" .. mega
+      -- Experiment 2
+      forced_key = forced_mega_key.. mega
+      -- End Experiment 2
       card.ability.extra.used_on = forced_key
     else
       forced_key = get_previous_evo(target, true)

--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -590,10 +590,8 @@ local megastone = {
         end
       end
     end
-    -- Experiment
     local prefix = target.config.center.poke_custom_prefix or "poke"
     local forced_mega_key = "j_"..prefix.."_"
-    -- End Experiment
     if target.config.center.megas then
       local mega = target.config.center.megas[1]
       if #target.config.center.megas > 1 then
@@ -603,10 +601,7 @@ local megastone = {
           mega = pseudorandom_element(mega, pseudoseed('megastone_'..target.config.center.name))
         end
       end
-      -- forced_key = "j_poke_" .. mega
-      -- Experiment 2
       forced_key = forced_mega_key.. mega
-      -- End Experiment 2
       card.ability.extra.used_on = forced_key
     else
       forced_key = get_previous_evo(target, true)

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -571,6 +571,15 @@ get_previous_evo = function(card, full_key)
   local found = nil
   local prev = nil
   local max = nil
+  -- Experiment
+  local choice = nil
+    if G.jokers.highlighted and #G.jokers.highlighted == 1 then
+      choice = G.jokers.highlighted[1]
+    else
+      choice = G.jokers.cards[1]
+    end
+  local prefix = choice.config.center.poke_custom_prefix or "poke"
+  -- End Experiment
   if not card.name and card.ability.name then
     name = card.ability.name
   else
@@ -599,7 +608,10 @@ get_previous_evo = function(card, full_key)
     if found then break end
   end
   if full_key then
-    prev = 'j_poke_'..prev
+    -- prev = 'j_poke_'..prev
+    -- Experiment 2
+    prev = "j_"..prefix.."_"..prev
+    -- End Experiment 2
   end
   return prev
 end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -577,7 +577,7 @@ get_previous_evo = function(card, full_key)
     else
       choice = G.jokers.cards[1]
     end
-  local prefix = choice.config.center.poke_custom_prefix or "poke"
+  local prefix = card.config.center.poke_custom_prefix or "poke"
   if not card.name and card.ability.name then
     name = card.ability.name
   else

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -571,7 +571,6 @@ get_previous_evo = function(card, full_key)
   local found = nil
   local prev = nil
   local max = nil
-  -- Experiment
   local choice = nil
     if G.jokers.highlighted and #G.jokers.highlighted == 1 then
       choice = G.jokers.highlighted[1]
@@ -579,7 +578,6 @@ get_previous_evo = function(card, full_key)
       choice = G.jokers.cards[1]
     end
   local prefix = choice.config.center.poke_custom_prefix or "poke"
-  -- End Experiment
   if not card.name and card.ability.name then
     name = card.ability.name
   else
@@ -608,10 +606,7 @@ get_previous_evo = function(card, full_key)
     if found then break end
   end
   if full_key then
-    -- prev = 'j_poke_'..prev
-    -- Experiment 2
-    prev = "j_"..prefix.."_"..prev
-    -- End Experiment 2
+    prev = "j_"..prefix.."_"..prev 
   end
   return prev
 end


### PR DESCRIPTION
I'm still pretty new to coding and github etiquette, but I think I'm doing this close enough to correctly? Anyways, I tested these changes on my own custom mega evo, and multiple native mega evo pokermon. Activating, deactivating and selling a mega stone, with any combination of custom and native megas, in various combinations of positions, all appear to be working as desired. (8 commits are listed for what should be 2 small changes due to me running into a very niche bug after opting for some last minute testing right before I initially went to submit this. Said bug has been fixed now.)