### PR TITLE
Hazard Logic Quantum Enhancement Fix.toml

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -737,7 +737,7 @@ end
 '''
 position = "after"
 payload = '''
-if self.ability and old_center and old_center.config.card_limit then
+if self.ability and old_center and old_center.config.card_limit and not self.from_quantum then
     if self.area == G.hand and not self.debuff then
       if G.hand.config.real_card_limit then
         G.hand.config.real_card_limit = G.hand.config.real_card_limit - self.ability.card_limit


### PR DESCRIPTION
Small extra condition to make Hazard cards compatible with Quantum enhancements - without, it obliterates max hand size.

(P.S. not sure why it's saying the match_indent line changed to itself, I didn't touch it)