### PR TITLE
fixing crash with energizing vanilla jokers

### DIFF
--- a/functions/energyfunctions.lua
+++ b/functions/energyfunctions.lua
@@ -169,44 +169,15 @@ energize_other = function(card, etype, center, colorless_penalty, amount)
   if energizable_vanilla[center.name] then
     -- get the relevant vanilla joker value from the center and ability and energy_value type
     local field, value = energizable_vanilla[center.name][1], energizable_vanilla[center.name][2]
-    -- checking if the target value is in ability or ability.extra
-    local config = center.config[value] ~= nil and center.config or center.config.extra
-    local ability = (config == center.config) and card.ability or card.ability.extra
-    -- energy calculations
-    local increase = energy_values[field] * amount / colorless_penalty
-    if (type(config[value]) == "number") and (type(ability[value]) == "number") then
-      ability[value] = ability[value] + (config[value] * increase)
-    -- compatibility with mods that affect config structure of particular vanilla jokers; i.e. Minty with Fibonacci
-    elseif (type(config[value]) == "table") then
-      for u, num in pairs(ability[value]) do
-        if energy_values[u] then
-          for w, base in pairs(config[value]) do
-            if u == w then ability[value][u] = num + (base * increase) end
-          end
-        end
-      end
-    end
+    energize_vanilla_values(card, center, field, value, colorless_penalty, amount)
     -- this checks if a second value needs to be energized
     local field2, value2
     if energizable_vanilla[center.name][3] then
       field2, value2 = energizable_vanilla[center.name][3].field, energizable_vanilla[center.name][3].value
-      config = center.config[value2] ~= nil and center.config or center.config.extra
-      ability = card.ability[value2] ~= nil and card.ability or card.ability.extra
-      increase = energy_values[field2] * amount / colorless_penalty
-      if (type(config[value2]) == "number") and (type(ability[value2]) == "number") then
-        ability[value2] = ability[value2] + (config[value2] * increase)
-      -- compatibility with mods that affect config structure of particular vanilla jokers; i.e. Minty with Fibonacci
-      elseif (type(config[value2]) == "table") then
-        for u, num in pairs(ability[value]) do
-          if energy_values[u] then
-            for w, base in pairs(config[value2]) do
-              if u == w then ability[value2][u] = num + (base * increase) end
-            end
-          end
-        end
-      end
+      energize_vanilla_values(card, center, field2, value2, colorless_penalty, amount)
     end
     for k, _ in pairs(energy_values) do
+      local increase = energy_values[k] * amount / colorless_penalty
       -- energize existing vanilla values if they aren't the target (i.e. ability.x_mult)
       if card.ability[k] and center.config[k] and field ~= k and not (field2 and field2 == k) then
         card.ability[k] = card.ability[k] + (center.config[k] * increase)
@@ -223,6 +194,28 @@ energize_other = function(card, etype, center, colorless_penalty, amount)
         card.ability[k] = card.ability[k] + (center.config[k] * increase)
         -- apparently Xmult and x_mult get stored from config into ability.x_mult so that's irritating
         if k == 'Xmult' then card.ability.x_mult = card.ability.x_mult + (center.config[k] * increase) end
+      end
+    end
+  end
+end
+
+energize_vanilla_values = function(card, center, field, value, colorless_penalty, amount)
+  if not amount then amount = 1 end
+  if not center then center = card.config.center end
+  -- checking if the target value is in ability or ability.extra
+  local config = center.config[value] ~= nil and center.config or center.config.extra
+  local ability = (config == center.config) and card.ability or card.ability.extra
+  -- energy calculations
+  local increase = energy_values[field] * amount / colorless_penalty
+  if (type(config[value]) == "number") and (type(ability[value]) == "number") then
+    ability[value] = ability[value] + (config[value] * increase)
+  -- compatibility with mods that affect config structure of particular vanilla jokers; i.e. Minty with Fibonacci
+  elseif (type(config[value]) == "table") then
+    for u, num in pairs(ability[value]) do
+      if energy_values[u] then
+        for w, base in pairs(config[value]) do
+          if u == w then ability[value][u] = num + (base * increase) end
+        end
       end
     end
   end


### PR DESCRIPTION
Variable check for the value type "number" needed to be in quotes, was always returning false