### PR TITLE
Joker Display Pichu bug fix

### DIFF
--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -288,28 +288,24 @@ jd_def["j_poke_crobat"] = {
 --	Lanturn
 --	Pichu
 jd_def["j_poke_pichu"] = {
-    extra = {{
-        {
-            border_nodes = {
-                { text = "X" },
-                { ref_table = "card.ability.extra", ref_value = "Xmult_minus", retrigger_type = "exp" },
-            },
-        },
-    },},
-    text = {
-        {text = "$", colour = G.C.GOLD},
-        { ref_table = "card.joker_display_values", ref_value = "money", colour = G.C.GOLD  },
-    
+  extra = {{
+    {
+      border_nodes = {
+        { text = "X" },
+        { ref_table = "card.ability.extra", ref_value = "Xmult_minus", retrigger_type = "exp" },
+      },
     },
-    reminder_text = {
-        { ref_table = "card.joker_display_values", ref_value = "localized_text" },
-    },
-    calc_function = function(card)
-        local money
-        money = math.min(10, #G.jokers.cards * card.ability.extra.money)
-        card.joker_display_values.money = money
-        card.joker_display_values.localized_text = "(" .. localize("k_round") .. ")"
-    end
+  },},
+  text = {
+    {text = "+$", colour = G.C.GOLD},
+    { ref_table = "card.ability.extra", ref_value = "money", colour = G.C.GOLD },
+  },
+  reminder_text = {
+    { ref_table = "card.joker_display_values", ref_value = "localized_text" },
+  },
+  calc_function = function(card)
+    card.joker_display_values.localized_text = "(" .. localize("k_round") .. ")"
+  end
 }
 
 

--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -288,16 +288,14 @@ jd_def["j_poke_crobat"] = {
 --	Lanturn
 --	Pichu
 jd_def["j_poke_pichu"] = {
-  extra = {{
+  text = {
     {
       border_nodes = {
         { text = "X" },
         { ref_table = "card.ability.extra", ref_value = "Xmult_minus", retrigger_type = "exp" },
       },
     },
-  },},
-  text = {
-    {text = "+$", colour = G.C.GOLD},
+    { text = " +$", colour = G.C.GOLD },
     { ref_table = "card.ability.extra", ref_value = "money", colour = G.C.GOLD },
   },
   reminder_text = {
@@ -307,7 +305,6 @@ jd_def["j_poke_pichu"] = {
     card.joker_display_values.localized_text = "(" .. localize("k_round") .. ")"
   end
 }
-
 
 --	Cleffa
 jd_def["j_poke_cleffa"] = {


### PR DESCRIPTION
Pichu joker display's money wasn't updating when energized. Also I decided to put the xmult in the same line with +$ since being able to collapse the xmult was a bit weird and to bring it in line with other jokers that simultaneously give xmult and money.