### PR TITLE
Let a Pokémon be discovered if it's set to be discovered from base

### DIFF
--- a/functions/apifunctions.lua
+++ b/functions/apifunctions.lua
@@ -1,5 +1,4 @@
 pokermon.load_pokemon = function(item)
-  item.discovered = true
   if not item.key then
     item.key = item.name
   end
@@ -32,8 +31,7 @@ pokermon.load_pokemon = function(item)
       item.config.extra = {item_req = item.evo_list}
     end
   end
-  item.discovered = not pokermon_config.pokemon_discovery
-  if item.name == "unown" then item.discovered = true end
+  if not item.discovered then item.discovered = not pokermon_config.pokemon_discovery end
   local prev_load = item.load
   item.load = function(self, card, card_table, other_card)
     card_table.ability.extra.juiced = nil

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -1022,6 +1022,7 @@ local unown={
     add_target_cards_to_vars(card_vars, center.ability.extra.targets)
     return {vars = card_vars}
   end,
+  discovered = true,
   rarity = "poke_safari",
   cost = 5,
   stage = "Basic",


### PR DESCRIPTION
Currently this does nothing for Pokermon, except remove that Unown exception in pokemon_load, but it'd let you have more jokers discovered by default more easily in the future if you want.

For me though, I have some multiplayer Jokers that load regardless of if you have Multiplayer or not (to show that I have some multiplayer content), so I need them to be discovered by default.