### PR TITLE
Evo item gen fix

### DIFF
--- a/boosters/packs1.lua
+++ b/boosters/packs1.lua
@@ -38,7 +38,7 @@ local poll_evo_item = function(seed)
   end
   local evo_item_key_list = {}
   for key, _ in pairs(evo_item_key_set) do
-    if not G.GAME.used_jokers[key] and (not (type(G.P_CENTERS[key].in_pool) == 'function') or G.P_CENTERS[key]:in_pool()) then
+    if G.P_CENTERS[key] and not G.GAME.used_jokers[key] and not G.GAME.banned_keys[key] and (not (type(G.P_CENTERS[key].in_pool) == 'function') or G.P_CENTERS[key]:in_pool()) then
       evo_item_key_list[#evo_item_key_list+1] = key
     end
   end


### PR DESCRIPTION
fixes a bug where pocket packs wouldn't try to force evolution items if you only had 1 joker that evolved by item, and hopefully fixes a crash with Multiplayer Small World (unable to test this)