### PR TITLE
add `saveable` option to consumables

### DIFF
--- a/consumables/mart1.lua
+++ b/consumables/mart1.lua
@@ -311,6 +311,7 @@ local megastone = {
   set = "Spectral",
   artist = "MyDude_YT",
   helditem = true,
+  saveable = true,
   config = {extra = {usable = true, used_on = nil}},
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = { set = 'Other', key = 'endless' }

--- a/lovely.toml
+++ b/lovely.toml
@@ -577,7 +577,7 @@ position = "at"
 payload = '''
 local reserve_and_use = nil
 if (G.STATE == G.STATES.SMODS_BOOSTER_OPENED and SMODS.OPENED_BOOSTER.label:find("Pocket")) or (G.GAME.poke_save_all and not SMODS.OPENED_BOOSTER.label:find("Wish")) 
-or (card.ability.name == 'megastone') then
+or (card.config.center.saveable) then
   base_attach.children.reserve = G.UIDEF.card_focus_button{
     card = card, parent = base_attach, type = 'reserve',
     func = 'can_reserve_card', button = 'Can Reserve', card_width = card_width


### PR DESCRIPTION
Changes the hardcoded exception for Mega Stone to always be saveable from Spectral packs, to a generic `saveable` field for reusability