### PR TITLE
Fix Evo Item Popups with Custom Content

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -679,7 +679,7 @@ get_family_keys = function(cardname, custom_prefix, card)
   local extra = nil
   local initial_custom_prefix = custom_prefix
   custom_prefix = custom_prefix and 'j_'..custom_prefix..'_' or 'j_poke_'
-  if card.config.center.poke_multi_item then custom_prefix = initial_custom_prefix and 'c_poke'..initial_custom_prefix..'_' or 'c_poke_' end
+  if card.config.center.poke_multi_item then custom_prefix = initial_custom_prefix and 'c_'..initial_custom_prefix..'_' or 'c_poke_' end
   for k, v in pairs(pokermon.family) do
     for x, y in pairs(v) do
       if y == cardname or (type(y) == "table" and y.key == cardname) then line = v; break end
@@ -763,7 +763,7 @@ get_family_keys = function(cardname, custom_prefix, card)
             evo_item_prefix = 'poke'
             break
           else
-            evo_item_prefix = custom_prefix
+            evo_item_prefix = initial_custom_prefix
           end 
         end
       item_key = 'c_'..(evo_item_prefix)..'_'..card.config.center.item_req[i]
@@ -775,7 +775,7 @@ get_family_keys = function(cardname, custom_prefix, card)
           evo_item_prefix = 'poke'
           break
         else
-          evo_item_prefix = custom_prefix
+          evo_item_prefix = initial_custom_prefix
         end
       end
       item_key = 'c_'..(evo_item_prefix)..'_'..card.config.center.item_req

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -749,13 +749,36 @@ get_family_keys = function(cardname, custom_prefix, card)
     
   if card and card.config and card.config.center and card.config.center.item_req then
     local item_key = nil
+    local evo_item_prefix = nil
+    local native_evo_items = {
+      "firestone", "waterstone", "leafstone", "thunderstone", 
+      "dawnstone", "shinystone", "moonstone", "duskstone", 
+      "sunstone", "icestone", "prismscale", "upgrade", "dubious_disc", 
+      "linkcable", "kingsrock", "dragonscale", "hardstone",
+    }
     if type(card.config.center.item_req) == "table" then
       for i = 1, #card.config.center.item_req do
-        item_key = 'c_'..(initial_custom_prefix or 'poke')..'_'..card.config.center.item_req[i]
-        table.insert(keys, item_key)
+        for k, v in pairs(native_evo_items) do
+          if v == card.config.center.item_req[i] then
+            evo_item_prefix = 'poke'
+            break
+          else
+            evo_item_prefix = custom_prefix
+          end 
+        end
+      item_key = 'c_'..(evo_item_prefix)..'_'..card.config.center.item_req[i]
+      table.insert(keys, item_key)
       end
     else
-      item_key = 'c_'..(initial_custom_prefix or 'poke')..'_'..card.config.center.item_req
+      for k, v in pairs(native_evo_items) do
+        if v == card.config.center.item_req then
+          evo_item_prefix = 'poke'
+          break
+        else
+          evo_item_prefix = custom_prefix
+        end
+      end
+      item_key = 'c_'..(evo_item_prefix)..'_'..card.config.center.item_req
       table.insert(keys, item_key)
     end
   end


### PR DESCRIPTION
The new addition to Family popups would crash when pulling up a non-native pokemon that uses a native evo item to evolve. (or vice versa if that made sense) I've reworked the bottom of the get_family_keys function a bunch to allow the separation of the pokemon's mod prefix from the evo item's mod prefix. 

I ran tests with every relevant combination of native and non-native elements I could think of, including branching evolutions having at least one item from each source. Despite finding no issues during my testing, I was still guessing on parts of this solution by the end, and would advise some additional testing before fully merging.

There's also certainly some room to clean up my solution to separating native and non-native evo items, but I'm pretty sure said improvements require things I do not yet know how to do.