### PR TITLE
Should not need to replace ptype

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -918,10 +918,6 @@ apply_type_sticker = function(card, sticker_type)
     end
   end
   
-  if card.ability and card.ability.extra and type(card.ability.extra) == "table" and card.ability.extra.ptype then
-    card.ability.extra.ptype = apply_type 
-  end
-  
   if card.config and type(card.config) == "table" and card.config.center and type(card.config.center) == "table" and not card.config.center.stage 
      and not G.P_CENTERS[card.config.center_key].taken_ownership then
     if G.P_CENTERS[card.config.center_key].loc_vars and type(G.P_CENTERS[card.config.center_key].loc_vars) == "function" then


### PR DESCRIPTION
Applying the type sticker adds the sticker attribute and then also replaces the original type? That seems off, especially as so much type checking is doing the correct thing of checking for the sticker before the original type.

Replacing the original type is unneeded and removes useful information from the card.

I removed the following lines and spammed Tera orb, type sticker updates accordingly. Applying energy cards still works, transform energizes successfully and evolves the mon. Placed Grubbin alongside a tera orbed lighting mon and his ability still procced. 

@Eternalnacho was looking at reading the original type for an effect and we both ran into the offending code, it seems to go against what all the type_sticker code is trying to accomplish.