### PR TITLE
Shiny rival does not remove extra booster on self destruct

### DIFF
--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -448,7 +448,7 @@ local rival = {
         
         G.E_MANAGER:add_event(Event({
           func = function()
-            remove(self, card, context)
+            remove(self, card, context, true)
             return true
           end
         }))


### PR DESCRIPTION
As the title says:

https://github.com/user-attachments/assets/580fa73d-1242-4150-add8-75cb414b45e6

After the rival gets triggered and self destructs it wasn't removing the booster bonus.