### PR TITLE
Remove references to G.ASSET_ATLAS

### DIFF
--- a/editions/editions1.lua
+++ b/editions/editions1.lua
@@ -41,7 +41,7 @@ local shiny = ({
       end
     end,
     on_load = function(card)
-      if card.config.center.atlas and G.ASSET_ATLAS[card.config.center.atlas..'Shiny'] and type(card.config.center.atlas) == 'string' then
+      if card.config.center.atlas and SMODS.get_atlas(card.config.center.atlas..'Shiny') and type(card.config.center.atlas) == 'string' then
         local old_atlas = card.config.center.atlas
         card.config.center.atlas = card.config.center.atlas..'Shiny'
         card:set_sprites(card.config.center)
@@ -91,7 +91,7 @@ local shiny = ({
         card:set_sprites(card.config.center)
         card.config.center.atlas = "poke_altjirachi"
       end
-      if card.children.center.atlas.name == "Joker" and G.ASSET_ATLAS["poke_AtlasJokersVanillaShiny"] then
+      if card.children.center.atlas.name == "Joker" and SMODS.get_atlas("poke_AtlasJokersVanillaShiny") then
         SMODS.Joker:take_ownership(card.config.center_key, {atlas = "poke_AtlasJokersVanillaShiny", discovered = true, unlocked = true}, true)
         card.config.center.shiny = true
         card:set_sprites(card.config.center)

--- a/functions/pokedraw.lua
+++ b/functions/pokedraw.lua
@@ -16,7 +16,7 @@ SMODS.DrawStep({
       local prev_pos = card.children.center.sprite_pos
       local new_atlas = (card.edition and card.edition.poke_shiny) and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"
 
-      card.children.center.atlas = G.ASSET_ATLAS[new_atlas]
+      card.children.center.atlas = SMODS.get_atlas(new_atlas)
       card.children.center:set_sprite_pos(center.pos)
 
       card.children.center:draw_shader('poke_zorua', nil, card.ARGS.send_to_shader)

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -199,7 +199,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
     has_custom_values_to_keep = true
   end
   
-  card.children.center = Sprite(card.T.x, card.T.y, card.T.w, card.T.h, G.ASSET_ATLAS[new_card.atlas or "Joker"], new_card.pos)
+  card.children.center = Sprite(card.T.x, card.T.y, card.T.w, card.T.h, SMODS.get_atlas(new_card.atlas or "Joker"), new_card.pos)
   card.children.center.states.hover = card.states.hover
   card.children.center.states.click = card.states.click
   card.children.center.states.drag = card.states.drag
@@ -231,7 +231,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
   end
 
   if new_card.soul_pos then
-    card.children.floating_sprite = Sprite(card.T.x, card.T.y, card.T.w, card.T.h, G.ASSET_ATLAS[new_card.atlas or "Joker"], new_card.soul_pos)
+    card.children.floating_sprite = Sprite(card.T.x, card.T.y, card.T.w, card.T.h, SMODS.get_atlas(new_card.atlas or "Joker"), new_card.soul_pos)
     card.children.floating_sprite.role.draw_major = card
     card.children.floating_sprite.states.hover.can = false
     card.children.floating_sprite.states.click.can = false

--- a/functions/uifunctions.lua
+++ b/functions/uifunctions.lua
@@ -410,10 +410,10 @@ G.FUNCS.toggle_pokermon_skins = function()
     if table.contains(vanilla_stakes, k) then
       if pokermon_config.stake_skins then
         SMODS.Stake:take_ownership(k, { atlas = "poke_pokestakes" }, true)
-        G.shared_stickers[string.sub(k, 7, -1)].atlas = G.ASSET_ATLAS["poke_pokestakes_stickers"]
+        G.shared_stickers[string.sub(k, 7, -1)].atlas = SMODS.get_atlas("poke_pokestakes_stickers")
       else
         SMODS.Stake:take_ownership(k, { atlas = "chips", prefix_config = { key = { mod = false } } }, true)
-        G.shared_stickers[string.sub(k, 7, -1)].atlas = G.ASSET_ATLAS["stickers"]
+        G.shared_stickers[string.sub(k, 7, -1)].atlas = SMODS.get_atlas("stickers")
       end
     end
   end

--- a/lovely/start_up.toml
+++ b/lovely/start_up.toml
@@ -42,8 +42,8 @@ target = "game.lua"
 pattern = '''
 G.SPLASH_LOGO = Sprite(0, 0, 
     13*SC_scale, 
-    13*SC_scale*(G.ASSET_ATLAS["balatro"].py/G.ASSET_ATLAS["balatro"].px),
-    G.ASSET_ATLAS["balatro"], {x=0,y=0})
+    13*SC_scale*(SMODS.get_atlas("balatro").py/SMODS.get_atlas("balatro").px),
+    SMODS.get_atlas("balatro"), {x=0,y=0})
 '''
 position = "after"
 payload = '''
@@ -51,8 +51,8 @@ payload = '''
       local poke_logo = pokermon_config.pokemon_aprilfools and "poke_smeargle_logo" or "poke_logo"
       G.SPLASH_LOGO = Sprite(0, 0, 
           13/333*389*SC_scale, 
-          13/333*389*SC_scale*(G.ASSET_ATLAS[poke_logo].py/G.ASSET_ATLAS[poke_logo].px),
-          G.ASSET_ATLAS[poke_logo], {x=0.0,y=0})
+          13/333*389*SC_scale*(SMODS.get_atlas(poke_logo).py/SMODS.get_atlas(poke_logo).px),
+          SMODS.get_atlas(poke_logo), {x=0.0,y=0})
     end
 '''
 match_indent = true

--- a/pokemon/pokejokers_19.lua
+++ b/pokemon/pokejokers_19.lua
@@ -194,10 +194,10 @@ local zorua = {
     if card.area ~= G.jokers and not G.SETTINGS.paused then
       card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zorua', nil, 1)
       local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-      card.children.center.atlas = G.ASSET_ATLAS[_o.atlas]
+      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
       card.children.center:set_sprite_pos(_o.pos)
     else
-      card.children.center.atlas = G.ASSET_ATLAS[self.atlas]
+      card.children.center.atlas = SMODS.get_atlas(self.atlas)
       card.children.center:set_sprite_pos(self.pos)
     end
   end,
@@ -220,7 +220,7 @@ local zorua = {
         textDyna.strings = {}
         textDyna:update_text(true)
       end
-      card.children.center.atlas = G.ASSET_ATLAS[_o.atlas]
+      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
       card.children.center:set_sprite_pos(_o.pos)
       local poketype_list = {Grass = true, Fire = true, Water = true, Lightning = true, Psychic = true, Fighting = true, Colorless = true, Dark = true, Metal = true, Fairy = true, Dragon = true, Earth = true}
       for i = #info_queue, 1, -1 do
@@ -256,13 +256,13 @@ local zorua = {
           card.children.floating_sprite.atlas = other_joker.children.floating_sprite.atlas
           card.children.floating_sprite:set_sprite_pos(other_joker.children.floating_sprite.sprite_pos)
         else
-          card.children.floating_sprite.atlas = G.ASSET_ATLAS[self.atlas]
+          card.children.floating_sprite.atlas = SMODS.get_atlas(self.atlas)
           card.children.floating_sprite:set_sprite_pos(self.soul_pos)
         end
       else
-        card.children.center.atlas = G.ASSET_ATLAS[card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"]
+        card.children.center.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
         card.children.center:set_sprite_pos(self.pos)
-        card.children.floating_sprite.atlas = G.ASSET_ATLAS[card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"]
+        card.children.floating_sprite.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
         card.children.floating_sprite:set_sprite_pos(self.soul_pos)
       end
     elseif poke_is_in_collection(card) and card.children.center.sprite_pos ~= self.pos and card.children.center.atlas.name ~= self.atlas then

--- a/pokemon/pokejokers_20.lua
+++ b/pokemon/pokejokers_20.lua
@@ -43,10 +43,10 @@ local zoroark = {
         if card.area ~= G.jokers and not G.SETTINGS.paused then
           card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zoroark', nil, 'poke_safari', nil, nil, {j_poke_zoroark = true})
           local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-          card.children.center.atlas = G.ASSET_ATLAS[_o.atlas]
+          card.children.center.atlas = SMODS.get_atlas(_o.atlas)
           card.children.center:set_sprite_pos(_o.pos)
         else
-          card.children.center.atlas = G.ASSET_ATLAS[self.atlas]
+          card.children.center.atlas = SMODS.get_atlas(self.atlas)
           card.children.center:set_sprite_pos(self.pos)
         end
         return true
@@ -68,7 +68,7 @@ local zoroark = {
         textDyna.strings = {}
         textDyna:update_text(true)
       end
-      card.children.center.atlas = G.ASSET_ATLAS[_o.atlas]
+      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
       card.children.center:set_sprite_pos(_o.pos)
       local poketype_list = {Grass = true, Fire = true, Water = true, Lightning = true, Psychic = true, Fighting = true, Colorless = true, Dark = true, Metal = true, Fairy = true, Dragon = true, Earth = true}
       for i = #info_queue, 1, -1 do
@@ -104,13 +104,13 @@ local zoroark = {
           card.children.floating_sprite.atlas = other_joker.children.floating_sprite.atlas
           card.children.floating_sprite:set_sprite_pos(other_joker.children.floating_sprite.sprite_pos)
         else
-          card.children.floating_sprite.atlas = G.ASSET_ATLAS[self.atlas]
+          card.children.floating_sprite.atlas = SMODS.get_atlas(self.atlas)
           card.children.floating_sprite:set_sprite_pos(self.soul_pos)
         end
       else
-        card.children.center.atlas = G.ASSET_ATLAS[card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"]
+        card.children.center.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
         card.children.center:set_sprite_pos(self.pos)
-        card.children.floating_sprite.atlas = G.ASSET_ATLAS[card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"]
+        card.children.floating_sprite.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
         card.children.floating_sprite:set_sprite_pos(self.soul_pos)
       end
     elseif poke_is_in_collection(card) and card.children.center.sprite_pos ~= self.pos and card.children.center.atlas.name ~= self.atlas then

--- a/pokemon/pokejokers_26.lua
+++ b/pokemon/pokejokers_26.lua
@@ -75,7 +75,7 @@ local mimikyu={
         end
         if save then
           card.ability.extra.disguise = false
-          card.children.center.atlas = G.ASSET_ATLAS['poke_'..card.config.center.poke_lookup_atlas]
+          card.children.center.atlas = SMODS.get_atlas('poke_'..card.config.center.poke_lookup_atlas)
           card.children.center:set_sprite_pos(card.config.center.broke_pos)
           
           G.E_MANAGER:add_event(Event({
@@ -107,7 +107,7 @@ local mimikyu={
   end,
   set_sprites = function(self, card, front)
     if card and card.ability and card.ability.extra and not card.ability.extra.disguise then
-      card.children.center.atlas = G.ASSET_ATLAS['poke_'..card.config.center.poke_lookup_atlas]
+      card.children.center.atlas = SMODS.get_atlas('poke_'..card.config.center.poke_lookup_atlas)
       card.children.center:set_sprite_pos(card.config.center.broke_pos)
     end
   end,

--- a/pokeui.lua
+++ b/pokeui.lua
@@ -837,7 +837,7 @@ G.FUNCS.pokemon_toggle_sprite = function(card)
     if atlas_prefix then
       if not card.config.center.animated then
         local stub = string.sub(atlas, atlas_find + 1)
-        if G.ASSET_ATLAS['poke_'..atlas_prefix..stub] then
+        if SMODS.get_atlas('poke_'..atlas_prefix..stub) then
           card.config.center.atlas = 'poke_'..atlas_prefix..stub
         else
           card.config.center.atlas = 'poke_'..atlas_prefix..'Natdex'


### PR DESCRIPTION
Changes all references to `G.ASSET_ATLAS` to instead use `SMODS.get_atlas`

Admittedly kind of a find and replace job, since SMODS' function just checks the animated atlas in case it can't find it in the asset atlas, it should be safe to replace