### PR TITLE
Add Joker Display definitions for Snubbull, Azurill, and Gligar evo lines. Fix Dragonite's Joker Display bug

### DIFF
--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -2999,6 +2999,7 @@ jd_def["j_poke_dragonite"] = {
     },
     retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
         local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+        if held_in_hand then return 0 end
         if #scoring_hand == 1 and #JokerDisplay.current_hand == 1 then
             return joker_card.ability.extra.retriggers * JokerDisplay.calculate_joker_triggers(joker_card)
         end

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -827,6 +827,52 @@ end
 
 --	Dunsparce
 --	Gligar
+jd_def["j_poke_gligar"] = {
+  text = {
+      {
+          border_nodes = {
+              { text = "X" },
+              { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
+          }
+      }
+  },
+  reminder_text = {
+      { text = "(" },
+      { ref_table = "card.joker_display_values", ref_value = "gligar_suit" },
+      { text = ")" }
+  },
+  calc_function = function(card)
+    local count = 0
+    local suit_count = 0
+    local playing_hand = next(G.play.cards)
+    for _, playing_card in ipairs(G.hand.cards) do
+        if playing_hand or not playing_card.highlighted then
+            if not (playing_card.facing == 'back') and not playing_card.debuff and playing_card:is_suit(G.GAME.current_round.gligar_suit) then
+                suit_count = suit_count + 1
+            end
+        end
+    end
+    if G.play then
+        local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+        if text ~= 'Unknown' then
+            for _, scoring_card in pairs(scoring_hand) do
+                if scoring_card then
+                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
+                end
+            end
+        end
+    end
+    card.joker_display_values.x_mult = (1 + (card.ability.extra.Xmult_multi * suit_count)) ^ count
+    card.joker_display_values.gligar_suit = localize(G.GAME.current_round.gligar_suit, 'suits_singular')
+  end,
+  style_function = function(card, text, reminder_text, extra)
+      if reminder_text and reminder_text.children[2] then
+          reminder_text.children[2].config.colour = lighten(G.C.SUITS[G.GAME.current_round.gligar_suit], 0.35)
+      end
+      return false
+  end
+}
+
 --	Steelix
 jd_def["j_poke_steelix"] = {
     text = {

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -779,7 +779,73 @@ jd_def["j_poke_steelix"] = {
 }
 
 --	Snubbull
+jd_def["j_poke_snubbull"] = {
+  text = {
+    {
+      border_nodes = {
+        { text = "X" },
+        { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
+      }
+    }
+  },
+  text_config = { colour = G.C.WHITE},
+  calc_function = function(card)
+    local xmult = card.ability.extra.Xmult
+    local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+    face_cards = {}
+    if text ~= 'Unknown' then
+      for _, scoring_card in pairs(scoring_hand) do
+          if scoring_card:is_face() then
+              table.insert(face_cards, scoring_card)
+          end
+      end
+    end
+    local first_face = JokerDisplay.calculate_leftmost_card(face_cards)
+    if first_face then
+      if first_face:get_id() == 12 then
+        xmult = card.ability.extra.Xmult2
+      else
+        xmult = card.ability.extra.Xmult
+      end
+    end
+    card.joker_display_values.x_mult = math.max(first_face and (xmult ^ JokerDisplay.calculate_card_triggers(first_face, scoring_hand)) or 1, 1)
+  end
+}
+
 --	Granbull
+jd_def["j_poke_granbull"] = {
+  text = {
+    {
+      border_nodes = {
+        { text = "X" },
+        { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
+      }
+    }
+  },
+  text_config = { colour = G.C.WHITE},
+  calc_function = function(card)
+    local xmult = card.ability.extra.Xmult
+    local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+    face_cards = {}
+    if text ~= 'Unknown' then
+      for _, scoring_card in pairs(scoring_hand) do
+          if scoring_card:is_face() then
+              table.insert(face_cards, scoring_card)
+          end
+      end
+    end
+    local first_face = JokerDisplay.calculate_leftmost_card(face_cards)
+    if first_face then
+      if first_face:get_id() == 12 then
+        xmult = card.ability.extra.Xmult2
+      else
+        xmult = card.ability.extra.Xmult
+      end
+    end
+    card.joker_display_values.x_mult = math.max(first_face and (xmult ^ JokerDisplay.calculate_card_triggers(first_face, scoring_hand)) or 1, 1)
+  end
+}
+
 --	Qwilfish
 jd_def["j_poke_qwilfish"] = {
     text = {

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -411,7 +411,68 @@ end
 }
 
 --	Marill
+jd_def["j_poke_marill"] = {
+    text = {
+        {
+            border_nodes = {
+                { text = "X" },
+                { ref_table = "card.joker_display_values", ref_value = "Xmult", retrigger_type = "exp" },
+            },
+        },
+    },
+    calc_function = function(card)
+      local enhanced_found = false
+      local unenhanced_found = false
+      local xmult = 1
+      local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+      if text ~= "Unknown" then
+        for _, scoring_card in pairs(scoring_hand) do
+          if scoring_card.config.center == G.P_CENTERS.c_base then
+            unenhanced_found = true
+          else
+            enhanced_found = true
+          end
+        end
+      end
+      if (enhanced_found == true) and (unenhanced_found == true) then
+        card.joker_display_values.Xmult = card.ability.extra.Xmult
+      else
+        card.joker_display_values.Xmult = xmult
+      end
+    end
+}
+
 --	Azumarill
+jd_def["j_poke_azumarill"] = {
+    text = {
+        {
+            border_nodes = {
+                { text = "X" },
+                { ref_table = "card.joker_display_values", ref_value = "Xmult", retrigger_type = "exp" },
+            },
+        },
+    },
+    calc_function = function(card)
+      local bonus_found = false
+      local nonbonus_found = false
+      local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+      if text ~= "Unknown" then
+        for _, scoring_card in pairs(scoring_hand) do
+          if scoring_card.ability.effect and scoring_card.ability.effect == "Bonus Card" then
+            bonus_found = true
+          else
+            nonbonus_found = true
+          end
+        end
+      end
+      if (bonus_found == true) and (nonbonus_found == true) then
+        card.joker_display_values.Xmult = card.ability.extra.Xmult * 2
+      else
+        card.joker_display_values.Xmult = card.ability.extra.Xmult
+      end
+    end
+}
+
 --	Sudowoodo
 jd_def["j_poke_sudowoodo"] = {
     text = {            

--- a/jokerdisplay/definitions3.lua
+++ b/jokerdisplay/definitions3.lua
@@ -355,8 +355,19 @@ jd_def["j_poke_swampert"] = {
 --	Makuhita
 --	Hariyama
 --	Azurill
+jd_def["j_poke_azurill"] = {
+    text = {
+        {
+            border_nodes = {
+                { text = "X" },
+                { ref_table = "card.ability.extra", ref_value = "Xmult_minus", retrigger_type = "exp" },
+            },
+        },
+    },
+}
+
 --	Nosepass
-jd_def["j_poke_nosepass"] = { 
+jd_def["j_poke_nosepass"] = {
 text = {
     {
         border_nodes = {

--- a/jokerdisplay/definitions4.lua
+++ b/jokerdisplay/definitions4.lua
@@ -382,6 +382,52 @@ text_config = { colour = G.C.WHITE },
 --	Leafeon
 --	Glaceon
 --	Gliscor
+jd_def["j_poke_gliscor"] = {
+  text = {
+      {
+          border_nodes = {
+              { text = "X" },
+              { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
+          }
+      }
+  },
+  reminder_text = {
+      { text = "(" },
+      { ref_table = "card.joker_display_values", ref_value = "gligar_suit" },
+      { text = ")" }
+  },
+  calc_function = function(card)
+    local count = 0
+    local suit_count = 0
+    local playing_hand = next(G.play.cards)
+    for _, playing_card in ipairs(G.hand.cards) do
+        if playing_hand or not playing_card.highlighted then
+            if not (playing_card.facing == 'back') and not playing_card.debuff and playing_card:is_suit(G.GAME.current_round.gligar_suit) then
+                suit_count = suit_count + 1
+            end
+        end
+    end
+    if G.play then
+        local text, _, scoring_hand = JokerDisplay.evaluate_hand()
+        if text ~= 'Unknown' then
+            for _, scoring_card in pairs(scoring_hand) do
+                if scoring_card then
+                    count = count + JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
+                end
+            end
+        end
+    end
+    card.joker_display_values.x_mult = (1 + (card.ability.extra.Xmult_multi * suit_count)) ^ count
+    card.joker_display_values.gligar_suit = localize(G.GAME.current_round.gligar_suit, 'suits_singular')
+  end,
+  style_function = function(card, text, reminder_text, extra)
+      if reminder_text and reminder_text.children[2] then
+          reminder_text.children[2].config.colour = lighten(G.C.SUITS[G.GAME.current_round.gligar_suit], 0.35)
+      end
+      return false
+  end
+}
+
 --	Mamoswine
 --	Porygon-Z
 jd_def["j_poke_porygonz"] = { 


### PR DESCRIPTION
Dragonite's jokerdisplay definition had a bug where it would apply its five retriggers to cards held in hand and that caused jokers like Golurk to display inaccurate joker display information.