### PR TITLE
Moved Nature definition of Nature jokers to their own function

### DIFF
--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -1097,13 +1097,16 @@ local unown={
       card.ability.extra.form = form
       self:set_sprites(card)
       
-      card.ability.extra.targets = get_poke_target_card_ranks("unown", 1, card.ability.extra.targets)
+      self:set_nature(card)
       
       if poke_is_in_collection(card) then
         local edition = {negative = true}
         card:set_edition(edition, true, true)
       end
     end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("unown", 1, card.ability.extra.targets)
   end,
   set_sprites = function(self, card, front)
     card.children.center:set_sprite_pos({x = 0, y = 0})

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -589,9 +589,12 @@ local treecko={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("treecko", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("treecko", 3, card.ability.extra.targets)
+  end,
 }
 -- Grovyle 253
 local grovyle={
@@ -655,9 +658,12 @@ local grovyle={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("grovyle", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("grovyle", 3, card.ability.extra.targets)
+  end,
 }
 -- Sceptile 254
 local sceptile={
@@ -712,9 +718,12 @@ local sceptile={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("sceptile", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("sceptile", 3, card.ability.extra.targets)
+  end,
 }
 -- Torchic 255
 local torchic={
@@ -767,9 +776,12 @@ local torchic={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("torchic", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("torchic", 3, card.ability.extra.targets)
+  end,
 }
 -- Combusken 256
 local combusken={
@@ -821,9 +833,12 @@ local combusken={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("combusken", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("combusken", 3, card.ability.extra.targets)
+  end,
 }
 -- Blaziken 257
 local blaziken={
@@ -907,9 +922,12 @@ local blaziken={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("blaziken", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("blaziken", 3, card.ability.extra.targets)
+  end,
 }
 -- Mudkip 258
 local mudkip={
@@ -967,9 +985,12 @@ local mudkip={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("mudkip", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("mudkip", 3, card.ability.extra.targets)
+  end,
 }
 -- Marshtomp 259
 local marshtomp={
@@ -1027,9 +1048,12 @@ local marshtomp={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("marshtomp", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("marshtomp", 3, card.ability.extra.targets)
+  end,
 }
 -- Swampert 260
 local swampert={
@@ -1115,9 +1139,12 @@ local swampert={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_ranks("swampert", 3, card.ability.extra.targets)
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_ranks("swampert", 3, card.ability.extra.targets)
+  end,
 }
 -- Poochyena 261
 local poochyena={
@@ -1339,9 +1366,12 @@ local wurmple={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_suit('wurmple', true, 'Spades', {'Spades', 'Hearts', 'Diamonds', 'Clubs'})
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_suit('wurmple', true, 'Spades', {'Spades', 'Hearts', 'Diamonds', 'Clubs'})
+  end,
 }
 -- Silcoon 266
 local silcoon={
@@ -1382,9 +1412,12 @@ local silcoon={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_suit('silcoon', true, 'Hearts', {'Hearts', 'Diamonds'})
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_suit('silcoon', true, 'Hearts', {'Hearts', 'Diamonds'})
+  end,
 }
 -- Beautifly 267
 local beautifly={
@@ -1433,9 +1466,12 @@ local beautifly={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_suit('beautifly', true, 'Hearts', {'Hearts', 'Diamonds'})
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_suit('beautifly', true, 'Hearts', {'Hearts', 'Diamonds'})
+  end,
 }
 -- Cascoon 268
 local cascoon={
@@ -1476,9 +1512,12 @@ local cascoon={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_suit('cascoon', true, 'Spades', {'Spades', 'Clubs'})
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_suit('cascoon', true, 'Spades', {'Spades', 'Clubs'})
+  end,
 }
 -- Dustox 269
 local dustox={
@@ -1530,9 +1569,12 @@ local dustox={
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      card.ability.extra.targets = get_poke_target_card_suit('cascoon', true, 'Spades', {'Spades', 'Clubs'})
+      self:set_nature(card)
     end
-  end
+  end,
+  set_nature = function(self,card)
+    card.ability.extra.targets = get_poke_target_card_suit('dustox', true, 'Spades', {'Spades', 'Clubs'})
+  end,
 }
 -- Lotad 270
 return {name = "Pokemon Jokers 240-270", 


### PR DESCRIPTION
This would allow better Nature manipulation from external sources (ex: nature mints that'd reroll the nature). You can't just call `set_ability` because:
- it's not `initial` (though you could just set `initial` in the function call)
- Specifically Unown does a bunch of other things in its `set_ability` function, and so calling it would for example change its form, and other future jokers with a Nature could do other things in this function than setting a nature too

Also, that means you can check if a Joker has a `set_nature` function to know if it has a nature (I guess that already worked by checking if it had a `targets` field in its ability, but `targets` in general can mean other things that "this joker has a nature")

Your call if you wanna implement that. Currently it doesn't do much, but I think it's better to do it now that there's only 15, than in the future when we have many more Nature jokers and suddenly we need to do something similar for all of them because of a joker or consumable concept