### PR TITLE
Changed Nightmare's call to remove() to have "self" as the 1st parameter

### DIFF
--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -780,7 +780,7 @@ local nightmare = {
     local selected = G.jokers.highlighted[1]
     local energy = matching_energy(selected)
     local context = {}
-    remove(selected, selected, context)
+    remove(self, selected, context)
     for i= 1, 2 do
       local _card = create_card("Energy", G.pack_cards, nil, nil, true, true, energy, nil)
       local edition = {negative = true}


### PR DESCRIPTION
Even if currently unused, remove takes "self" as its first parameter and if it eventually gets used (for example, if self == card then we know it's a self destruct) then it's better than Nightmare passes "self" as the 1st parameter instead of "selected".