### PR TITLE
Moving values to keep in evolution to their respective jokers

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -211,7 +211,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
   if type(card.ability.extra) == "table" then
     for k,v in pairs(values_to_keep) do
       if card.ability.extra[k] or k == "energy_count" or k == "c_energy_count" or k == "e_limit_up" then
-        if type(card.ability.extra[k]) ~= "number" or (type(v) == "number" and v > card.ability.extra[k]) or k == "form" or k == "jack_target" then
+        if type(card.ability.extra[k]) ~= "number" or (type(v) == "number" and v > card.ability.extra[k]) or k == "form" then
           card.ability.extra[k] = v
         end
       end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -176,7 +176,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
     card.debuff = false
   end
 
-  local names_to_keep = {"targets", "rank", "id", "cards_scored", "cards_drawn", "upgrade", "energy_count", "c_energy_count", "e_limit_up", "form"}
+  local names_to_keep = {"targets", "rank", "id", "cards_scored", "cards_drawn", "energy_count", "c_energy_count", "e_limit_up", "form"}
   if type_sticker_applied(card) then
     table.insert(names_to_keep, "ptype")
   end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -176,7 +176,7 @@ poke_backend_evolve = function(card, to_key, energize_amount)
     card.debuff = false
   end
 
-  local names_to_keep = {"targets", "rank", "id", "cards_scored", "cards_drawn", "upgrade", "hazards_drawn", "energy_count", "c_energy_count", "e_limit_up", "form", "jack_target",                         "jacks_discarded"}
+  local names_to_keep = {"targets", "rank", "id", "cards_scored", "cards_drawn", "upgrade", "energy_count", "c_energy_count", "e_limit_up", "form"}
   if type_sticker_applied(card) then
     table.insert(names_to_keep, "ptype")
   end

--- a/pokemon/pokejokers_01.lua
+++ b/pokemon/pokejokers_01.lua
@@ -1035,6 +1035,7 @@ local spearow={
   gen = 1,
   ptype = "Colorless",
   blueprint_compat = false,
+  poke_custom_values_to_keep = { "upgrade" },
   calculate = function(self, card, context)
     if context.first_hand_drawn and not context.blueprint then
       local eval = function() return (card.ability.extra.upgrade == true) and not G.RESET_JIGGLES end

--- a/pokemon/pokejokers_24.lua
+++ b/pokemon/pokejokers_24.lua
@@ -79,6 +79,7 @@ local pumpkaboo={
   perishable_compat = true,
   blueprint_compat = true,
   eternal_compat = true,
+  poke_custom_values_to_keep = { "jack_target", "jacks_discarded" },
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
       card.ability.extra.form = pseudorandom_element({0, 1, 2, 3}, pseudoseed('pumpkaboo'))
@@ -217,7 +218,7 @@ local gourgeist={
     end
   end,
   set_sprites = function(self, card, front)
-    if poke_can_set_sprite(self) then
+    if poke_can_set_sprite(card) then
       if card.loaded then
         card.loaded = nil
         self:set_ability(card)


### PR DESCRIPTION
Teensiest bit of spring cleaning: the variables moved to poke_custom_values_to_keep are only being used by those specific jokers, and it feels odd to have them be generic exceptions in backend_evolve in light of that.

Also gourgeist's check for poke_can_set_sprite isn't using a card currently despite the function requiring one