### PR TITLE
JokerDisplay - Fix massive bug in Mega Pidgeot

### DIFF
--- a/jokerdisplay/definitions1.lua
+++ b/jokerdisplay/definitions1.lua
@@ -387,7 +387,6 @@ jd_def["j_poke_pidgeot"] = {
     end
     card.joker_display_values.mult = (num_ranks + num_suits) * card.ability.extra.mult_mod
   end
-
 }
 
 jd_def["j_poke_mega_pidgeot"] = {
@@ -409,9 +408,6 @@ jd_def["j_poke_mega_pidgeot"] = {
     for _, scoring_card in pairs(scoring_hand) do
       local rank_found = false
       local suit_found = false
-      if scoring_card.ability.effect == 'Stone Card' then
-        goto continue
-      end
 
       for _, v in pairs(ranks) do
         if v == scoring_card:get_id() then


### PR DESCRIPTION
I've heard that goto statements were the worst, I now see why. I used goto statements in my first try to update the pidgey line to the new effect but decided to do something different and apparently missed a remnant of that first try. Sorry about introducing a worse bug in a bug fix commit.

The dangling goto statement seemed to have made every definition in definitions1.lua non-functional or at least it made the charmander, krabby, bulbasuar, and voltorb lines non-functional.