### PR TITLE
Smeargle tooltip fix

### DIFF
--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -1382,13 +1382,14 @@ local smeargle={
       -- Display the description of the copy, instead of the center
       local other_center = copy.config.center
       local new_config = copy_table(copy.ability)
+      local other_vars
       if type(other_center.loc_vars) == 'function' then
-        local other_vars = other_center:loc_vars({}, copy)
+        other_vars = other_center:loc_vars({}, copy)
         if other_vars and other_vars.vars then
           new_config.loc_vars_replacement = other_vars.vars
         end
       end
-      info_queue[#info_queue+1] = {set = 'Joker', key = other_center.key, name = other_center.name, config = new_config }
+      info_queue[#info_queue+1] = {set = 'Joker', key = (other_vars and other_vars.key) or other_center.key, config = new_config, vars = other_vars and other_vars.vars or {} }
     end
 
     -- Add blueprint compatible/incompatible text


### PR DESCRIPTION
- Fixed bugged display when the key doesn't exist by checking if loc_vars returns a key (e.i. gourgeist)
- Future fix for the next SMODS release, which allows to properly display variables that are in the joker's name

Tested in both 1620a and the newest dev version and both work