### PR TITLE
Refactor Chip Drain

### DIFF
--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -729,3 +729,20 @@ poke_convert_to_set = function(element_or_list)
     return set
   end
 end
+
+poke_drain_chips = function(card, amount)
+  if amount < 0 then return 0 end
+
+  local nominal_chips = card.base.nominal - (card.ability.nominal_drain or 0)
+  local bonus_chips = card.ability.bonus + (card.ability.perma_bonus or 0)
+
+  local base_drain = math.min(nominal_chips - 1, amount)
+
+  card.ability.nominal_drain = (card.ability.nominal_drain or 0) + base_drain
+
+  local bonus_drain = math.min(bonus_chips, amount - base_drain)
+
+  card.ability.perma_bonus = (card.ability.perma_bonus or 0) - bonus_drain
+
+  return base_drain + bonus_drain
+end

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -961,7 +961,6 @@ local misdreavus = {
         return {
           message = localize('k_eroded_ex'),
           colour = G.C.CHIPS,
-          card = context.other_card,
           func = function()
             SMODS.scale_card(card, {
               ref_value = 'chips',

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -952,38 +952,31 @@ local misdreavus = {
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.individual and context.cardarea == G.play and context.other_card then
-      if not context.other_card.debuff and context.other_card:is_face() then
-        context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain or 0
-        context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus or 0
-        local drained_vals = math.min(card.ability.extra.chip_mod, context.other_card.base.nominal - context.other_card.ability.nominal_drain - 1)
-        if drained_vals > 0 then
-          context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain + drained_vals
-        end
-        local drain_bonus = math.min(context.other_card.ability.bonus + context.other_card.ability.perma_bonus, card.ability.extra.chip_mod - drained_vals)
-        if drain_bonus > 0 then
-          context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus - drain_bonus
-          drained_vals = drained_vals + drain_bonus
-        end
-        if drained_vals > 0 then
-          card.ability.extra.chips = card.ability.extra.chips + drained_vals
-          return {
-            message = localize('k_eroded_ex'),
-            colour = G.C.CHIPS,
-            card = context.other_card,
-            extra = { func = function() card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_upgrade_ex')}) end },
-          }
-        end
-      end
-    end
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
+    if context.individual and context.cardarea == G.play
+        and context.other_card:is_face() and not context.other_card.debuff then
+
+      local drained_chips = poke_drain_chips(context.other_card, card.ability.extra.chip_mod)
+
+      if drained_chips > 0 then
         return {
-          message = localize{type = 'variable', key = 'a_chips', vars = {card.ability.extra.chips}},
+          message = localize('k_eroded_ex'),
           colour = G.C.CHIPS,
-          chip_mod = card.ability.extra.chips,
+          card = context.other_card,
+          func = function()
+            SMODS.scale_card(card, {
+              ref_value = 'chips',
+              operation = function(ref_table, ref_value, initial)
+                ref_table[ref_value] = initial + drained_chips
+              end,
+            })
+          end,
         }
       end
+    end
+    if context.joker_main then
+      return {
+        chips = card.ability.extra.chips,
+      }
     end
     return item_evo(self, card, context, "j_poke_mismagius")
   end,

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -328,25 +328,19 @@ local tyranitar={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.individual and context.cardarea == G.play and context.scoring_hand and context.scoring_name == "Full House" then
-      context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain or 0
-      local drained_vals = math.min(card.ability.extra.chip_mod_minus, context.other_card.base.nominal - context.other_card.ability.nominal_drain - 1)
-      if drained_vals > 0 then
-        context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain + drained_vals
-      end
-      local drain_bonus = math.min(context.other_card.ability.bonus + context.other_card.ability.perma_bonus, card.ability.extra.chip_mod_minus- drained_vals)
-      if drain_bonus > 0 then
-        context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus - drain_bonus
-        drained_vals = drained_vals + drain_bonus
-      end
-      if drained_vals > 0 then
-        card_eval_status_text(context.other_card, 'extra', nil, nil, nil, {message = localize('k_eroded_ex'), colour = G.C.CHIPS})
-        context.other_card.ability.perma_x_mult = context.other_card.ability.perma_x_mult or 1
-        context.other_card.ability.perma_x_mult = context.other_card.ability.perma_x_mult + card.ability.extra.Xmult_multi
+    if context.individual and context.cardarea == G.play and context.scoring_name == "Full House" then
+
+      local drained_chips = poke_drain_chips(context.other_card, card.ability.extra.chip_mod_minus)
+
+      if drained_chips > 0 then
+        context.other_card.ability.perma_x_mult = (context.other_card.ability.perma_x_mult or 1) + card.ability.extra.Xmult_multi
         return {
-          extra = {message = localize('k_upgrade_ex'), colour = G.C.XMULT},
+          message = localize('k_eroded_ex'),
           colour = G.C.CHIPS,
-          card = card
+          extra = {
+            message = localize('k_upgrade_ex'),
+            colour = G.C.XMULT
+          },
         }
       end
     end

--- a/pokemon/pokejokers_15.lua
+++ b/pokemon/pokejokers_15.lua
@@ -197,47 +197,38 @@ local mismagius = {
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.individual and context.cardarea == G.play and context.other_card then
-      if not context.other_card.debuff and context.other_card:is_face() then
-        context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain or 0
-        context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus or 0
-        if SMODS.pseudorandom_probability(card, 'mismagius', card.ability.extra.num, card.ability.extra.dem, 'mismagius') then
-          context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus + card.ability.extra.chips2
+    if context.individual and context.cardarea == G.play
+        and context.other_card:is_face() and not context.other_card.debuff then
+      if SMODS.pseudorandom_probability(card, 'mismagius', card.ability.extra.num, card.ability.extra.dem, 'mismagius') then
+        context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus + card.ability.extra.chips2
+        return {
+          message = localize('k_upgrade_ex'),
+          colour = G.C.CHIPS,
+        }
+      else
+        local drained_chips = poke_drain_chips(context.other_card, card.ability.extra.chip_mod)
+
+        if drained_chips > 0 then
           return {
-            message = localize('k_upgrade_ex'),
+            message = localize('k_eroded_ex'),
             colour = G.C.CHIPS,
             card = context.other_card,
+            func = function()
+              SMODS.scale_card(card, {
+                ref_value = 'chips',
+                operation = function(ref_table, ref_value, initial)
+                  ref_table[ref_value] = initial + drained_chips
+                end,
+              })
+            end,
           }
-        else
-          local drained_vals = math.min(card.ability.extra.chip_mod, context.other_card.base.nominal - context.other_card.ability.nominal_drain - 1)
-          if drained_vals > 0 then
-            context.other_card.ability.nominal_drain = context.other_card.ability.nominal_drain + drained_vals
-          end
-          local drain_bonus = math.min(context.other_card.ability.bonus + context.other_card.ability.perma_bonus, card.ability.extra.chip_mod - drained_vals)
-          if drain_bonus > 0 then
-            context.other_card.ability.perma_bonus = context.other_card.ability.perma_bonus - drain_bonus
-            drained_vals = drained_vals + drain_bonus
-          end
-          if drained_vals > 0 then
-            card.ability.extra.chips = card.ability.extra.chips + drained_vals
-            return {
-              message = localize('k_eroded_ex'),
-              colour = G.C.CHIPS,
-              card = context.other_card,
-              extra = { func = function() card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_upgrade_ex')}) end },
-            }
-          end
         end
       end
     end
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        return {
-          message = localize{type = 'variable', key = 'a_chips', vars = {card.ability.extra.chips}},
-          colour = G.C.CHIPS,
-          chip_mod = card.ability.extra.chips,
-        }
-      end
+    if context.joker_main then
+      return {
+        chips = card.ability.extra.chips,
+      }
     end
   end,
   attributes = {"face", "modify_card", "scaling", "chance", "perma_bonus", "chips"},

--- a/pokemon/pokejokers_15.lua
+++ b/pokemon/pokejokers_15.lua
@@ -212,7 +212,6 @@ local mismagius = {
           return {
             message = localize('k_eroded_ex'),
             colour = G.C.CHIPS,
-            card = context.other_card,
             func = function()
               SMODS.scale_card(card, {
                 ref_value = 'chips',


### PR DESCRIPTION
Quick refactor of all 3 Chip Drain Jokers, including making Misdreavus and Mismagius use `SMODS.scale_card`.
Should also help for making future Chip Drain Jokers.

Next up will be Ruins of Alph, Rival, Litwick's evolution line, and Deino's evolution line, but I'm unsure how soon I'll get to these