### PR TITLE
Fix multiple Machamps taking away all your hands

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1416,18 +1416,19 @@ poke_can_save_consumable = function(card)
       or (card.config.center.saveable)
 end
 
-poke_get_consumeables = function(set)
-  local consumeables = {}
-  if G.STAGE ~= G.STAGES.RUN then return consumeables end
-  local count = 0
-  local areas = {G.jokers.cards, G.consumeables.cards}
-  for i = 1, #areas do
-    local area = areas[i]
-    for j = 1, #area do
-      if area[j].ability.consumeable and not (set and area[j].ability.set ~= set) then
-        consumeables[#consumeables + 1] = area[j]
-      end
-    end
-  end
-  return consumeables
+poke_drain_chips = function(card, amount)
+  if amount < 0 then return 0 end
+
+  local nominal_chips = card.base.nominal - (card.ability.nominal_drain or 0)
+  local bonus_chips = card.ability.bonus + (card.ability.perma_bonus or 0)
+
+  local base_drain = math.min(nominal_chips - 1, amount)
+
+  card.ability.nominal_drain = (card.ability.nominal_drain or 0) + base_drain
+
+  local bonus_drain = math.min(bonus_chips, amount - base_drain)
+
+  card.ability.perma_bonus = (card.ability.perma_bonus or 0) - bonus_drain
+
+  return base_drain + bonus_drain
 end

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -738,3 +738,23 @@ poke_get_consumeables = function(set)
   end
   return consumeables
 end
+
+poke_ease_hands_played = function(mod, instant)
+  if mod >= 0 then
+    return ease_hands_played(mod, instant)
+  else
+    local to_decrease = math.min(G.GAME.current_round.hands_left + (G.poke_hands_buffer or 0) - 1, -mod)
+    if to_decrease > 0 then
+      if not instant then
+        G.poke_hands_buffer = (G.poke_hands_buffer or 0) - to_decrease
+        G.E_MANAGER:add_event(Event({
+          func = function()
+            G.poke_hands_buffer = 0
+            return true
+          end
+        }))
+      end
+      ease_hands_played(-to_decrease, instant)
+    end
+  end
+end

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -723,19 +723,18 @@ poke_convert_to_set = function(element_or_list)
   end
 end
 
-poke_drain_chips = function(card, amount)
-  if amount < 0 then return 0 end
-
-  local nominal_chips = card.base.nominal - (card.ability.nominal_drain or 0)
-  local bonus_chips = card.ability.bonus + (card.ability.perma_bonus or 0)
-
-  local base_drain = math.min(nominal_chips - 1, amount)
-
-  card.ability.nominal_drain = (card.ability.nominal_drain or 0) + base_drain
-
-  local bonus_drain = math.min(bonus_chips, amount - base_drain)
-
-  card.ability.perma_bonus = (card.ability.perma_bonus or 0) - bonus_drain
-
-  return base_drain + bonus_drain
+poke_get_consumeables = function(set)
+  local consumeables = {}
+  if G.STAGE ~= G.STAGES.RUN then return consumeables end
+  local count = 0
+  local areas = {G.jokers.cards, G.consumeables.cards}
+  for i = 1, #areas do
+    local area = areas[i]
+    for j = 1, #area do
+      if area[j].ability.consumeable and not (set and area[j].ability.set ~= set) then
+        consumeables[#consumeables + 1] = area[j]
+      end
+    end
+  end
+  return consumeables
 end

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -741,20 +741,25 @@ end
 
 poke_ease_hands_played = function(mod, instant)
   if mod >= 0 then
-    return ease_hands_played(mod, instant)
+    ease_hands_played(mod, instant)
   else
     local to_decrease = math.min(G.GAME.current_round.hands_left + (G.poke_hands_buffer or 0) - 1, -mod)
     if to_decrease > 0 then
-      if not instant then
-        G.poke_hands_buffer = (G.poke_hands_buffer or 0) - to_decrease
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            G.poke_hands_buffer = 0
-            return true
-          end
-        }))
-      end
       ease_hands_played(-to_decrease, instant)
     end
   end
+end
+
+local ease_hands_played_ref = ease_hands_played
+ease_hands_played = function(mod, instant, ...)
+  if not instant then
+    G.poke_hands_buffer = (G.poke_hands_buffer or 0) + mod
+    G.E_MANAGER:add_event(Event({
+      func = function()
+        G.poke_hands_buffer = 0
+        return true
+      end
+    }))
+  end
+  return ease_hands_played_ref(mod, instant, ...)
 end

--- a/pokemon/pokejokers_01.lua
+++ b/pokemon/pokejokers_01.lua
@@ -424,10 +424,7 @@ local squirtle={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive", "chips", "scaling", "scaling_evo"},
 }
@@ -474,10 +471,7 @@ local wartortle={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive", "chips", "scaling", "scaling_evo"},
 }
@@ -513,10 +507,7 @@ local blastoise={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   megas = {"mega_blastoise"},
   attributes = {"starter", "hands", "passive", "chips"},
@@ -546,10 +537,7 @@ local mega_blastoise = {
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive"},
 }

--- a/pokemon/pokejokers_03.lua
+++ b/pokemon/pokejokers_03.lua
@@ -322,10 +322,7 @@ local machop={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
     ease_discard(card.ability.extra.discards)
   end,
   attributes = {"mult", "passive", "hands", "discard", "round_evo"},
@@ -373,10 +370,7 @@ local machoke={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
     ease_discard(card.ability.extra.discards)
   end,
   attributes = {"mult", "passive", "hands", "discard", "item_evo"},
@@ -419,10 +413,7 @@ local machamp={
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
     G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
     ease_discard(card.ability.extra.discards)
   end,
   attributes = {"mult", "passive", "hands", "discard"},

--- a/pokemon/pokejokers_06.lua
+++ b/pokemon/pokejokers_06.lua
@@ -332,10 +332,7 @@ local totodile = {
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive", "chips", "scaling", "reset", "round_evo"},
 }
@@ -388,10 +385,7 @@ local croconaw = {
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive", "chips", "scaling", "reset", "round_evo"},
 }
@@ -443,10 +437,7 @@ local feraligatr = {
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   attributes = {"starter", "hands", "passive", "chips", "scaling", "reset"},
 }

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -60,9 +60,7 @@ local mega_ampharos={
         G.GAME.round_resets.temp_handsize = (G.GAME.round_resets.temp_handsize or 0) + increase
       end
       ease_discard(-G.GAME.current_round.discards_left, nil, true)
-      if G.GAME.blind.name ~= "The Needle" then
-        ease_hands_played(-G.GAME.current_round.hands_left + 1)
-      end
+      poke_ease_hands_played(-G.GAME.current_round.hands_left + 1)
     end
     if context.joker_main and card.ability.extra.Xmult > 0 and card.ability.extra.Xmult ~= 1  then
       return {

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -986,10 +986,7 @@ local mudkip={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
@@ -1050,10 +1047,7 @@ local marshtomp={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
@@ -1142,10 +1136,7 @@ local swampert={
   end,
   remove_from_deck = function(self, card, from_debuff)
     G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
-    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
-    if to_decrease > 0 then
-      ease_hands_played(-to_decrease)
-    end
+    poke_ease_hands_played(-card.ability.extra.hands)
   end,
   set_ability = function(self, card, initial, delay_sprites)
     if initial then


### PR DESCRIPTION
- Moves `poke_get_consumables` into pokeutils.lua, and `poke_drain_chips` into pokefunctions.lua
- Adds a new helper function, `poke_ease_hands_played`. This function works identically to `ease_hands_played` except when using a negative modifier, where it it won't let your hands drop below 1
- Adds a new buffer variable `G.poke_hands_buffer`. This is automatically set and cleared whenever `ease_hands_played` is called without specifying instant, and is used in the new `poke_ease_hands_played` function
- Updates all Water Starters, the Machop line, and Mega Ampharos to use the new `poke_ease_hands_played` when removing hands
- Removes the exception for The Needle in Mega Ampharos' code, since `poke_ease_hands_played` runs after the boss blind it will take the newly set buffer variable into account