### PR TITLE
so i forgot to null check previous evo overrides...

### DIFF
--- a/functions/pokeconstants.lua
+++ b/functions/pokeconstants.lua
@@ -45,7 +45,7 @@ pokermon.get_evo_overrides = function(name)
         if pokemon == name then
           local overrides = {}
           if i > 1 then
-            overrides.previous_evo = evo_line[1]
+            overrides.previous_evo = evo_line[i-1]
           end
           if i < #evo_line then
             overrides.highest_evo = evo_line[#evo_line]

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -500,7 +500,7 @@ pokermon.get_previous_evo_from_center = function(center, full_key)
   local index, prev
   local prefix = center.poke_custom_prefix or "poke"
 
-  if next(pokermon.get_evo_overrides(name)) then
+  if next(pokermon.get_evo_overrides(name)) and pokermon.get_evo_overrides(name).previous_evo then
     prev = pokermon.get_evo_overrides(name).previous_evo
     return full_key and "j_"..prefix.."_"..prev or prev
   end


### PR DESCRIPTION
beautifly and jokers with specific overrides for the get_X_evo functions would crash when stickering because the recursive function bit assumed the *lower* evos *also* had previous evo overrides and they don't. oops.