### PR TITLE
Fixed Smeargle tooltip when copying a vanilla joker showing nil variables

### DIFF
--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -1389,7 +1389,7 @@ local smeargle={
           new_config.loc_vars_replacement = other_vars.vars
         end
       end
-      info_queue[#info_queue+1] = {set = 'Joker', key = (other_vars and other_vars.key) or other_center.key, config = new_config, vars = other_vars and other_vars.vars or {} }
+      info_queue[#info_queue+1] = {set = 'Joker', key = (other_vars and other_vars.key) or other_center.key, name = other_center.name, config = new_config, vars = other_vars and other_vars.vars or {} }
     end
 
     -- Add blueprint compatible/incompatible text


### PR DESCRIPTION
Turns out "name" did have a use. I don't know if it'll fix #788, I think this one might be Multiplayer related since it didn't crash on my end with Baron like they said, but at least Baron now shows X1.5 instead of Xnil (and I checked with Green Joker that it actually takes the values from the copied card and not the center)