### PR TITLE
Misc. Refactors

### DIFF
--- a/functions/energyfunctions.lua
+++ b/functions/energyfunctions.lua
@@ -290,16 +290,6 @@ ease_poke_dollars = function(card, seed, amt, calc_only)
         earned = earned + 1
       end
     end
-    if card.ability.money1_frac then
-      if card.ability.money1_frac > pseudorandom(pseudoseed(seed)) then
-        earned = earned + 1
-      end
-    end
-    if card.ability.money2_frac then
-      if card.ability.money2_frac > pseudorandom(pseudoseed(seed)) then
-        earned = earned + 1
-      end
-    end
   end
   if (SMODS.Mods["Talisman"] or {}).can_load then
     earned = to_number(earned)

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1103,27 +1103,36 @@ poke_total_chips = function(card)
 end
 
 poke_drain = function(card, target, amount, one_way)
-  local amt = amount
-  local amt_drained = 0
-  if target.sell_cost == 1 then return end
-  target.ability.extra_value = target.ability.extra_value or 0
-  if target.sell_cost <= amt then
-    amt_drained = amt_drained + target.sell_cost - 1
-    target.ability.extra_value = target.ability.extra_value - amt_drained
-  else
-     target.ability.extra_value = target.ability.extra_value - amt
-     amt_drained = amt
-  end
-  
-  if amt_drained > 0 then
+  local drain_amount = math.min(target.sell_cost - 1, amount)
+
+  if drain_amount > 0 then
+    SMODS.scale_card(target, {
+      ref_table = target.ability,
+      ref_value = 'extra_value',
+      operation = function(ref_table, ref_value, initial)
+        ref_table[ref_value] = initial - drain_amount
+      end,
+      scaling_message = {
+        message = localize('poke_val_down'),
+        colour = G.C.RED
+      }
+    })
     target:set_cost()
-    card_eval_status_text(target, 'extra', nil, nil, nil, {message = localize('poke_val_down'), colour = G.C.RED})
+
     if not one_way then
-      card.ability.extra_value = card.ability.extra_value or 0
-      card.ability.extra_value = card.ability.extra_value + amt_drained
+      SMODS.scale_card(card, {
+        ref_table = card.ability,
+        ref_value = 'extra_value',
+        operation = function(ref_table, ref_value, initial)
+          ref_table[ref_value] = initial + drain_amount
+        end,
+        scaling_message = {
+          message = localize('k_val_up'),
+          colour = G.C.MONEY
+        }
+      })
       card:set_cost()
-      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_val_up')})
-    end    
+    end
   end
 end
 

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -700,18 +700,6 @@ type_tooltip = function(self, info_queue, center)
           info_queue[#info_queue+1] = {set = 'Other', key = "money_chance", vars = {percent}}
         end
       end
-      if center.ability.money1_frac and center.ability.money1_frac > 0 then
-        percent = tonumber(string.format('%.3f', center.ability.money1_frac)) * 100
-        if percent ~= 100 and percent ~= 0 then
-          info_queue[#info_queue+1] = {set = 'Other', key = "money_chance", vars = {percent}}
-        end
-      end
-      if center.ability.money2_frac and center.ability.money2_frac > 0 then
-        percent = tonumber(string.format('%.3f', center.ability.money2_frac)) * 100
-        if percent ~= 100 and percent ~= 0 then
-          info_queue[#info_queue+1] = {set = 'Other', key = "money_chance", vars = {percent}}
-        end
-      end
       if center.ability.money_mod_frac and center.ability.money_mod_frac > 0 then
         percent = tonumber(string.format('%.3f', center.ability.money_mod_frac)) * 100
         if percent ~= 100 and percent ~= 0 then

--- a/pokemon/pokejokers_21.lua
+++ b/pokemon/pokejokers_21.lua
@@ -206,28 +206,24 @@ local litwick={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        local Mult = card.ability.extra.mult
-        if card.sell_cost >= card.ability.extra.sell_goal then
-          Mult = 3 * card.ability.extra.mult
-        end
-        return {
-          message = localize{type = 'variable', key = 'a_mult', vars = {Mult}}, 
-          colour = G.C.MULT,
-          mult_mod = Mult
-        }
+    if context.joker_main then
+      local mult = card.ability.extra.mult
+      if card.sell_cost >= card.ability.extra.sell_goal then
+        mult = mult * 3
       end
+      return {
+        mult = mult
+      }
     end
     if context.end_of_round and not context.individual and not context.repetition then
       local adjacent = poke_get_adjacent_jokers(card)
-      for i = 1, #adjacent do 
-        poke_drain(card, adjacent[i], card.ability.extra.money_minus)
+      for _, v in ipairs(adjacent) do
+        poke_drain(card, v, card.ability.extra.money_minus)
       end
     end
     return scaling_evo(self, card, context, "j_poke_lampent", card.sell_cost, self.config.evo_rqmt)
   end,
-  attributes = {"drain", "mult", "sell_value", "condition_evo"},
+  attributes = {"drain", "mult", "sell_value", "scaling", "scaling_evo"},
 }
 -- Lampent 608
 local lampent={
@@ -252,26 +248,21 @@ local lampent={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        return {
-          message = localize{type = 'variable', key = 'a_mult', vars = {card.sell_cost}},
-          colour = G.C.MULT,
-          mult_mod = card.sell_cost
-        }
-      end
+    if context.joker_main then
+      return {
+        mult = card.sell_cost
+      }
     end
     if context.end_of_round and not context.individual and not context.repetition then
-      local adjacent = poke_get_adjacent_jokers(card)
-      for i = 1, #G.jokers.cards do 
-        if G.jokers.cards[i] ~= card then
-          poke_drain(card, G.jokers.cards[i], card.ability.extra.money_minus)
+      for _, v in ipairs(G.jokers.cards) do
+        if v ~= card then
+          poke_drain(card, v, card.ability.extra.money_minus)
         end
       end
     end
     return item_evo(self, card, context, "j_poke_chandelure")
   end,
-  attributes = {"drain", "mult", "sell_value", "joker", "item_evo"},
+  attributes = {"drain", "mult", "sell_value", "joker", "scaling", "item_evo"},
 }
 -- Chandelure 609
 local chandelure={
@@ -292,27 +283,15 @@ local chandelure={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        return {
-          message = localize{type = 'variable', key = 'a_mult', vars = {card.sell_cost}}, 
-          colour = G.C.MULT,
-          mult_mod = card.sell_cost
-        }
-      end
+    if context.joker_main then
+      return {
+        mult = card.sell_cost
+      }
     end
-    if context.other_joker and context.other_joker.config and context.other_joker.sell_cost < 2 and context.other_joker.ability.set == 'Joker' and not context.post_trigger then
-        G.E_MANAGER:add_event(Event({
-          func = function()
-              context.other_joker:juice_up(0.5, 0.5)
-              return true
-          end
-        })) 
-        return {
-          message = localize{type = 'variable', key = 'a_xmult', vars = {card.ability.extra.Xmult_multi}}, 
-          colour = G.C.XMULT,
-          Xmult_mod = card.ability.extra.Xmult_multi
-        }
+    if context.other_joker and context.other_joker.sell_cost < 2 then
+      return {
+        Xmult = card.ability.extra.Xmult_multi
+      }
     end
   end,
   attributes = {"xmult", "mult", "sell_value", "joker"},

--- a/pokemon/pokejokers_22.lua
+++ b/pokemon/pokejokers_22.lua
@@ -95,11 +95,12 @@ local hydreigon={
         Xmult = card.ability.extra.Xmult
       }
     end
-    if context.destroy_card and context.scoring_name == "Three of a Kind" and not context.blueprint
-        and context.cardarea == 'unscored' then
-      return {
-        remove = true
-      }
+    if context.after and context.scoring_name == "Three of a Kind" and not context.blueprint then
+      for k, v in pairs(context.full_hand) do
+        if not SMODS.in_scoring(v, context.scoring_hand) then
+          poke_remove_card(v, card)
+        end
+      end
     end
     if context.remove_playing_cards and not context.blueprint then
       for _, removed_card in ipairs(context.removed) do

--- a/pokemon/pokejokers_22.lua
+++ b/pokemon/pokejokers_22.lua
@@ -20,15 +20,13 @@ local deino={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand and context.scoring_name == "Three of a Kind" then
+    if context.scoring_name == "Three of a Kind" then
+      if context.before and not context.blueprint then
+        card.ability.extra.hand_played = card.ability.extra.hand_played + 1
+      end
       if context.joker_main then
-        if not context.blueprint then
-          card.ability.extra.hand_played = card.ability.extra.hand_played + 1
-        end
         return {
-          message = localize{type = 'variable', key = 'a_xmult', vars = {card.ability.extra.Xmult}}, 
-          colour = G.C.mult,
-          Xmult_mod = card.ability.extra.Xmult
+          Xmult = card.ability.extra.Xmult
         }
       end
     end
@@ -55,15 +53,13 @@ local zweilous={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand and context.scoring_name == "Three of a Kind" then
+    if context.scoring_name == "Three of a Kind" then
+      if context.before and not context.blueprint then
+        card.ability.extra.hand_played = card.ability.extra.hand_played + 1
+      end
       if context.joker_main then
-        if not context.blueprint then
-          card.ability.extra.hand_played = card.ability.extra.hand_played + 1
-        end
         return {
-          message = localize{type = 'variable', key = 'a_xmult', vars = {card.ability.extra.Xmult}}, 
-          colour = G.C.mult,
-          Xmult_mod = card.ability.extra.Xmult
+          Xmult = card.ability.extra.Xmult
         }
       end
     end

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -469,80 +469,72 @@ local ruins_of_alph={
   blueprint_compat = true,
   eternal_compat = false,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        if card.ability.extra.mult > 0 then
-          return {
-            message = localize{type = 'variable', key = 'a_mult', vars = {card.ability.extra.mult}}, 
-            colour = G.C.MULT,
-            mult_mod = card.ability.extra.mult
-          }
+    if context.joker_main then
+      return {
+        mult = card.ability.extra.mult
+      }
+    end
+    if context.after then
+      local unowns = SMODS.find_card("j_poke_unown")
+      local added = nil
+      for k, v in pairs(unowns) do
+        if v.ability.extra.triggered and not v.ability.extra.merged then
+          SMODS.scale_card(card, {
+            ref_value = 'mult',
+            scalar_value = 'mult_mod',
+            no_message = true,
+          })
+          card.ability.extra.merged = card.ability.extra.merged + 1
+          v.ability.extra.merged = true
+          table.insert(card.ability.extra.forms, v.ability.extra.form)
+          added = true
         end
       end
-      if context.after then
-        local unowns = SMODS.find_card("j_poke_unown")
-        local added = nil
-        for k, v in pairs(unowns) do
-          if v.ability.extra.triggered and not v.ability.extra.merged then
-            card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
-            card.ability.extra.merged = card.ability.extra.merged + 1
-            v.ability.extra.merged = true
-            table.insert(card.ability.extra.forms, v.ability.extra.form)
-            added = true
-          end
-        end
-        if added then table.sort(card.ability.extra.forms) end
-      end
+      if added then table.sort(card.ability.extra.forms) end
     end
     if context.setting_blind and not context.blueprint then
-      for i = 1, 3 do
-        G.E_MANAGER:add_event(Event({func = function()
-          local temp_card = {set = "Joker", area = G.jokers, key = "j_poke_unown"}
-          local new_card = SMODS.create_card(temp_card)
-          local edition = {negative = true}
-          new_card:set_edition(edition, true)
-          new_card.cost = 0
-          new_card.sell_cost = 0
-          new_card:add_to_deck()
-          G.jokers:emplace(new_card)
-          new_card:start_materialize()
-        return true end }))
+      for _ = 1, 3 do
+        G.E_MANAGER:add_event(Event({
+          func = function()
+            local unown = SMODS.add_card({set = 'Joker', key = 'j_poke_unown', edition = 'e_negative'})
+            return true
+          end
+        }))
       end
     end
     if context.selling_self and not context.blueprint then
-      local temp_card = nil
-      local reward_card = nil
       if card.ability.extra.merged >= 28 then
-        temp_card = {set = "Joker", area = G.jokers, key = "j_poke_unown_swarm"}
-        reward_card = SMODS.create_card(temp_card)
-        local _card = create_card('Spectral', G.consumeables, nil, nil, nil, nil, 'c_soul')
-              _card:add_to_deck()
-              G.consumeables:emplace(_card)
-              card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('k_plus_spectral'), colour = G.C.SECONDARY_SET.Spectral})
+        SMODS.add_card({set = "Joker", key = "j_poke_unown_swarm"})
+        local soul = SMODS.add_card({set = 'Spectral', key = 'c_soul'})
+
+        SMODS.calculate_effect({
+          message = localize('k_plus_spectral'),
+          colour = G.C.SECONDARY_SET.Spectral
+        }, soul)
       elseif card.ability.extra.merged >= 20 then
-        temp_card = {set = "Joker", area = G.jokers, key = "j_brainstorm"}
-        reward_card = SMODS.create_card(temp_card)
+        SMODS.add_card({set = "Joker", key = "j_brainstorm"})
       elseif card.ability.extra.merged >= 10 then
         local jokers = {}
-        for i = 1, #G.jokers.cards do
-            if G.jokers.cards[i] ~= card then
-                jokers[#jokers + 1] = G.jokers.cards[i]
-            end
+        for k, v in ipairs(G.jokers.cards) do
+          if v ~= card then
+            jokers[#jokers+1] = v
+          end
         end
         if #jokers > 0 then
-          local chosen_joker = pseudorandom_element(jokers, 'alph')
-          reward_card = copy_card(chosen_joker, nil, nil, nil, chosen_joker.edition and chosen_joker.edition.negative)
-          card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_duplicated_ex')})
+          return {
+            message = localize('k_duplicated_ex'),
+            func = function()
+              local chosen_joker = pseudorandom_element(jokers, 'alph')
+              local copy = copy_card(chosen_joker, nil, nil, nil, chosen_joker.edition and chosen_joker.edition.negative)
+              copy:add_to_deck()
+              G.jokers:emplace(copy)
+            end
+          }
         else
-          card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_no_other_jokers')})
+          return {message = localize('k_no_other_jokers')}
         end
       elseif card.ability.extra.merged >= 5 then
-        reward_card = SMODS.create_card({ set = "Joker", rarity = "poke_safari", key_append = "alph" })
-      end
-      if reward_card then
-        reward_card:add_to_deck()
-        G.jokers:emplace(reward_card)
-        reward_card:start_materialize()
+        SMODS.add_card({set = "Joker", rarity = "poke_safari", key_append = "alph"})
       end
     end
   end,

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -412,6 +412,10 @@ local rival = {
         ease_poke_dollars(card, 'rival', money)
 
         SMODS.destroy_cards(card, nil, nil, true)
+
+        return {
+          message = localize("poke_smell_ya")
+        }
       else
         G.E_MANAGER:add_event(Event({
           func = (function()
@@ -422,10 +426,6 @@ local rival = {
           end)
         }))
       end
-
-      return {
-        message = localize("poke_smell_ya")
-      }
     end
   end,
   set_ability = function(self, card, initial, delay_sprites)

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -385,82 +385,68 @@ local rival = {
   blueprint_compat = true,
   eternal_compat = false,
   calculate = function(self, card, context)
-    if context.skip_blind and card.ability.extra.form < 2 and not context.blueprint then
-      if card.ability.extra.form == 1 then
-        card.ability.extra.money2 = card.ability.extra.money2 + card.ability.extra.money_mod2
-      else
-        card.ability.extra.money1 = card.ability.extra.money1 + card.ability.extra.money_mod1
-      end
-      
+    local form = card.ability.extra.form
+
+    if context.skip_blind and form < 2 and not context.blueprint then
+      SMODS.scale_card(card, {
+        ref_value = form == 0 and 'money1' or 'money2',
+        scalar_value = form == 0 and 'money_mod1' or 'money_mod2',
+        message_colour = G.C.MONEY,
+      })
+    end
+
+    if context.joker_main and form == 2 then
       return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.MONEY
+        Xmult = 1 + G.GAME.skips * card.ability.extra.Xmult_mod
       }
     end
-    
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.joker_main then
-        if card.ability.extra.form > 1 then
-          return {
-            message = localize{type = 'variable', key = 'a_xmult', vars = {1 + G.GAME.skips * card.ability.extra.Xmult_mod}}, 
-            colour = G.C.XMULT,
-            Xmult_mod =  1 + G.GAME.skips * card.ability.extra.Xmult_mod
-          }
-        end
-      end
-    end
 
-    if (context.end_of_round and G.GAME.blind.boss) and not context.repetition and not context.individual and not context.blueprint then
-      G.GAME.rival_losses = G.GAME.rival_losses + 1
+    if context.end_of_round and context.game_over == false and context.main_eval and context.beat_boss and not context.blueprint then
+      if form < 2 then
+        G.GAME.rival_losses = (G.GAME.rival_losses or 0) + 1
 
-      local money = card.ability.extra.money1
-      if card.ability.extra.form == 1 then
-        money = card.ability.extra.money2
-      end
-      if card.ability.extra.form < 2 then
+        local money = form == 0
+            and card.ability.extra.money1
+            or card.ability.extra.money2
+
         ease_poke_dollars(card, 'rival', money)
+
+        SMODS.destroy_cards(card, nil, nil, true)
       else
         G.E_MANAGER:add_event(Event({
           func = (function()
-              add_tag(Tag('tag_skip'))
-              play_sound('generic1', 0.9 + math.random()*0.1, 0.8)
-              play_sound('holo1', 1.2 + math.random()*0.1, 0.4)
-              return true
+            add_tag(Tag('tag_skip'))
+            play_sound('generic1', 0.9 + math.random() * 0.1, 0.8)
+            play_sound('holo1', 1.2 + math.random() * 0.1, 0.4)
+            return true
           end)
         }))
       end
 
-      if card.ability.extra.form < 2 then
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            remove(self, card, context, true)
-            return true
-          end
-        }))
-      end
-
       return {
-          message = localize("poke_smell_ya")
+        message = localize("poke_smell_ya")
       }
     end
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
-      G.GAME.rival_losses = G.GAME.rival_losses or 0
-      card.ability.extra.form = G.GAME.rival_losses
+      card.ability.extra.form = math.min(2, G.GAME.rival_losses or 0)
       self:set_sprites(card)
     end
   end,
   set_sprites = function(self, card, front)
-    if card.ability and card.ability.extra and card.ability.extra.form and card.ability.extra.form > 1 then
-      card.children.center:set_sprite_pos({x = 4, y = 2})
-    elseif card.ability and card.ability.extra and card.ability.extra.form and card.ability.extra.form == 1 then
-      card.children.center:set_sprite_pos({x = 2, y = 2})
-    else
-      card.children.center:set_sprite_pos({x = 0, y = 2})
+    if card.ability and card.ability.extra and card.ability.extra.form then
+      local form = card.ability.extra.form
+      local sprite_pos = ({
+        [0] = {x = 0, y = 2},
+        [1] = {x = 2, y = 2},
+        [2] = {x = 4, y = 2},
+      })[form]
+
+      card.children.center:set_sprite_pos(sprite_pos)
     end
   end,
-  attributes = {"skip", "economy", "boss_blind", "tag", "generation"},
+  attributes = {"skip", "economy", "boss_blind", "tag", "generation", "scaling"},
 }
 
 local ruins_of_alph={

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -494,12 +494,7 @@ local ruins_of_alph={
     end
     if context.setting_blind and not context.blueprint then
       for _ = 1, 3 do
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            local unown = SMODS.add_card({set = 'Joker', key = 'j_poke_unown', edition = 'e_negative'})
-            return true
-          end
-        }))
+        SMODS.add_card({set = 'Joker', key = 'j_poke_unown', edition = 'e_negative'})
       end
     end
     if context.selling_self and not context.blueprint then
@@ -523,7 +518,7 @@ local ruins_of_alph={
         if #jokers > 0 then
           return {
             message = localize('k_duplicated_ex'),
-            func = function()
+            func = function() -- display message before copy is created to match invis_joker behaviour
               local chosen_joker = pseudorandom_element(jokers, 'alph')
               local copy = copy_card(chosen_joker, nil, nil, nil, chosen_joker.edition and chosen_joker.edition.negative)
               copy:add_to_deck()


### PR DESCRIPTION
Refactors of
- Litwick, Lampent, and Chandelure
- Rival, Bitter Rival, and Champion
- Ruins of Alph
- Deino, Zweilous and Hydreigon

Litwick, Lampent, Rival, Bitter Rival, and Ruins of Alph (as well as the Drain mechanic in general) now use `SMODS.scale_card`
Deino and Zweilous have been cleaned up, while Hydreigon has had a partial revert to use the old card destruction animation.
Champion no longer says "Smell ya Later" and the Rival line in general no longer give bonus chance at money.