### PR TITLE
Add Alolan starters

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1435,3 +1435,72 @@ poke_drain_chips = function(card, amount)
 
   return base_drain + bonus_drain
 end
+
+--Taken directly from JokerDisplay's evaluate_hand function, ported to avoid dependency
+poke_evaluate_hand = function(cards, count_facedowns)
+    local valid_cards = cards
+    local has_facedown = false
+
+    if not cards then
+        local hand_info = JokerDisplay.current_hand_info
+        return hand_info.text, hand_info.poker_hands, hand_info.scoring_hand
+    elseif type(cards) ~= "table" then
+        return "Unknown", {}, {}
+    end
+    for i = 1, #cards do
+        if type(cards[i]) ~= "table" or not cards[i].ability or not (cards[i].ability.set == 'Enhanced' or cards[i].ability.set == 'Default') then
+            return "Unknown", {}, {}
+        end
+    end
+
+    -- To prevent crashing during poker hand eval
+    if G.play then
+        for i = 1, #G.play.cards do
+            if type(G.play.cards[i]) ~= "table" or not G.play.cards[i].ability or not (G.play.cards[i].ability.set == 'Enhanced' or G.play.cards[i].ability.set == 'Default') then
+                return "Unknown", {}, {}
+            end
+        end
+    end
+
+    if not count_facedowns then
+        valid_cards = {}
+        for i = 1, #cards do
+            if cards[i].facing and cards[i].facing ~= 'back' then
+                table.insert(valid_cards, cards[i])
+            else
+                has_facedown = true
+            end
+        end
+    else
+        valid_cards = cards
+    end
+
+    local text, _, poker_hands, scoring_hand, _ = G.FUNCS.get_poker_hand_info(valid_cards)
+
+    local final_scoring_hand = {}
+    for i = 1, #valid_cards do
+        local splashed = SMODS.always_scores(valid_cards[i]) or next(find_joker('Splash')) or next(find_joker('luvdisc')) or next(find_joker('magikarp')) or next(find_joker('feebas'))
+        local unsplashed = SMODS.never_scores(valid_cards[i])
+        if not splashed then
+            for _, card in pairs(scoring_hand) do
+                if card == valid_cards[i] then splashed = true end
+            end
+        end
+        local effects = {}
+        SMODS.calculate_context(
+            {
+                modify_scoring_hand = true,
+                other_card = valid_cards[i],
+                full_hand = valid_cards,
+                scoring_hand =
+                    scoring_hand
+            }, effects)
+        local flags = SMODS.trigger_effects(effects, valid_cards[i])
+        flags = flags or {}
+        if flags.add_to_hand then splashed = true end
+        if flags.remove_from_hand then unsplashed = true end
+        if splashed and not unsplashed then table.insert(final_scoring_hand, valid_cards[i]) end
+    end
+
+    return (has_facedown and "Unknown" or text), poker_hands, final_scoring_hand
+end

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -5230,6 +5230,106 @@ return {
                   "sticker to leftmost {C:attention}Joker"
                 }
             },
+						j_poke_rowlet = {
+							name = 'Rowlet',
+							text = {
+								"{C:attention}+#2#{} hand size",
+								"Earn {C:money}$#1#{} if held hand is a",
+								"{C:attention}[#3#]{}, resets each hand",
+								"Next target: {C:attention}[#4#]",
+								"{C:inactive,s:0.8}(Evolves after earning {C:money,s:0.8}$#5#{C:inactive,s:0.8})",
+							}
+						},
+						j_poke_dartrix = {
+							name = 'Dartrix',
+							text = {
+								"{C:attention}+#2#{} hand size",
+								"Earn {C:money}$#1#{} if held hand is a",
+								"{C:attention}[#3#]{}, resets each hand",
+								"Next target: {C:attention}[#4#]",
+								"{C:inactive,s:0.8}(Evolves after earning {C:money,s:0.8}$#5#{C:inactive,s:0.8})",
+							}
+						},
+						j_poke_decidueye = {
+							name = 'Decidueye',
+							text = {
+								"{C:attention}+#2#{} hand size",
+								"Earn {C:money}$#1#{} if held hand is a",
+								"{C:attention}[#3#]{}, resets each hand",
+								"Next target: {C:attention}[#4#]",
+								"{br:2}ERROR - CONTACT STEAK",
+								"Also {C:green}#6# in #7#{} chance to gain a",
+								"{C:spectral}Spectral{} card if played {C:attention}poker hand{}",
+								"is the previous target: {C:attention}[#5#]",
+							}
+						},
+						j_poke_litten = {
+							name = 'Litten',
+							text = {
+								"{C:red}+#1#{} discard",
+								"Gain {C:mult}+#3#{} after discarding",
+								"your most played {C:attention}poker hand{}",
+								"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
+								"{C:inactive,s:0.8}(Evolves at {C:mult,s:0.8}+#4#{C:inactive,s:0.8} Mult)",
+							}
+						},
+						j_poke_torracat = {
+							name = 'Torracat',
+							text = {
+								"{C:red}+#1#{} discard",
+								"Gain {C:mult}+#3#{} after discarding",
+								"your most played {C:attention}poker hand{}",
+								"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
+								"{C:inactive,s:0.8}(Evolves at {C:mult,s:0.8}+#4#{C:inactive,s:0.8} Mult)",
+							}
+						},
+						j_poke_incineroar = {
+							name = 'Incineroar',
+							text = {
+								"{C:red}+#2#{} discard",
+								"Gain {C:mult}+#4#{} after discarding",
+								"your most played {C:attention}poker hand{}",
+								"{br:2}ERROR - CONTACT STEAK",
+								"Also earn {C:money}$#1#{} per card",
+								"in discarded {C:attention}poker hand{}",
+								"{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
+							}
+						},
+						j_poke_popplio = {
+							name = 'Popplio',
+							text = {
+								"{C:chips}+#3#{} hand",
+								"Gain {C:chips}+#2#{} Chips if {C:attention}poker hand{} is a",
+								"{C:attention}[#4#]{}, {C:attention}poker hand{} changes",
+								"after each hand",
+								"{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
+								"{C:inactive,s:0.8}(Evolves at {C:chips,s:0.8}+#5#{C:inactive,s:0.8} Chips)",
+							}
+						},
+						j_poke_brionne = {
+							name = 'Brionne',
+							text = {
+								"{C:chips}+#3#{} hand",
+								"Gain {C:chips}+#2#{} Chips if {C:attention}poker hand{} is a",
+								"{C:attention}[#4#]{}, {C:attention}poker hand{} changes",
+								"after each hand",
+								"{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
+								"{C:inactive,s:0.8}(Evolves at {C:chips,s:0.8}+#5#{C:inactive,s:0.8} Chips)",
+							}
+						},
+						j_poke_primarina = {
+							name = 'Primarina',
+							text = {
+								"{C:chips}+#3#{} hand",
+								"Gain {C:chips}+#2#{} Chips if {C:attention}poker hand{} is a",
+								"{C:attention}[#6#]{}, {C:attention}poker hand{} changes",
+								"after each hand",
+								"{br:2}ERROR - CONTACT STEAK",
+								"Also gain {X:mult,C:white}X#5#{} per consecutive",
+								"correct hand, resets on round end",
+								"{C:inactive}(Currently {X:mult,C:white}X#4#{}, {C:chips}+#1#{C:inactive})",
+							}
+						},
             j_poke_grubbin = {
                 name = 'Grubbin',
                 text = {

--- a/pokemon/pokejokers_25.lua
+++ b/pokemon/pokejokers_25.lua
@@ -1,13 +1,685 @@
 -- Volcanion 721
 -- Rowlet 722
+local rowlet = {
+	name = "rowlet",
+	--pos = {x = 2, y = 48},
+	config = {extra = {money = 2, totalEarned = 0, h_size = 1, next_poker_hand = "High Card", poker_hand = "None"}, evo_rqmt = 14},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.money, abbr.h_size, abbr.poker_hand, abbr.next_poker_hand, math.max(self.config.evo_rqmt - abbr.totalEarned, 0)}}
+	end,
+	rarity = 2, --Uncommon
+	cost = 5,
+	stage = "Basic",
+	ptype = "Grass",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = true,
+	blueprint_compat = true,
+	eternal_compat = true,
+	starter = true,
+	
+  calculate = function(self, card, context)
+		if context.before then
+			if G.hand and G.hand.cards and #G.hand.cards > 0 then
+				local handname, _, poker_hands = G.FUNCS.get_poker_hand_info(G.hand.cards)
+				if handname == card.ability.extra.poker_hand then 
+				local earned = ease_poke_dollars(card, "rowlet", card.ability.extra.money)
+					card.ability.extra.totalEarned = card.ability.extra.totalEarned + earned
+					return {
+						message = '$'..earned,
+						colour = G.C.MONEY
+					}
+				end
+			end
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+			card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'rowlet')
+			return {
+					message = localize('k_reset')
+			}
+		end
+		return scaling_evo(self, card, context, "j_poke_dartrix", card.ability.extra.totalEarned, self.config.evo_rqmt)
+	end,
+
+	set_ability = function(self, card, initial, delay_sprites)
+		local _poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'rowlet')
+		_poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'rowlet')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end,
+}
 -- Dartrix 723
+local dartrix = {
+	name = "dartrix",
+	--pos = {x = 4, y = 48},
+	config = {extra = {money = 3, totalEarned = 0, h_size = 1, next_poker_hand = "High Card", poker_hand = "None"}, evo_rqmt = 21},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+		return {vars = {abbr.money, abbr.h_size, abbr.poker_hand, abbr.next_poker_hand, math.max(self.config.evo_rqmt - abbr.totalEarned, 0)}}
+	end,
+	rarity = "poke_safari", 
+	cost = 7,
+	stage = "One",
+	ptype = "Grass",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = true,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+ calculate = function(self, card, context)
+		if context.before then
+			if G.hand and G.hand.cards and #G.hand.cards > 0 then
+				local handname, _, poker_hands = G.FUNCS.get_poker_hand_info(G.hand.cards)
+				if handname == card.ability.extra.poker_hand then 
+					local earned = ease_poke_dollars(card, "dartrix", card.ability.extra.money)
+					card.ability.extra.totalEarned = card.ability.extra.totalEarned + earned
+					return {
+						message = '$'..earned,
+						colour = G.C.MONEY
+					}
+				end
+			end
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+			card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'dartrix')
+			return {
+					message = localize('k_reset')
+			}
+		end
+		return scaling_evo(self, card, context, "j_poke_decidueye", card.ability.extra.totalEarned, self.config.evo_rqmt)
+	end,
+
+	set_ability = function(self, card, initial, delay_sprites)
+		local _poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'dartrix')
+		_poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'dartrix')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end,
+}
 -- Decidueye 724
+local decidueye = {
+	name = "decidueye",
+	--pos = {x = 6, y = 48},
+	config = {extra = {money = 4, h_size = 1, next_poker_hand = "High Card", poker_hand = "None", prev_poker_hand = "None", num = 1, dem = 2}},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+		local num, dem = SMODS.get_probability_vars(card, abbr.num, abbr.dem, 'decidueye')
+	  return {vars = {abbr.money, abbr.h_size, abbr.poker_hand, abbr.next_poker_hand, abbr.prev_poker_hand, num, dem}}
+	end,
+	rarity = "poke_safari", 
+	cost = 8,
+	stage = "Two",
+	ptype = "Grass",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = true,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+	calculate = function(self, card, context)
+		if context.before then
+			if G.hand and G.hand.cards and #G.hand.cards > 0 then
+				local handname, _, poker_hands = G.FUNCS.get_poker_hand_info(G.hand.cards)
+				if handname == card.ability.extra.poker_hand then 
+					local earned = ease_poke_dollars(card, "decidueye", card.ability.extra.money)
+					if context.scoring_name == card.ability.extra.prev_poker_hand then
+						if #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
+							if SMODS.pseudorandom_probability(card, 'decidueye', card.ability.extra.num, card.ability.extra.dem, 'decidueye') then
+								G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
+								G.E_MANAGER:add_event(Event({
+									func = (function()
+										SMODS.add_card {
+											set = 'Spectral',
+											key_append = 'poke_decidueye' -- Optional, useful for manipulating the random seed and checking the source of the creation in `in_pool`.
+											}
+											G.GAME.consumeable_buffer = 0
+											return true
+									end)
+								}))
+							return {
+								message = localize('k_plus_spectral'),
+								colour = G.C.SECONDARY_SET.Spectral
+							}
+							else
+								return {
+									message = '$'..earned,
+									colour = G.C.MONEY
+								}
+							end
+						end
+					end
+					return {
+						message = '$'..earned,
+						colour = G.C.MONEY
+					}
+				end
+			end
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.prev_poker_hand = card.ability.extra.poker_hand
+			card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+			card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'decidueye')
+			return {
+					message = localize('k_reset')
+			}
+		end
+		
+	end,
+
+	set_ability = function(self, card, initial, delay_sprites)
+		local _poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'decidueye')
+		_poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= card.ability.extra.next_poker_hand then
+				_poker_hands[#_poker_hands + 1] = handname
+			end
+		end
+		card.ability.extra.poker_hand = card.ability.extra.next_poker_hand
+		card.ability.extra.next_poker_hand = pseudorandom_element(_poker_hands, 'decidueye')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.hand:change_size(card.ability.extra.h_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.hand:change_size(-card.ability.extra.h_size)
+  end,
+}
 -- Litten 725
+local litten = {
+	name = "litten",
+	--pos = {x = 8, y = 48},
+	config = {extra = {mult = 0, mult_mod = 1, d_size = 1}, evo_rqmt = 10},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+		return {vars = {abbr.d_size, abbr.mult, abbr.mult_mod, self.config.evo_rqmt}}
+	end,
+	rarity = 2, --Uncommon
+	cost = 5,
+	stage = "Basic",
+	ptype = "Fire",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	starter = true,
+	
+  calculate = function(self, card, context)
+		if context.pre_discard and not context.hook then
+		  local trigger = true
+			local discardedHand = G.FUNCS.get_poker_hand_info(context.full_hand)
+			for handname, values in pairs(G.GAME.hands) do
+				if handname ~= discardedHand and (values.played or 0) > (G.GAME.hands[discardedHand].played or 0) and SMODS.is_poker_hand_visible(handname) then
+					trigger = false
+					break
+				end
+			end
+			if trigger == true then
+				card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
+				return {
+					message = "Rawr",
+					colour = G.C.MULT
+				}
+			end
+		end
+		
+		if context.joker_main and card.ability.extra.mult > 0 then
+			return {
+				mult = card.ability.extra.mult
+			}
+		end
+		
+		return scaling_evo(self, card, context, "j_poke_torracat", card.ability.extra.mult, self.config.evo_rqmt)
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
+    ease_discard(-card.ability.extra.d_size)
+  end
+}
 -- Torracat 726
+local torracat = {
+	name = "torracat",
+	--pos = {x = 10, y = 48},
+	config = {extra = {mult = 0, mult_mod = 2, d_size = 1}, evo_rqmt = 24},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.d_size, abbr.mult, abbr.mult_mod, self.config.evo_rqmt}}
+	end,
+	rarity = "poke_safari", 
+	cost = 7,
+	stage = "One",
+	ptype = "Fire",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+  calculate = function(self, card, context)
+		if context.pre_discard and not context.hook and not context.blueprint then
+		  local trigger = true
+			local discardedHand = G.FUNCS.get_poker_hand_info(context.full_hand)
+			for handname, values in pairs(G.GAME.hands) do
+				if handname ~= discardedHand and (values.played or 0) > (G.GAME.hands[discardedHand].played or 0) and SMODS.is_poker_hand_visible(handname) then
+					trigger = false
+					break
+				end
+			end
+			if trigger == true then
+				card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
+				return {
+					message = "Rawr!",
+					colour = G.C.MULT
+				}
+			end
+		end
+		
+		if context.joker_main and card.ability.extra.mult > 0 then
+			return {
+				mult = card.ability.extra.mult
+			}
+		end
+		
+		return scaling_evo(self, card, context, "j_poke_incineroar", card.ability.extra.mult, self.config.evo_rqmt)
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
+    ease_discard(-card.ability.extra.d_size)
+  end
+}
+
 -- Incineroar 727
+local incineroar = {
+	name = "incineroar",
+	--pos = {x = 12, y = 48},
+	config = {extra = {money = 1, mult = 0, mult_mod = 3, d_size = 1}},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.money, abbr.d_size, abbr.mult, abbr.mult_mod}}
+	end,
+	rarity = "poke_safari", 
+	cost = 8,
+	stage = "Two",
+	ptype = "Fire",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+  calculate = function(self, card, context)
+		if context.pre_discard and not context.hook and not context.blueprint then
+			local discardedHand = G.FUNCS.get_poker_hand_info(context.full_hand)
+			local trigger = true
+			for handname, values in pairs(G.GAME.hands) do
+				if handname ~= discardedHand and (values.played or 0) > (G.GAME.hands[discardedHand].played or 0) and SMODS.is_poker_hand_visible(handname) then
+					trigger = false
+					break
+				end
+			end
+			if trigger == true then
+				card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
+				if not context.blueprint then
+					local _,_, scoringCards = poke_evaluate_hand(context.full_hand, true)
+					local earned = ease_poke_dollars(card, "incineroar", (card.ability.extra.money * #scoringCards))
+				end
+				return {
+					message = 'Roar!',
+					colour = G.C.MULT
+				}
+			end
+		end
+		
+		if context.joker_main and card.ability.extra.mult > 0 then
+			return {
+				mult = card.ability.extra.mult
+			}
+		end
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.d_size
+    ease_discard(card.ability.extra.d_size)
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.discards = G.GAME.round_resets.discards - card.ability.extra.d_size
+    ease_discard(-card.ability.extra.d_size)
+  end
+}
+
 -- Popplio 728
+local popplio = {
+	name = "popplio",
+	--pos = {x = 14, y = 48},
+	config = {extra = {chips = 0, chip_mod = 6, hands = 1, poker_hand = "High Card"}, evo_rqmt = 30},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.chips, abbr.chip_mod, abbr.hands, abbr.poker_hand, self.config.evo_rqmt}}
+	end,
+	rarity = 2, --Uncommon
+	cost = 5,
+	stage = "Basic",
+	ptype = "Water",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	starter = true,
+	
+	calculate = function(self, card, context)
+		if context.before and context.scoring_name == card.ability.extra.poker_hand and not context.blueprint then
+			card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_mod
+			return {
+				message = "Bounce!"
+			}
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'popplio')
+			return {
+					message = localize('k_reset')
+			}
+		end
+		if context.joker_main then
+			return {
+				chips = card.ability.extra.chips
+			}
+		end
+		return scaling_evo(self, card, context, "j_poke_brionne", card.ability.extra.chips, self.config.evo_rqmt)
+	end,
+	
+	set_ability = function(self, card, initial, delay_sprites)
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+					if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+							_poker_hands[#_poker_hands + 1] = handname
+					end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'popplio')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
+  end,
+}
 -- Brionne 729
+local brionne = {
+	name = "brionne",
+	--pos = {x = 16, y = 48},
+	config = {extra = {chips = 0, chip_mod = 8, hands = 1, poker_hand = "High Card"}, evo_rqmt = 96},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.chips, abbr.chip_mod, abbr.hands, abbr.poker_hand, self.config.evo_rqmt}}
+	end,
+	rarity = "poke_safari", 
+	cost = 7,
+	stage = "One",
+	ptype = "Water",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+	calculate = function(self, card, context)
+		if context.before and context.scoring_name == card.ability.extra.poker_hand and not context.blueprint then
+			card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_mod
+			return {
+				message = "Bounce!"
+			}
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'brionne')
+			return {
+					message = localize('k_reset')
+			}
+		end
+		if context.joker_main then
+			return {
+				chips = card.ability.extra.chips
+			}
+		end
+		return scaling_evo(self, card, context, "j_poke_primarina", card.ability.extra.chips, self.config.evo_rqmt)
+	end,
+	
+	set_ability = function(self, card, initial, delay_sprites)
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+					if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+							_poker_hands[#_poker_hands + 1] = handname
+					end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'brionne')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
+  end,
+}
 -- Primarina 730
+local primarina = {
+	name = "primarina",
+	--pos = {x = 18, y = 48},
+	config = {extra = {chips = 0, chip_mod = 10, Xmult_mod = 1, currXmult = 1, hands = 1, poker_hand = "High Card", triggered = false}},
+	loc_vars = function(self, info_queue, card)
+		type_tooltip(self, info_queue, card)
+		local abbr = card.ability.extra
+	  return {vars = {abbr.chips, abbr.chip_mod, abbr.hands, abbr.currXmult, abbr.Xmult_mod, abbr.poker_hand}}
+	end,
+	rarity = "poke_safari", 
+	cost = 8,
+	stage = "Two",
+	ptype = "Water",
+	gen = 7,
+	designer = "Thor's Girdle",
+	--atlas = "AtlasJokersBasicNatdex",
+	perishable_compat = false,
+	blueprint_compat = true,
+	eternal_compat = true,
+	
+  calculate = function(self, card, context)
+		if context.before and context.scoring_name == card.ability.extra.poker_hand and not context.blueprint then
+			card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_mod
+			card.ability.extra.triggered = true
+			return {
+				message = "Bounce!"
+			}
+		elseif context.before and context.scoring_name ~= card.ability.extra.poker_hand and not context.blueprint then
+			card.ability.extra.currXmult = 1
+			card.ability.extra.triggered = false
+		end
+		
+		if context.after and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+					_poker_hands[#_poker_hands + 1] = handname
+				end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'primarina')
+			if card.ability.extra.triggered == true then
+				card.ability.extra.currXmult = card.ability.extra.currXmult + card.ability.extra.Xmult_mod
+				card.ability.extra.triggered = false
+				return {
+				message = "Liquid Voice!"
+				}
+			end
+			return {
+					message = localize('k_reset')
+			}
+		end
+		if context.joker_main then
+			return {
+				chips = card.ability.extra.chips,
+				xmult = card.ability.extra.currXmult,
+			}
+		end
+		
+		if context.end_of_round and context.game_over == false and context.main_eval and not context.blueprint then
+			card.ability.extra.currXmult = 1
+			card.ability.extra.triggered = false
+			return {
+				message = localize('k_reset')
+			}
+		end
+		
+	end,
+
+	set_ability = function(self, card, initial, delay_sprites)
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+					if SMODS.is_poker_hand_visible(handname) and handname ~= card.ability.extra.poker_hand and handname ~= "Straight Flush" then
+							_poker_hands[#_poker_hands + 1] = handname
+					end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, 'primarina')
+	end,
+	
+	add_to_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.hands
+    if not from_debuff then
+      ease_hands_played(card.ability.extra.hands)
+    end
+  end,
+  remove_from_deck = function(self, card, from_debuff)
+    G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.hands
+    local to_decrease = math.min(G.GAME.current_round.hands_left - 1, card.ability.extra.hands)
+    if to_decrease > 0 then
+      ease_hands_played(-to_decrease)
+    end
+  end,
+}
 -- Pikipek 731
 -- Trumbeak 732
 -- Toucannon 733
@@ -308,5 +980,5 @@ local lycanroc_dusk={
 -- Mudbray 749
 -- Mudsdale 750
 return {name = "Pokemon Jokers 721-750", 
-        list = {grubbin, charjabug, vikavolt, rockruff, lycanroc_day, lycanroc_night, lycanroc_dusk},
+        list = {rowlet, dartrix, decidueye, litten, torracat, incineroar, popplio, brionne, primarina, grubbin, charjabug, vikavolt, rockruff, lycanroc_day, lycanroc_night, lycanroc_dusk},
 }


### PR DESCRIPTION
Bit of a doozy, this one. I've always felt the convention for the starter designs puts their individual personalities as secondary. So these guys are my attempt to (mostly) stay in line with the convention while letting the mons' flavor shine and keeping cohesive themes within the trio. All of them are focused on different ways to care about specific poker hands, with the final stage for each each adding another, unique wrinkle as a nod to each getting a different second type.

Rowlet is the sneaky archer so their design focuses on holding back and planning until the right moment.

Litten is the Heel so they like to mess with what you like while putting on a show.

Popplio is the singer and circus entertainer so they need to keep on rhythm and not drop the ball.

Admittedly this isn't the primary form I made for these guys, so their balance might be all over the place. But hopefully that can be smoothed with just number tweaks. Prim especially is very likely too strong, and in general they all may need to lose the improvement to their first effect on their final evos.

I'm also not completely satisfied with Decidueye's tooltip, but I couldn't think of a good way to condense it.