### PR TITLE
fix crash when mirror transforms a form joker

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -410,7 +410,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
         end
       end
     end
-    if values_to_keep["form"] then
+    if values_to_keep["form"] and type(new_card.set_ability) == 'function' then
       new_card:set_ability(card)
     end
     if card.ability.extra.energy_count or card.ability.extra.c_energy_count then


### PR DESCRIPTION
Quick null check because I somehow forgot that you can turn form jokers into other jokers, and that `new_card` is a center and not a card