### PR TITLE
JokerDisplay - Relicanth fix money bug

### DIFF
--- a/jokerdisplay/definitions3.lua
+++ b/jokerdisplay/definitions3.lua
@@ -1764,7 +1764,7 @@ jd_def["j_poke_relicanth"] = {
     if four_count >= 1 then
       chips = card.ability.extra.chips * last_card_triggers
     end
-    if four_count >= 3 then
+    if four_count >= 2 then
       money = card.ability.extra.money_mod * last_card_triggers
     end
     if four_count >= 4 then


### PR DESCRIPTION
Money was only showing when there was 3+ fours in poker hand but not 2+ fours