### PR TITLE
Add context calls for joker destruction effects

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -264,7 +264,12 @@ copy_scaled_values = function(card)
   return values
 end
 
-remove = function(self, card, context, check_shiny)
+remove = function(self, card, context, check_shiny, skip_joker_type_destroyed)
+  if not skip_joker_type_destroyed then
+    card.getting_sliced = true
+    local flags = SMODS.calculate_context({joker_type_destroyed = true, card = card})
+    if flags.no_destroy then card.getting_sliced = nil return end
+  end
   if check_shiny and card.edition and card.edition.poke_shiny then
     SMODS.change_booster_limit(-1)
   end

--- a/pokemon/pokejokers_20.lua
+++ b/pokemon/pokejokers_20.lua
@@ -272,17 +272,7 @@ local vanillite={
         if card.ability.extra.chips - card.ability.extra.chips_minus <= 0 then 
             G.E_MANAGER:add_event(Event({
                 func = function()
-                    play_sound('tarot1')
-                    card.T.r = -0.2
-                    card:juice_up(0.3, 0.4)
-                    card.states.drag.is = true
-                    card.children.center.pinch.x = true
-                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                        func = function()
-                                G.jokers:remove_card(self)
-                                card:remove()
-                                card = nil
-                            return true; end})) 
+                    remove(self, card, context)
                     return true
                 end
             })) 
@@ -341,17 +331,7 @@ local vanillish={
         if card.ability.extra.chips - card.ability.extra.chips_minus <= 0 then 
             G.E_MANAGER:add_event(Event({
                 func = function()
-                    play_sound('tarot1')
-                    card.T.r = -0.2
-                    card:juice_up(0.3, 0.4)
-                    card.states.drag.is = true
-                    card.children.center.pinch.x = true
-                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                        func = function()
-                                G.jokers:remove_card(self)
-                                card:remove()
-                                card = nil
-                            return true; end})) 
+                    remove(self, card, context)
                     return true
                 end
             })) 
@@ -401,17 +381,7 @@ local vanilluxe={
         if card.ability.extra.chips - card.ability.extra.chips_minus <= 0 then 
             G.E_MANAGER:add_event(Event({
                 func = function()
-                    play_sound('tarot1')
-                    card.T.r = -0.2
-                    card:juice_up(0.3, 0.4)
-                    card.states.drag.is = true
-                    card.children.center.pinch.x = true
-                    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                        func = function()
-                                G.jokers:remove_card(self)
-                                card:remove()
-                                card = nil
-                            return true; end})) 
+                    remove(self, card, context)
                     return true
                 end
             }))

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -171,17 +171,7 @@ local jelly_donut={
       if card.ability.extra.rounds <= 0 then 
         G.E_MANAGER:add_event(Event({
             func = function()
-                play_sound('tarot1')
-                card.T.r = -0.2
-                card:juice_up(0.3, 0.4)
-                card.states.drag.is = true
-                card.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(card)
-                            card:remove()
-                            card = nil
-                        return true; end})) 
+                remove(self, card, context)
                 return true
             end
         })) 
@@ -224,17 +214,7 @@ local treasure_eatery={
       if card.ability.extra.rounds <= 0 then 
         G.E_MANAGER:add_event(Event({
             func = function()
-                play_sound('tarot1')
-                card.T.r = -0.2
-                card:juice_up(0.3, 0.4)
-                card.states.drag.is = true
-                card.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(card)
-                            card:remove()
-                            card = nil
-                        return true; end})) 
+                remove(self, card, context)
                 return true
             end
         })) 


### PR DESCRIPTION
This PR adds a context call with `joker_type_destroyed = true` to the `remove` function, making it closer to the base steammodded implementation and letting future jokers (and fan addons) trigger when jokers are destroyed

It also changes the Vanilite evo line, Jelly Donut, and Treasure Eatery destruction effects to call `remove`.