### PR TITLE
JokerDisplay - Skarmory bug fix

### DIFF
--- a/jokerdisplay/definitions2.lua
+++ b/jokerdisplay/definitions2.lua
@@ -1465,7 +1465,7 @@ jd_def["j_poke_skarmory"] = {
         for _, playing_card in ipairs(G.hand.cards) do
             if playing_hand or not playing_card.highlighted then
                 if playing_card.facing and not (playing_card.facing == 'back') and not playing_card.debuff and (SMODS.has_enhancement(playing_card, "m_poke_hazard") or SMODS.has_enhancement(playing_card, "m_steel") ) then
-                    count = count + JokerDisplay.calculate_card_triggers(playing_card, nil, true)
+                    count = count + 1
                 end
             end
         end


### PR DESCRIPTION
Skarmory's joker display was bugged when used with Gigalith and I assume other jokers that retrigger held in hand cards. 