### PR TITLE
Luminous deck patch fix

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -183,7 +183,7 @@ pattern = "if card.ability.consumeable and not skip_materialize then card:start_
 position = "after"
 payload = '''
 if front and G.GAME.modifiers.poke_force_seal then card:set_seal(G.GAME.modifiers.poke_force_seal) end
-if _type == 'Joker' and G.GAME.modifiers.apply_type then apply_type_sticker(card); energy_increase(card, type_sticker_applied(card)) end
+if _type == 'Joker' and G.GAME.modifiers.apply_type then apply_type_sticker(card); energy_increase(card, get_type(card)) end
 '''
 match_indent = true
 
@@ -821,4 +821,5 @@ pattern = '''order = 40,
 position = "after"
 payload = '''if self.config.center.key == 'j_poke_unown_swarm' then return end'''
 match_indent = true
+
 


### PR DESCRIPTION
I missed a spot in the energy refactor - energy_increase needs to be called with get_type(card) instead of type_sticker_applied