### PR TITLE
Fix Ruins Refactor

### DIFF
--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -493,9 +493,14 @@ local ruins_of_alph={
       if added then table.sort(card.ability.extra.forms) end
     end
     if context.setting_blind and not context.blueprint then
-      for _ = 1, 3 do
-        SMODS.add_card({set = 'Joker', key = 'j_poke_unown', edition = 'e_negative'})
-      end
+      G.E_MANAGER:add_event(Event({
+        func = function()
+          for _ = 1, 3 do
+            SMODS.add_card({set = 'Joker', key = 'j_poke_unown', edition = 'e_negative'})
+          end
+          return true
+        end
+      }))
     end
     if context.selling_self and not context.blueprint then
       if card.ability.extra.merged >= 28 then


### PR DESCRIPTION
Fixes a small goof I made while refactoring Ruins of Alph where it would create Unowns *before* The Mirror selected a target to turn into Ditto, always giving you a negative Ditto