### PR TITLE
Fix formatting in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Both [Lovely](https://github.com/ethangreen-dev/lovely-injector) (use latest rel
 
 1. Download the zip file with the contents of the repository. (Code -> Download Zip)\
 2. Create a folder named Pokermon inside your mods folder.
-3. Extract the zip file into the mods folder. Make sure that there is a single folder between the mods folder and the contents. (Ie it should go Mods\Pokermon\contents and not Mods\Pokermon\Pokermon\contents or Mods\contents, where contents are the inner files)
+3. Extract the zip file into the mods folder. Make sure that there is a single folder between the mods folder and the contents. (Ie it should go `Mods\Pokermon\contents` and not `Mods\Pokermon\Pokermon\contents` or `Mods\contents`, where contents are the inner files)
 4. Make sure the files are directly under the Pokermon folder in your mods folder and not under the zip file folder.
    (In other words, unzip the file and then copy and paste the assests, config.lua, pokermon.lua, etc to be under the Pokermon folder in the mods folder) 
 


### PR DESCRIPTION
Format installation instructions to denote start and end of path due to "and not" plus "or" could be misinterpreted as part of path string.