### PR TITLE
Misc fixes

### DIFF
--- a/functions/displaycard.lua
+++ b/functions/displaycard.lua
@@ -55,6 +55,7 @@ function PokeDisplayCard:init(args, x, y, w, h)
     atlas = args.atlas,
     pos = args.pos,
     soul_pos = args.soul_pos,
+    discovered = true,
   }
 
   self.display_text = args.display_text

--- a/functions/uifunctions.lua
+++ b/functions/uifunctions.lua
@@ -112,12 +112,12 @@ poke_blueprint_compat_ui = function(copy)
 end
 
 -- Collection Grid UI helper functions
-function poke_create_your_collection_card(key, x, y)
+function poke_create_your_collection_card(key, x, y, params)
   local form = type(key == 'table') and key.form
   local center_key = type(key == 'table') and key.key or key
   local center = G.P_CENTERS[center_key]
 
-  local card = Card(x, y, G.CARD_W, G.CARD_H, nil, center)
+  local card = Card(x, y, G.CARD_W, G.CARD_H, nil, center, params)
 
   if form and center.set_sprites then
     card.ability.extra.form = form

--- a/pokeui.lua
+++ b/pokeui.lua
@@ -780,7 +780,7 @@ G.FUNCS.pokermon_individual_sprites = function(e)
         keys = keys,
         cols = 3,
         create_card_func = function(key, x, y)
-          local card = poke_create_your_collection_card(key, x, y)
+          local card = poke_create_your_collection_card(key, x, y, { bypass_discovery_center = true })
           card.poke_change_sprite = true
           return card
         end,


### PR DESCRIPTION
Includes a fix for the menu card not having its soul sprite rendered on new saves, and makes cards in the Individual Sprites menu no longer need to be discovered to see their sprites (The description will still say "Not Discovered" but the sprite will be rendered)