### PR TITLE
Fix Tera Orb + Copy interaction where sprite doesn't update correctly

### DIFF
--- a/consumables/04_mart_rare.lua
+++ b/consumables/04_mart_rare.lua
@@ -199,6 +199,7 @@ local teraorb = {
       card.ability.extra.change_to_type = self:get_next_type(card)
     end
     G.E_MANAGER:add_event(Event({
+      blockable = false,
       func = function()
         self:set_sprites(card)
         return true

--- a/consumables/04_mart_rare.lua
+++ b/consumables/04_mart_rare.lua
@@ -197,8 +197,13 @@ local teraorb = {
   set_ability = function(self, card, initial, delay_sprites)
     if initial then
       card.ability.extra.change_to_type = self:get_next_type(card)
-      self:set_sprites(card)
     end
+    G.E_MANAGER:add_event(Event({
+      func = function()
+        self:set_sprites(card)
+        return true
+      end
+    }))
   end,
   set_sprites = function(self, card, front)
     local info = card.ability and card.ability.extra or self.config.extra


### PR DESCRIPTION
Per Numbuh214's observation on discord, should hopefully fix the interaction between tera orb and copy effects (ho-oh, etc.) where the sprite doesn't match the tera type