### PR TITLE
Switch to using `mod.menu_cards()`

### DIFF
--- a/functions/displaycard.lua
+++ b/functions/displaycard.lua
@@ -155,6 +155,14 @@ SMODS.DrawStep {
   conditions = {vortex = false, facing = 'front'},
 }
 
+local create_card_ref = SMODS.create_card
+function SMODS.create_card(args, ...)
+  if args.poke_display_card_args then
+    return PokeDisplayCard(args.poke_display_card_args)
+  end
+  return create_card_ref(args, ...)
+end
+
 -- Controller support
 local game_draw_ref = Game.draw
 function Game:draw()

--- a/functions/displaycard.lua
+++ b/functions/displaycard.lua
@@ -59,6 +59,7 @@ function PokeDisplayCard:init(args, x, y, w, h)
 
   self.display_text = args.display_text
   self.shader = args.shader
+  self.soul_shader = args.soul_shader
 
   -- To disable automatic `no_ui` while using vanilla tooltip functionality, set `display_text` to false
   if self.display_text == nil then self.no_ui = true end
@@ -150,6 +151,20 @@ SMODS.DrawStep {
   func = function(self, layer)
     if self.shader and self:is(PokeDisplayCard) then
       self.children.center:draw_shader(self.shader, nil, self.ARGS.send_to_shader)
+    end
+  end,
+  conditions = {vortex = false, facing = 'front'},
+}
+
+SMODS.DrawStep {
+  key = 'display_card_soul_shader',
+  order = 61,
+  func = function(self, layer)
+    if self.soul_shader and self:is(PokeDisplayCard) then
+      local scale_mod = 0.07 + 0.02*math.sin(1.8*G.TIMERS.REAL) + 0.00*math.sin((G.TIMERS.REAL - math.floor(G.TIMERS.REAL))*math.pi*14)*(1 - (G.TIMERS.REAL - math.floor(G.TIMERS.REAL)))^3
+      local rotate_mod = 0.05*math.sin(1.219*G.TIMERS.REAL) + 0.00*math.sin((G.TIMERS.REAL)*math.pi*5)*(1 - (G.TIMERS.REAL - math.floor(G.TIMERS.REAL)))^2
+
+      self.children.floating_sprite:draw_shader(self.soul_shader, nil, nil, nil, self.children.center, scale_mod, rotate_mod)
     end
   end,
   conditions = {vortex = false, facing = 'front'},

--- a/lovely/start_up.toml
+++ b/lovely/start_up.toml
@@ -58,44 +58,6 @@ payload = '''
 match_indent = true
 overwrite = true
 
-
-# Replace start menu card with unown
-[[patches]]
-[patches.pattern]
-target = "game.lua"
-pattern = '''
-local replace_card = Card(self.title_top.T.x, self.title_top.T.y, 1.2*G.CARD_W*SC_scale, 1.2*G.CARD_H*SC_scale, G.P_CARDS.S_A, G.P_CENTERS.c_base)
-'''
-position = "at"
-payload = '''
-local replace_card = nil
-if pokermon_config.pokemon_title then
-  local poke_atlas_string = nil
-  if G.ASSET_ATLAS["poke_"..pokermon_config.pokemon_spritesheet_atlas.."TitleCard"] then
-    poke_atlas_string = "poke_"..pokermon_config.pokemon_spritesheet_atlas.."TitleCard"
-  else
-    poke_atlas_string = "poke_AtlasJokersBasicTitleCard"
-  end
-  replace_card = PokeDisplayCard({atlas = poke_atlas_string, pos = {x = 0, y = 0}, soul_pos = {x = 1, y = 0}, suppress_text = true}, self.title_top.T.x, self.title_top.T.y, 1.2*G.CARD_W*SC_scale, 1.2*G.CARD_H*SC_scale)
-else
-  replace_card = Card(self.title_top.T.x, self.title_top.T.y, 1.2*G.CARD_W*SC_scale, 1.2*G.CARD_H*SC_scale, G.P_CARDS.S_A, G.P_CENTERS.c_base)
-end
-'''
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "game.lua"
-pattern = "replace_card.states.visible = false"
-position = "after"
-payload = '''
-if pokermon_config.pokemon_title then
-  replace_card.seal = nil
-end
-'''
-match_indent = true
-
-
 #Tutorial Functionality
 [[patches]]
 [patches.pattern]

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -338,7 +338,8 @@ function SMODS.current_mod.menu_cards()
         atlas = atlas,
         pos = { x = 0, y = y },
         soul_pos = { x = 1, y = y },
-        shader = shiny and 'poke_shiny'
+        shader = shiny and 'poke_shiny',
+        soul_shader = shiny and 'poke_shiny',
       }
     },
     remove_original = true,

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -317,3 +317,30 @@ function end_round()
   }))
 
 end
+
+function SMODS.current_mod.menu_cards()
+  local shiny = pseudorandom('poke_shiny_menu_card') < 1 / 4096
+
+  local sprite_info = PokemonSprites['unown']
+  local atlas_prefix = poke_get_atlas_prefix('unown', sprite_info)
+
+  local atlas = 'poke_' .. atlas_prefix .. 'TitleCard'
+
+  if not SMODS.get_atlas(atlas) then
+    atlas = 'poke_AtlasJokersBasicTitleCard'
+  end
+
+  local y = shiny and 1 or 0
+
+  return {
+    {
+      poke_display_card_args = {
+        atlas = atlas,
+        pos = { x = 0, y = y },
+        soul_pos = { x = 1, y = y },
+        shader = shiny and 'poke_shiny'
+      }
+    },
+    remove_original = true,
+  }
+end


### PR DESCRIPTION
Uses the new built-in SMODS functionality to make menu cards instead of patches.
Additionally chooses the Unown Title Card sprite that matches your current Unown sprite in use, and includes a 1/4096 change for the card to be shiny

Not included here but planned are delaying the shiny application (with added visual flair and sound effects) and replacing Multiplayer's custom card with Unown 'E'