### PR TITLE
make the main menu displaycard unselectable on controller

### DIFF
--- a/functions/displaycard.lua
+++ b/functions/displaycard.lua
@@ -551,7 +551,7 @@ end)
 -- Controller support
 local is_node_focusable_ref = G.CONTROLLER.is_node_focusable
 function G.CONTROLLER:is_node_focusable(node)
-  if not self.screen_keyboard and node:is(PokeDisplayCard) then
+  if not self.screen_keyboard and node:is(PokeDisplayCard) and node.area ~= G.title_top then
     return true
   end
   return is_node_focusable_ref(self, node)


### PR DESCRIPTION
fixes an issue where the main menu card could be selected through settings menus