### PR TITLE
update mystery dungeon back sprite code to fix tilted cards

### DIFF
--- a/challenges/pokechallenges.lua
+++ b/challenges/pokechallenges.lua
@@ -484,12 +484,14 @@ local mystery_dungeon = {
             Back(G.P_CENTERS[deck_key]):apply_to_run()
           end
 
+          G.GAME.poke_mystery_dungeon_deck_key = deck_key
+
           G.E_MANAGER:add_event(Event({
             func = function()
               play_sound('tarot1')
               G.deck.cards[1]:juice_up(0.3, 0.3)
               -- Handles drawing the new deck sprite on top of the challenge deck
-              G.GAME.poke_mystery_dungeon_deck_key = deck_key
+              poke_set_mystery_dungeon_back_sprites()
               return true
             end
           }))

--- a/functions/pokedraw.lua
+++ b/functions/pokedraw.lua
@@ -100,43 +100,49 @@ SMODS.DrawStep {
   conditions = { vortex = false, facing = 'front' },
 }
 
-local sprite_equals = function(sprite, atlas, x, y)
+local sprite_matches = function(sprite, atlas, x, y)
   return sprite.atlas.name == atlas
       and sprite.sprite_pos.x == (x or 0)
       and sprite.sprite_pos.y == (y or 0)
 end
 
-SMODS.DrawStep {
-  key = 'mystery_dungeon_back',
-  order = 5,
-  func = function (card, layer)
-    -- Draws Mystery Dungeon's current deck on top of the challenge deck sprite
-    if G.GAME.poke_mystery_dungeon_deck_key and card.children.back
-        and sprite_equals(card.children.back, 'centers', 0, 4) then -- Filter for Challenge Deck sprite
-      local deck_key = G.GAME.poke_mystery_dungeon_deck_key
+local function should_apply_mystery_dungeon_back_sprite(card)
+  return G.GAME.poke_mystery_dungeon_deck_key
+      and card.children.back
+      and sprite_matches(card.children.back, 'centers', 0, 4) -- Filter for Challenge Deck sprite
+end
 
-      G.poke_shared_back_sprites = G.poke_shared_back_sprites or {}
-      local deck_sprite = G.poke_shared_back_sprites[deck_key]
+local function apply_mystery_dungeon_back_sprite(card)
+  if card.children.back then card.children.back:remove() end
 
-      if not deck_sprite then
-        local deck = G.P_CENTERS[G.GAME.poke_mystery_dungeon_deck_key]
-        local atlas = deck.atlas or 'centers'
-        local pos = deck.pos or {x = 0, y = 0}
+  local deck = G.P_CENTERS[G.GAME.poke_mystery_dungeon_deck_key]
+  local atlas = deck.atlas or 'centers'
+  local pos = deck.pos or {x = 0, y = 0}
 
-        deck_sprite = SMODS.create_sprite(0, 0, G.CARD_W, G.CARD_H, atlas, pos)
-        G.poke_shared_back_sprites[deck_key] = deck_sprite
-      end
+  card.children.back = SMODS.create_sprite(card.T.x, card.T.y, card.T.w, card.T.h, atlas, pos)
+  card.children.back.states.hover = card.states.hover
+  card.children.back.states.click = card.states.click
+  card.children.back.states.drag = card.states.drag
+  card.children.back.states.collide.can = false
+  card.children.back:set_role({major = card, role_type = 'Glued', draw_major = card})
+end
 
-      if card.area and card.area.config.type == 'deck' and card.rank > 3 then
-        -- Turns the bottom cards in your deck darker to imitate depth
-        local prev_overlay = G.BRUTE_OVERLAY -- This is usually `nil` but lets save it just in case
-        G.BRUTE_OVERLAY = card.back_overlay
-        deck_sprite:draw_from(card.children.back)
-        G.BRUTE_OVERLAY = prev_overlay
-      else
-        deck_sprite:draw_shader('dissolve', nil, nil, nil, card.children.back)
-      end
-    end
-  end,
-  conditions = { vortex = false, facing = 'back' },
-}
+local function handle_mystery_dungeon_sprites(card)
+  if should_apply_mystery_dungeon_back_sprite(card) then
+    apply_mystery_dungeon_back_sprite(card)
+  end
+end
+
+-- Changes the back sprite during the Mystery Dungeon challenge to match your random deck
+local card_set_sprites_ref = Card.set_sprites
+function Card:set_sprites(_center, _front)
+  card_set_sprites_ref(self, _center, _front)
+  handle_mystery_dungeon_sprites(self)
+end
+
+-- Manually update cards that have been created before the random deck was applied
+function poke_set_mystery_dungeon_back_sprites()
+  for _, card in ipairs(G.I.CARD) do
+    handle_mystery_dungeon_sprites(card)
+  end
+end


### PR DESCRIPTION
*better late than never*

Changes the Mystery Dungeon draw code to replace the back sprites instead of drawing over them.

Still has the delay and visual pop when starting the challenge.