### PR TITLE
Add Crobat Joker Display definition and other Joker Display fixes

### DIFF
--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -2002,16 +2002,16 @@ jd_def["j_poke_krabby"] = {
             },
     calc_function = function(card)
         local count = 0
-        local _, poker_hands, _ = JokerDisplay.evaluate_hand()
+        local chips = card.ability.extra.chips
         local text, _, scoring_hand = JokerDisplay.evaluate_hand()
-            for _, scoring_card in pairs(scoring_hand) do
-                if scoring_card:get_id() == 11 or 
-                scoring_card:get_id() == 12 or 
-                scoring_card:get_id() == 13 then
-                    count = count + 1
-                end
+        if text ~= 'Unknown' then
+          for _, scoring_card in pairs(scoring_hand) do
+            if scoring_card:is_face() then
+              count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
             end
-        card.joker_display_values.chips = count * card.ability.extra.chips
+          end
+        end
+        card.joker_display_values.chips = count * chips
     end
 }
 
@@ -2022,16 +2022,16 @@ jd_def["j_poke_kingler"] = {
             },
     calc_function = function(card)
         local count = 0
-        local _, poker_hands, _ = JokerDisplay.evaluate_hand()
+        local chips = card.ability.extra.chips
         local text, _, scoring_hand = JokerDisplay.evaluate_hand()
-            for _, scoring_card in pairs(scoring_hand) do
-                if scoring_card:get_id() == 11 or 
-                scoring_card:get_id() == 12 or 
-                scoring_card:get_id() == 13 then
-                    count = count + 1
-                end
+        if text ~= 'Unknown' then
+          for _, scoring_card in pairs(scoring_hand) do
+            if scoring_card:is_face() then
+              count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
             end
-        card.joker_display_values.chips = count * card.ability.extra.chips
+          end
+        end
+        card.joker_display_values.chips = count * chips
     end
 }
 

--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -1799,9 +1799,7 @@ calc_function = function(card)
     end
     if text ~= 'Unknown' then
         for _, scoring_card in pairs(scoring_hand) do
-            if scoring_card:get_id() == 11 or 
-            scoring_card:get_id() == 12 or 
-            scoring_card:get_id() == 13 then
+            if scoring_card:is_face() then
                 facecount = facecount + 1
             end
         end
@@ -1828,9 +1826,7 @@ calc_function = function(card)
     end
     if text ~= 'Unknown' then
         for _, scoring_card in pairs(scoring_hand) do
-            if scoring_card:get_id() == 11 or 
-            scoring_card:get_id() == 12 or 
-            scoring_card:get_id() == 13 then
+            if scoring_card:is_face() then
                 facecount = facecount + 1
             end
         end

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -263,6 +263,27 @@ text_config = { colour = G.C.CHIPS },
 }
 
 --	Crobat
+jd_def["j_poke_crobat"] = {
+    text = {
+        { text = "+",  colour = G.C.CHIPS },
+        { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult",  colour = G.C.CHIPS  },
+        {text = " "},
+        { text = "+",  colour = G.C.MULT },
+        { ref_table = "card.ability.extra", ref_value = "mult", retrigger_type = "mult",  colour = G.C.MULT  },
+        {text = " "},
+        {
+            border_nodes = {
+                { text = "X", colour = G.C.WHITE  },
+                { ref_table = "card.ability.extra", ref_value = "Xmult", colour = G.C.WHITE }
+            },
+        },
+
+        {text = " "},
+        { text = "+$",  colour = G.C.GOLD  },
+        { ref_table = "card.ability.extra", ref_value = "money", retrigger_type = "mult",  colour = G.C.GOLD  }
+    },
+}
+
 --	Chinchou
 --	Lanturn
 --	Pichu

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -641,8 +641,9 @@ jd_def["j_poke_girafarig"] = {
     text_config = { colour = G.C.WHITE },
     calc_function = function(card)
         local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+        local _, poker_hands, _ = JokerDisplay.evaluate_hand()
         local face_cards = {}
-        if text == 'Two Pair' then
+        if poker_hands['Two Pair'] and next(poker_hands['Two Pair']) then
             for _, scoring_card in pairs(scoring_hand) do
                 if scoring_card:is_face() then
                     table.insert(face_cards, scoring_card)
@@ -651,9 +652,13 @@ jd_def["j_poke_girafarig"] = {
         end
         local first_face = JokerDisplay.calculate_leftmost_card(face_cards)
         local last_face = JokerDisplay.calculate_rightmost_card(face_cards)
-        card.joker_display_values.x_mult = math.max(last_face and
-            (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand) + (JokerDisplay.calculate_card_triggers(first_face, scoring_hand)))) or 1, 1)
-
+        if first_face ~= last_face then
+          card.joker_display_values.x_mult = math.max(last_face and
+              (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand) + (JokerDisplay.calculate_card_triggers(first_face, scoring_hand)))) or 1, 1)
+        else
+          card.joker_display_values.x_mult = math.max(last_face and
+              (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand))) or 1, 1)
+        end
     end
 }
 

--- a/jokerdisplay/definitions3.lua
+++ b/jokerdisplay/definitions3.lua
@@ -230,7 +230,7 @@ jd_def["j_poke_mudkip"] = {
                 if scoring_card:get_id() == card.ability.extra.targets[1].id or
                    scoring_card:get_id() == card.ability.extra.targets[2].id or
                    scoring_card:get_id() == card.ability.extra.targets[3].id then              
-                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, nil, true)
+                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
                 end
             end
         end
@@ -268,7 +268,7 @@ jd_def["j_poke_marshtomp"] = {
                 if scoring_card:get_id() == card.ability.extra.targets[1].id or
                    scoring_card:get_id() == card.ability.extra.targets[2].id or
                    scoring_card:get_id() == card.ability.extra.targets[3].id then              
-                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, nil, true)
+                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
                 end
             end
         end
@@ -306,7 +306,7 @@ jd_def["j_poke_swampert"] = {
                 if scoring_card:get_id() == card.ability.extra.targets[1].id or
                    scoring_card:get_id() == card.ability.extra.targets[2].id or
                    scoring_card:get_id() == card.ability.extra.targets[3].id then              
-                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, nil, true)
+                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
                 end
             end
         end

--- a/jokerdisplay/definitions7.lua
+++ b/jokerdisplay/definitions7.lua
@@ -19,9 +19,17 @@ local jd_def = JokerDisplay.Definitions
 jd_def["j_poke_grubbin"] = {
     text = {
         { text = "+" },
-        { ref_table = "card.ability.extra", ref_value = "mult", retrigger_type = "mult" }
+        { ref_table = "card.joker_display_values", ref_value = "mult", retrigger_type = "mult" }
     },
     text_config = { colour = G.C.MULT },
+    calc_function = function(card)
+        local count = #find_pokemon_type("Lightning")
+        if count >= 1 then
+          card.joker_display_values.mult = card.ability.extra.mult * 3
+        else
+          card.joker_display_values.mult = card.ability.extra.mult
+        end
+    end
 }
 
 --	Charjabug

--- a/jokerdisplay/definitions9.lua
+++ b/jokerdisplay/definitions9.lua
@@ -311,8 +311,9 @@ jd_def["j_poke_farigiraf"] = {
     text_config = { colour = G.C.WHITE },
     calc_function = function(card)
         local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+        local _, poker_hands, _ = JokerDisplay.evaluate_hand()
         local face_cards = {}
-        if text == 'Two Pair' then
+        if poker_hands['Two Pair'] and next(poker_hands['Two Pair']) then
             for _, scoring_card in pairs(scoring_hand) do
                 if scoring_card:is_face() then
                     table.insert(face_cards, scoring_card)
@@ -321,9 +322,13 @@ jd_def["j_poke_farigiraf"] = {
         end
         local first_face = JokerDisplay.calculate_leftmost_card(face_cards)
         local last_face = JokerDisplay.calculate_rightmost_card(face_cards)
-        card.joker_display_values.x_mult = math.max(last_face and
-            (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand) + (JokerDisplay.calculate_card_triggers(first_face, scoring_hand)))) or 1, 1)
-
+        if first_face ~= last_face then
+          card.joker_display_values.x_mult = math.max(last_face and
+              (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand) + (JokerDisplay.calculate_card_triggers(first_face, scoring_hand)))) or 1, 1)
+        else
+          card.joker_display_values.x_mult = math.max(last_face and
+              (card.ability.extra.Xmult_multi ^ (JokerDisplay.calculate_card_triggers(last_face, scoring_hand))) or 1, 1)
+        end
     end
 }
 


### PR DESCRIPTION
Grubbin definition didn't account for lightning jokers tripling its mult.

Krabby didn't account for face cards being debuffed or retrigger effects.  Similar thing with swampert line.

Girafarig line didn't account for other hands containing two pair. Also had this bug where acted as if no face cards were debuffed if there was a singular non-debuffed face card.

Doduo line didn't account for face cards being debuffed.