### PR TITLE
Pause the game when opening Pokedex View

### DIFF
--- a/pokeui.lua
+++ b/pokeui.lua
@@ -646,6 +646,7 @@ local function open_pokedex(target)
     local menu = G.SETTINGS.paused and 'pokedex_back' or nil
     if menu and G.OVERLAY_MENU:get_UIE_by_ID('cycle_shoulders') then poke_joker_page = G.OVERLAY_MENU:get_UIE_by_ID('cycle_shoulders').children[1].children[1].config.ref_table.current_option end
     if menu and target.config.center.poke_multi_item then menu = 'your_collection_consumables' end
+    G.SETTINGS.paused = true
     G.FUNCS.overlay_menu {
       definition = create_UIBox_pokedex_jokers(get_family_keys(target), menu),
     }


### PR DESCRIPTION
Pauses the game when opening Pokedex View, to prevent Controller users from selecting things in the background