### PR TITLE
Missed a spot in pokecompat

### DIFF
--- a/functions/pokecompat.lua
+++ b/functions/pokecompat.lua
@@ -316,7 +316,7 @@ poke_add_to_family = pokermon.add_to_family
 -- pokespriteload.lua
 
 ---@deprecated use `pokermon.sprites.load_sprites` instead
-poke_add_to_family = pokermon.sprites.load_sprites
+poke_load_sprites = pokermon.sprites.load_sprites
 
 ---@deprecated use `pokermon.sprites.get_atlas_prefix` instead
 poke_get_atlas_prefix = pokermon.sprites.get_atlas_prefix

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -97,7 +97,6 @@ end
 assert(SMODS.load_file("functions/pokeconstants.lua"))()
 assert(SMODS.load_file("functions/pokefunctions.lua"))()
 assert(SMODS.load_file("functions/energyfunctions.lua"))()
-assert(SMODS.load_file("functions/pokecompat.lua"))()
 assert(SMODS.load_file("functions/pokeutils.lua"))()
 assert(SMODS.load_file("functions/pokefamily.lua"))()
 assert(SMODS.load_file("functions/dex_order.lua"))()
@@ -129,6 +128,9 @@ assert(SMODS.load_file("pokeui.lua"))()
 
 --Load quip file
 assert(SMODS.load_file("pokequips.lua"))()
+
+--Load backwards compat file
+assert(SMODS.load_file("functions/pokecompat.lua"))()
 
 local load_directory = function(dirname, map_item, auto_discovery)
   local pfiles = NFS.getDirectoryItems(mod_dir .. dirname)


### PR DESCRIPTION
oopsie

(moves the load call in the main file for pokecompat.lua down so it catches the spriteload functions, and also fixes the copy + paste error)