### PR TITLE
energyfunctions.lua:energize_other compatibility with Minty

### DIFF
--- a/functions/energyfunctions.lua
+++ b/functions/energyfunctions.lua
@@ -215,7 +215,6 @@ energize_other = function(card, etype, center, colorless_penalty, amount)
       -- energize existing vanilla values if they aren't the target (i.e. ability.x_mult)
       if card.ability[k] and center.config[k] and field ~= k and not (field2 and field2 == k) then
         card.ability[k] = card.ability[k] + (center.config[k] * increase)
-		
         -- apparently Xmult and x_mult get stored from config into ability.x_mult so that's irritating
         if k == 'Xmult' then card.ability.x_mult = card.ability.x_mult + (center.config[k] * increase) end
       end


### PR DESCRIPTION
[Minty](https://github.com/wingedcatgirl/MintysSillyMod) changes how some particular vanilla jokers hold their config stats; ex. for Fibonacci, ```config = {extra = 8}}``` becomes ```config = {extra = {mult = 8, again = 0}}}```. This PR fixes crashes involved in energizing particular values that are expected to be numbers but have become tables with the relevant number inside, and maintains the intended functionality with and without Minty. See [this pokermon issue](https://github.com/InertSteak/Pokermon/issues/599) for the discussion