### PR TITLE
fix reusables from packs

### DIFF
--- a/consumable types/type1.lua
+++ b/consumable types/type1.lua
@@ -21,6 +21,7 @@ local item = {
  	},
   collection_row = {6, 6},
   shop_rate = 4,
+  select_card = 'consumeables',
   default = "c_poke_pokeball"
 }
 


### PR DESCRIPTION
Fixes a bug where items like Leftovers wouldn't get removed from the pool if used directly from packs