### PR TITLE
Refactor Zorua and Zoroark

### DIFF
--- a/functions/pokedraw.lua
+++ b/functions/pokedraw.lua
@@ -5,24 +5,19 @@ SMODS.DrawStep({
    key = 'zorua_shadow',
    order = 69,
    func = function(card, layer)
-      if not card or not card.ability or not card.children.center or (card.ability.name ~= 'zorua' and card.ability.name ~= 'zoroark') then return end
-      if card.debuff or (card.ability.name == 'zorua' and not card.ability.extra.active) or poke_is_in_collection(card) then return end
-      if G.jokers and card.area == G.jokers then
-         local other_joker = G.jokers.cards[#G.jokers.cards]
-         if other_joker == card or other_joker.debuff or not other_joker.config.center.blueprint_compat then return end
-      end
-      local center = card.config.center
-      local prev_atlas = card.children.center.atlas
-      local prev_pos = card.children.center.sprite_pos
-      local new_atlas = (card.edition and card.edition.poke_shiny) and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex"
+    if card.debuff or poke_is_in_collection(card) or not card.ability then return end
+    if not ((card.config.center.key == 'j_poke_zorua' and card.ability.extra.active) or card.config.center.key == 'j_poke_zoroark') then return end
+    if card.area and card.area == G.jokers then
+      local other_joker = G.jokers.cards[#G.jokers.cards]
+      if other_joker == card or not other_joker.config.center.blueprint_compat then return end
+    end
 
-      card.children.center.atlas = SMODS.get_atlas(new_atlas)
-      card.children.center:set_sprite_pos(center.pos)
+    local center = card.config.center
+    local shared_key = 'poke_shared_' .. card.ability.name
 
-      card.children.center:draw_shader('poke_zorua', nil, card.ARGS.send_to_shader)
-
-      card.children.center.atlas = prev_atlas
-      card.children.center:set_sprite_pos(prev_pos)
+    G[shared_key] = G[shared_key] or SMODS.create_sprite(0, 0, G.CARD_W, G.CARD_H, center.atlas, center.pos)
+    G[shared_key].role.draw_major = card
+    G[shared_key]:draw_shader('poke_zorua', nil, card.ARGS.send_to_shader, nil, card.children.center)
    end,
    conditions = { vortex = false, facing = 'front' },
 })

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -820,10 +820,11 @@ apply_type_sticker = function(card, sticker_type)
   end
 end
 
-get_random_poke_key = function(pseed, stage, pokerarity, _area, poketype, exclude_keys)
+get_random_poke_key = function(pseed, stage, pokerarity, _area, poketype, exclude_keys, exclude_types)
   local poke_keys = {}
   local poke_key
-  exclude_keys = exclude_keys or {}
+  exclude_keys = poke_convert_to_set(exclude_keys) or {}
+  exclude_types = poke_convert_to_set(exclude_types) or {}
 
   if pokerarity then
     local rarities = { common = 1, uncommon = 2, rare = 3, legendary = 4 }
@@ -841,8 +842,9 @@ get_random_poke_key = function(pseed, stage, pokerarity, _area, poketype, exclud
 
   for k, v in pairs(G.P_CENTER_POOLS.Joker) do
     if v.stage and v.stage ~= "Other" and (not valid_stages or valid_stages[v.stage]) and (not valid_rarities or valid_rarities[v.rarity]) and get_gen_allowed(v)
-       and not (poketype and poketype ~= v.ptype) and not poke_family_present(v) and (not (type(v.in_pool) == 'function') or v:in_pool()) and not v.aux_poke and v.rarity ~= "poke_mega" and not exclude_keys[v.key]
-       and not G.GAME.banned_keys[v.key] and not (G.GAME.used_jokers[v.key] and not SMODS.showman(v.key)) then
+        and not (poketype and poketype ~= v.ptype) and not exclude_types[v.ptype]
+        and not poke_family_present(v) and (not (type(v.in_pool) == 'function') or v:in_pool()) and not v.aux_poke and v.rarity ~= "poke_mega"
+        and not exclude_keys[v.key] and not G.GAME.banned_keys[v.key] and not (G.GAME.used_jokers[v.key] and not SMODS.showman(v.key)) then
 
       if v.enhancement_gate then
         if G.playing_cards then
@@ -874,7 +876,8 @@ get_random_poke_key_options = function(options)
   local pokerarity = options.rarity or options.pokerarity
   local poketype = options.type or options.poketype
   local exclude_keys = options.exclude_keys
-  return get_random_poke_key(pseed, stage, pokerarity, nil, poketype, exclude_keys)
+  local exclude_types = options.exclude_types
+  return get_random_poke_key(pseed, stage, pokerarity, nil, poketype, exclude_keys, exclude_types)
 end
 
 create_random_poke_joker = function(pseed, stage, pokerarity, area, poketype)

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -437,7 +437,7 @@ function Game:init_game_object()
 end
 
 poke_is_in_collection = function(card)
-  if not card.area then return true end
+  if not card.area and G.OVERLAY_MENU then return true end
   if G.your_collection then
     for k, v in pairs(G.your_collection) do
       if card.area == v then

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -713,9 +713,10 @@ poke_convert_to_set = function(element_or_list)
   if element_or_list then
     local set
     if type(element_or_list) == 'table' then
-      for _, v in ipairs(element_or_list) do
+      for k, v in pairs(element_or_list) do
         set = set or {}
-        set[v] = true
+local key = v == true and k or v
+        set[key] = true
       end
     else
       set = { [element_or_list] = true }

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -438,6 +438,7 @@ end
 
 poke_is_in_collection = function(card)
   if not card.area and G.OVERLAY_MENU then return true end
+  if card.area and card.area.config.collection then return true end
   if G.your_collection then
     for k, v in pairs(G.your_collection) do
       if card.area == v then

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -765,3 +765,95 @@ ease_hands_played = function(mod, instant, ...)
   end
   return ease_hands_played_ref(mod, instant, ...)
 end
+
+-- Utils for sprite manipulation on existing cards
+
+--- Checks whether two sprites are equal.
+--- Also accepts card centers (uses `atlas` and `pos`)
+poke_compare_sprites = function(a, b)
+  a = a or {}
+  b = b or {}
+  local a_atlas = type(a.atlas) == 'table' and a.atlas.name or a.atlas
+  local b_atlas = type(b.atlas) == 'table' and b.atlas.name or b.atlas
+  local a_pos = a.sprite_pos or a.pos or {}
+  local b_pos = b.sprite_pos or b.pos or {}
+  return a_atlas == b_atlas and a_pos.x == b_pos.x and a_pos.y == b_pos.y
+end
+
+--- Copies the sprite at `from.children[sprite_index]` to `card.children[sprite_index]`
+poke_copy_sprite = function(card, from, sprite_index)
+  if poke_compare_sprites(card.children[sprite_index], from.children[sprite_index]) then
+    return
+  end
+
+  if card.children[sprite_index] then
+    card.children[sprite_index]:remove()
+    card.children[sprite_index] = nil
+  end
+
+  if not from.children[sprite_index] then return end
+
+  local sprite = from.children[sprite_index]
+  local copy = SMODS.create_sprite(card.T.x, card.T.y, card.T.w, card.T.h, sprite.atlas.name, sprite.sprite_pos)
+
+  for k, v in pairs(sprite.states) do
+    if v == from.states[k] then
+      copy.states[k] = card.states[k]
+    elseif not v.can then
+      copy.states[k].can = false
+    end
+  end
+
+  for k, v in pairs(sprite.role) do
+    if v == from then
+      copy.role[k] = card
+    else
+      copy.role[k] = v
+    end
+  end
+
+  card.children[sprite_index] = copy
+end
+
+poke_copy_joker_sprites = function(card, from)
+  poke_copy_sprite(card, from, 'center')
+  poke_copy_sprite(card, from, 'floating_sprite')
+end
+
+--- Resets the card back to its original sprite, while keeping states/roles intact
+poke_reset_sprite = function(card, center)
+  center = center or card.config.center
+
+  local sprite = card.children.center
+  local soul = card.children.floating_sprite
+
+  if poke_compare_sprites(sprite, center) then return end
+
+  card.children.center = nil
+  card.children.floating_sprite = nil
+
+  local new_center = SMODS.create_sprite(card.T.x, card.T.y, card.T.w, card.T.h, center.atlas, center.pos)
+
+  new_center.states = sprite.states
+  new_center.role = sprite.role
+
+  card.children.center = new_center
+
+  if center.soul_pos then
+    local new_soul = SMODS.create_sprite(card.T.x, card.T.y, card.T.w, card.T.h, center.soul_atlas or center.atlas, center.soul_pos)
+
+    if soul then
+      new_soul.states = soul.states
+      new_soul.role = soul.role
+    else
+      new_soul.role.draw_major = card
+      new_soul.states.hover.can = false
+      new_soul.states.click.can = false
+    end
+
+    card.children.floating_sprite = new_soul
+  end
+
+  if sprite then sprite:remove() end
+  if soul then soul:remove() end
+end

--- a/functions/uifunctions.lua
+++ b/functions/uifunctions.lua
@@ -111,6 +111,34 @@ poke_blueprint_compat_ui = function(copy)
   }
 end
 
+poke_generate_illusion_ui = function(other_center, info_queue, card, desc_nodes, specific_vars, full_UI_table)
+  -- Create the illusion joker's text boxes
+  local old_ability = card.ability
+  card.ability = copy_table(old_ability)
+  for k, v in pairs(other_center.config) do card.ability[k] = v end
+  other_center:generate_ui(info_queue, card, desc_nodes, specific_vars, full_UI_table)
+  card.ability = old_ability
+  -- Adds the "...?" to the end of the name
+  if next(full_UI_table.name[1].nodes) then
+    local name_nodes = full_UI_table.name[1].nodes
+    local dynatext = name_nodes[#name_nodes].nodes[1].config.object
+    dynatext.string = dynatext.string .. localize("poke_illusion")
+    dynatext.config.string = {dynatext.string}
+    dynatext.strings = {}
+    dynatext:update_text(true)
+  end
+end
+
+poke_set_card_type_badge = function(card, badges, center)
+  if not center then center = card.config.center end
+
+  local card_type = SMODS.Rarity:get_rarity_badge(center.rarity)
+  local card_type_colour = get_type_colour(center, card)
+  local card_type_text_colour = SMODS.get_card_type_text_colour('Joker', center, card)
+
+  badges[#badges+1] = create_badge(card_type, card_type_colour, card_type_text_colour, 1.2)
+end
+
 -- Collection Grid UI helper functions
 function poke_create_your_collection_card(key, x, y, params)
   local form = type(key == 'table') and key.form

--- a/pokemon/pokejokers_19.lua
+++ b/pokemon/pokejokers_19.lua
@@ -138,6 +138,16 @@ local zorua = {
   pos = { x = 6, y = 5 },
   soul_pos = { x = 99, y = 99 },
   config = {extra = {hidden_key = nil, rounds = 5, active = true}},
+  loc_vars = function(self, info_queue, card)
+    local main_end
+
+    if card.area and card.area == G.jokers then
+      local other_joker = G.jokers.cards[#G.jokers.cards]
+      main_end = poke_blueprint_compat_ui(card ~= other_joker and other_joker)
+    end
+
+    return {vars = {card.ability.extra.rounds, colours = {not card.ability.extra.active and G.C.UI.TEXT_INACTIVE}}, main_end = main_end}
+  end,
   rarity = 3,
   cost = 8,
   stage = "Basic",
@@ -146,127 +156,89 @@ local zorua = {
   gen = 5,
   blueprint_compat = true,
   rental_compat = false,
+  get_illusion = function(self, card)
+    if card.ability and card.ability.extra
+        and card.area ~= G.jokers
+        and not poke_is_in_collection(card) then
+      return G.P_CENTERS[card.ability.extra.hidden_key]
+    end
+  end,
   calculate = function(self, card, context)
     local other_joker = G.jokers.cards[#G.jokers.cards]
-    if other_joker and other_joker ~= card and card.ability.extra.active then
+    if card.ability.extra.active and other_joker and other_joker ~= card then
       local ret = SMODS.blueprint_effect(card, other_joker, context)
+
       if ret then
         ret.colour = G.C.BLACK
         SMODS.calculate_effect(ret, card)
       end
-    end
-    if context.after and other_joker ~= card and card.ability.extra.active then
-      G.E_MANAGER:add_event(Event({
-        trigger = 'after',
-        delay = 0.2,
-        func = function()
-          card.ability.extra.active = false
-          SMODS.calculate_effect({message = localize('poke_reveal_ex')}, card)
-          return true
-        end
-      }))
+
+      if context.after then
+        G.E_MANAGER:add_event(Event({
+          trigger = 'after',
+          delay = 0.2,
+          func = function()
+            card.ability.extra.active = false
+            SMODS.calculate_effect({message = localize('poke_reveal_ex')}, card)
+            return true
+          end
+        }))
+      end
     end
     if context.end_of_round and context.game_over == false and context.main_eval and not card.ability.extra.active then
       card.ability.extra.active = true
-      SMODS.calculate_effect({message = localize('k_reset')}, card)
+      return {
+        message = localize('k_reset')
+      }
     end
     return level_evo(self, card, context, "j_poke_zoroark")
   end,
   set_card_type_badge = function(self, card, badges)
-    local card_type = SMODS.Rarity:get_rarity_badge(card.config.center.rarity)
-    local card_type_colour = get_type_colour(card.config.center or card.config, card)
-    if card.area and card.area ~= G.jokers and not poke_is_in_collection(card) then
-      local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-      card_type = SMODS.Rarity:get_rarity_badge(_o.rarity)
-      card_type_colour = get_type_colour(_o, card)
-    end
-    badges[#badges + 1] = create_badge(card_type, card_type_colour, nil, 1.2)
+    poke_set_card_type_badge(card, badges, self:get_illusion(card))
   end,
   set_sprites = function(self, card, front)
-    if card.ability and card.ability.extra and card.ability.extra.hidden_key then
-      self:set_ability(card)
+    local center = self:get_illusion(card)
+    if center then
+      card:set_sprites(center)
     end
   end,
   set_ability = function(self, card, initial, delay_sprites)
-    if not type_sticker_applied(card) and not poke_is_in_collection(card) and not G.SETTINGS.paused then
-      apply_type_sticker(card, "Dark")
+    if card.area ~= G.jokers and not poke_is_in_collection(card) then
+      -- Initialize the Illusion
+      if not type_sticker_applied(card) then apply_type_sticker(card, "Dark") end
+      if not card.ability.extra.hidden_key then
+        card.ability.extra.hidden_key = get_random_poke_key_options {
+          key_append = 'zorua',
+          rarity = 'Common',
+          exclude_types = 'Dark',
+        }
+      end
+
+      self:set_sprites(card)
     end
-    if card.area ~= G.jokers and not G.SETTINGS.paused then
-      card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zorua', nil, 1)
-      local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
-      card.children.center:set_sprite_pos(_o.pos)
-    else
-      card.children.center.atlas = SMODS.get_atlas(self.atlas)
-      card.children.center:set_sprite_pos(self.pos)
-    end
+  end,
+  add_to_deck = function(self, card, from_debuff)
+    card.ability.extra.hidden_key = nil
+    poke_reset_sprite(card)
   end,
   generate_ui = function(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
-    local _c = card and card.config.center or card
-    card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zorua', nil, 1)
-    local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-    if card.area ~= G.jokers and not poke_is_in_collection(card) then
-      local temp_ability = card.ability
-      card.ability = _o.config
-      _o:generate_ui(info_queue, card, desc_nodes, specific_vars, full_UI_table)
-      if not full_UI_table.name then
-        full_UI_table.name = localize({ type = "name", set = _o.set, key = _o.key, nodes = full_UI_table.name })
-      end
-      card.ability = temp_ability
-      if full_UI_table.name[1].nodes[1] then
-        local textDyna = full_UI_table.name[1].nodes[1].nodes[1].config.object
-        textDyna.string = textDyna.string .. localize("poke_illusion")
-        textDyna.config.string = {textDyna.string}
-        textDyna.strings = {}
-        textDyna:update_text(true)
-      end
-      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
-      card.children.center:set_sprite_pos(_o.pos)
-      local poketype_list = {Grass = true, Fire = true, Water = true, Lightning = true, Psychic = true, Fighting = true, Colorless = true, Dark = true, Metal = true, Fairy = true, Dragon = true, Earth = true}
-      for i = #info_queue, 1, -1 do
-        if info_queue[i].set == "Other" and info_queue[i].key and poketype_list[info_queue[i].key] then
-          table.remove(info_queue, i)
-        end
-      end
-    else
-      if not full_UI_table.name then
-        full_UI_table.name = localize({ type = "name", set = _c.set, key = _c.key, nodes = full_UI_table.name })
-      end
-      card.ability.blueprint_compat_ui = card.ability.blueprint_compat_ui or ''
-      card.ability.blueprint_compat_check = nil
-      local main_end = (card.area and card.area == G.jokers) and {
-        {n=G.UIT.C, config={align = "bm", minh = 0.4}, nodes={
-          {n=G.UIT.C, config={ref_table = card, align = "m", colour = G.C.JOKER_GREY, r = 0.05, padding = 0.06, func = 'blueprint_compat'}, nodes={
-            {n=G.UIT.T, config={ref_table = card.ability, ref_value = 'blueprint_compat_ui',colour = G.C.UI.TEXT_LIGHT, scale = 0.32*0.8}},
-          }}
-        }}
-      } or nil
-      localize{type = 'descriptions', key = _c.key, set = _c.set, nodes = desc_nodes, vars = {card.ability.extra.rounds, colours = {not card.ability.extra.active and G.C.UI.TEXT_INACTIVE}}}
-      desc_nodes[#desc_nodes+1] = main_end
+    local center = self:get_illusion(card)
+    if center then
+      return poke_generate_illusion_ui(center, info_queue, card, desc_nodes, specific_vars, full_UI_table)
     end
+    return SMODS.Center.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
   end,
   update = function(self, card, dt)
-    if G.STAGE == G.STAGES.RUN and card.area == G.jokers  then
+    if G.STAGE == G.STAGES.RUN and card.area and card.area == G.jokers then
       local other_joker = G.jokers.cards[#G.jokers.cards]
-      card.ability.blueprint_compat = ( other_joker and other_joker ~= card and not other_joker.debuff and other_joker.config.center.blueprint_compat and 'compatible') or 'incompatible'
-      if card.ability.blueprint_compat == 'compatible' and not card.debuff and card.ability.extra.active and other_joker.children.center.atlas.px == 71 then
-        card.children.center.atlas = other_joker.children.center.atlas
-        card.children.center:set_sprite_pos(other_joker.children.center.sprite_pos)
-        if other_joker.children.floating_sprite then
-          card.children.floating_sprite.atlas = other_joker.children.floating_sprite.atlas
-          card.children.floating_sprite:set_sprite_pos(other_joker.children.floating_sprite.sprite_pos)
-        else
-          card.children.floating_sprite.atlas = SMODS.get_atlas(self.atlas)
-          card.children.floating_sprite:set_sprite_pos(self.soul_pos)
-        end
+      if card.ability.extra.active and not card.debuff
+          and other_joker.children.center.atlas.px == 71 -- Disables Unown Swarm drawing, because I just couldn't be bothered today.
+          and other_joker and other_joker ~= card
+          and other_joker.config.center.blueprint_compat then
+        poke_copy_joker_sprites(card, other_joker)
       else
-        card.children.center.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
-        card.children.center:set_sprite_pos(self.pos)
-        card.children.floating_sprite.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
-        card.children.floating_sprite:set_sprite_pos(self.soul_pos)
+        poke_reset_sprite(card)
       end
-    elseif poke_is_in_collection(card) and card.children.center.sprite_pos ~= self.pos and card.children.center.atlas.name ~= self.atlas then
-      self:set_ability(card)
     end
   end,
   attributes = {"copying", "round_evo"},

--- a/pokemon/pokejokers_20.lua
+++ b/pokemon/pokejokers_20.lua
@@ -4,6 +4,16 @@ local zoroark = {
   pos = { x = 7, y = 5 },
   soul_pos = { x = 99, y = 99 },
   config = {extra = {hidden_key = nil}},
+  loc_vars = function(self, info_queue, card)
+    local main_end
+
+    if card.area and card.area == G.jokers then
+      local other_joker = G.jokers.cards[#G.jokers.cards]
+      main_end = poke_blueprint_compat_ui(card ~= other_joker and other_joker)
+    end
+
+    return {main_end = main_end}
+  end,
   rarity = "poke_safari",
   cost = 12,
   stage = "One",
@@ -11,6 +21,13 @@ local zoroark = {
   atlas = "Pokedex5",
   gen = 5,
   blueprint_compat = true,
+  get_illusion = function(self, card)
+    if card.ability and card.ability.extra
+        and card.area ~= G.jokers
+        and not poke_is_in_collection(card) then
+      return G.P_CENTERS[card.ability.extra.hidden_key]
+    end
+  end,
   calculate = function(self, card, context)
     local other_joker = G.jokers.cards[#G.jokers.cards]
     if other_joker and other_joker ~= card then
@@ -20,101 +37,51 @@ local zoroark = {
     end
   end,
   set_card_type_badge = function(self, card, badges)
-    local card_type = SMODS.Rarity:get_rarity_badge(card.config.center.rarity)
-    local card_type_colour = get_type_colour(card.config.center or card.config, card)
-    if card.area ~= G.jokers and not poke_is_in_collection(card) then
-      local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-      card_type = SMODS.Rarity:get_rarity_badge(_o.rarity)
-      card_type_colour = get_type_colour(_o, card)
-    end
-    badges[#badges + 1] = create_badge(card_type, card_type_colour, nil, 1.2)
+    poke_set_card_type_badge(card, badges, self:get_illusion(card))
   end,
   set_sprites = function(self, card, front)
-    if card.ability and card.ability.extra and card.ability.extra.hidden_key then
-      self:set_ability(card)
+    local center = self:get_illusion(card)
+    if center then
+      card:set_sprites(center)
     end
   end,
   set_ability = function(self, card, initial, delay_sprites)
-    if not type_sticker_applied(card) and not poke_is_in_collection(card) and not G.SETTINGS.paused then
-      apply_type_sticker(card, "Dark")
+    if card.area ~= G.jokers and not poke_is_in_collection(card) then
+      -- Initialize the Illusion
+      if not type_sticker_applied(card) then apply_type_sticker(card, "Dark") end
+      if not card.ability.extra.hidden_key then
+        card.ability.extra.hidden_key = get_random_poke_key_options {
+          key_append = 'zorua',
+          rarity = 'Common',
+          exclude_types = 'Dark',
+        }
+      end
+
+      self:set_sprites(card)
     end
-    G.E_MANAGER:add_event(Event({
-      func = function()
-        if card.area ~= G.jokers and not G.SETTINGS.paused then
-          card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zoroark', nil, 'poke_safari', nil, nil, {j_poke_zoroark = true})
-          local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-          card.children.center.atlas = SMODS.get_atlas(_o.atlas)
-          card.children.center:set_sprite_pos(_o.pos)
-        else
-          card.children.center.atlas = SMODS.get_atlas(self.atlas)
-          card.children.center:set_sprite_pos(self.pos)
-        end
-        return true
-      end }))
+  end,
+  add_to_deck = function(self, card, from_debuff)
+    card.ability.extra.hidden_key = nil
+    poke_reset_sprite(card)
   end,
   generate_ui = function(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
-    local _c = card and card.config.center or card
-    card.ability.extra.hidden_key = card.ability.extra.hidden_key or get_random_poke_key('zoroark', nil, 'poke_safari', nil, nil, {j_poke_zoroark = true})
-    local _o = G.P_CENTERS[card.ability.extra.hidden_key]
-    if card.area ~= G.jokers and not poke_is_in_collection(card) then
-      local temp_ability = card.ability
-      card.ability = _o.config
-      _o:generate_ui(info_queue, card, desc_nodes, specific_vars, full_UI_table)
-      card.ability = temp_ability
-      if full_UI_table.name[1].nodes[1] then
-        local textDyna = full_UI_table.name[1].nodes[1].nodes[1].config.object
-        textDyna.string = textDyna.string .. localize("poke_illusion")
-        textDyna.config.string = {textDyna.string}
-        textDyna.strings = {}
-        textDyna:update_text(true)
-      end
-      card.children.center.atlas = SMODS.get_atlas(_o.atlas)
-      card.children.center:set_sprite_pos(_o.pos)
-      local poketype_list = {Grass = true, Fire = true, Water = true, Lightning = true, Psychic = true, Fighting = true, Colorless = true, Dark = true, Metal = true, Fairy = true, Dragon = true, Earth = true}
-      for i = #info_queue, 1, -1 do
-        if info_queue[i].set == "Other" and info_queue[i].key and poketype_list[info_queue[i].key] then
-          table.remove(info_queue, i)
-        end
-      end
-    else
-      if not full_UI_table.name then
-        full_UI_table.name = localize({ type = "name", set = _c.set, key = _c.key, nodes = full_UI_table.name })
-      end
-      card.ability.blueprint_compat_ui = card.ability.blueprint_compat_ui or ''
-      card.ability.blueprint_compat_check = nil
-      local main_end = (card.area and card.area == G.jokers) and {
-        {n=G.UIT.C, config={align = "bm", minh = 0.4}, nodes={
-          {n=G.UIT.C, config={ref_table = card, align = "m", colour = G.C.JOKER_GREY, r = 0.05, padding = 0.06, func = 'blueprint_compat'}, nodes={
-            {n=G.UIT.T, config={ref_table = card.ability, ref_value = 'blueprint_compat_ui',colour = G.C.UI.TEXT_LIGHT, scale = 0.32*0.8}},
-          }}
-        }}
-      } or nil
-      localize{type = 'descriptions', key = _c.key, set = _c.set, nodes = desc_nodes, vars = {}}
-      desc_nodes[#desc_nodes+1] = main_end
+    local center = self:get_illusion(card)
+    if center then
+      return poke_generate_illusion_ui(center, info_queue, card, desc_nodes, specific_vars, full_UI_table)
     end
+    return SMODS.Center.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
   end,
   update = function(self, card, dt)
-    if G.STAGE == G.STAGES.RUN and card.area == G.jokers then
+    if G.STAGE == G.STAGES.RUN and card.area and card.area == G.jokers then
       local other_joker = G.jokers.cards[#G.jokers.cards]
-      card.ability.blueprint_compat = ( other_joker and other_joker ~= card and not other_joker.debuff and other_joker.config.center.blueprint_compat and 'compatible') or 'incompatible'
-      if card.ability.blueprint_compat == 'compatible' and not card.debuff and other_joker.children.center.atlas.px == 71 then
-        card.children.center.atlas = other_joker.children.center.atlas
-        card.children.center:set_sprite_pos(other_joker.children.center.sprite_pos)
-        if other_joker.children.floating_sprite then
-          card.children.floating_sprite.atlas = other_joker.children.floating_sprite.atlas
-          card.children.floating_sprite:set_sprite_pos(other_joker.children.floating_sprite.sprite_pos)
-        else
-          card.children.floating_sprite.atlas = SMODS.get_atlas(self.atlas)
-          card.children.floating_sprite:set_sprite_pos(self.soul_pos)
-        end
+      if not card.debuff
+          and other_joker.children.center.atlas.px == 71 -- Disables Unown Swarm drawing, because I just couldn't be bothered today.
+          and other_joker and other_joker ~= card
+          and other_joker.config.center.blueprint_compat then
+        poke_copy_joker_sprites(card, other_joker)
       else
-        card.children.center.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
-        card.children.center:set_sprite_pos(self.pos)
-        card.children.floating_sprite.atlas = SMODS.get_atlas(card.edition and card.edition.poke_shiny and "poke_AtlasJokersBasicNatdexShiny" or "poke_AtlasJokersBasicNatdex")
-        card.children.floating_sprite:set_sprite_pos(self.soul_pos)
+        poke_reset_sprite(card)
       end
-    elseif poke_is_in_collection(card) and card.children.center.sprite_pos ~= self.pos and card.children.center.atlas.name ~= self.atlas then
-      self:set_ability(card)
     end
   end,
   attributes = {"copying"},

--- a/pokemon/pokejokers_20.lua
+++ b/pokemon/pokejokers_20.lua
@@ -51,7 +51,7 @@ local zoroark = {
       if not type_sticker_applied(card) then apply_type_sticker(card, "Dark") end
       if not card.ability.extra.hidden_key then
         card.ability.extra.hidden_key = get_random_poke_key_options {
-          key_append = 'zorua',
+          key_append = 'zoroark',
           rarity = 'Common',
           exclude_types = 'Dark',
         }

--- a/pokemon/pokejokers_20.lua
+++ b/pokemon/pokejokers_20.lua
@@ -52,7 +52,7 @@ local zoroark = {
       if not card.ability.extra.hidden_key then
         card.ability.extra.hidden_key = get_random_poke_key_options {
           key_append = 'zoroark',
-          rarity = 'Common',
+          rarity = 'poke_safari',
           exclude_types = 'Dark',
         }
       end


### PR DESCRIPTION
Zorua and Zoroark Refactor!

This refactor includes:
- Dark Tera while in the shop!
- No longer disguises as Dark types!
- Has "Compatible/Incompatible" in the description!
- Copies Animated Sprites correctly!

Also includes changes to `poke_is_in_collection` so it might be worth checking if that's still working properly everywhere.
It still doesn't work with Unown Swarm.