### PR TITLE
move area nil check in `poke_is_in_collection`

### DIFF
--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -460,8 +460,8 @@ function Game:init_game_object()
 end
 
 poke_is_in_collection = function(card)
+  if not card.area then return true end
   if G.your_collection then
-    if not card.area then return true end
     for k, v in pairs(G.your_collection) do
       if card.area == v then
         return true


### PR DESCRIPTION
Fixes `poke_is_in_collection` behaving differently depending on whether you've opened the collection since starting the game