### PR TITLE
Split Evo functions

### DIFF
--- a/consumables/02_mart_spectral.lua
+++ b/consumables/02_mart_spectral.lua
@@ -84,17 +84,17 @@ local megastone = {
   end,
   use = function(self, card, area, copier)
     local target = get_mega_target(card)
-    local forced_key
     local prefix = target.config.center.poke_custom_prefix or "poke"
     if pokermon.get_mega(target) then
-      forced_key = "j_"..prefix.."_"..pokermon.get_mega(target)
+      local forced_key = "j_"..prefix.."_"..pokermon.get_mega(target)
       card.ability.extra.used_on = not G.GAME.modifiers.poke_infinite_megastone and target.unique_val
+      pokermon.evolve(target, forced_key)
     else
-      forced_key = pokermon.get_previous_evo(target, true)
+      local forced_key = pokermon.get_previous_evo(target, true)
       card.ability.extra.used_on = nil
+      pokermon.devolve(target, forced_key)
     end
     card.ability.extra.usable = false
-    pokermon.evolve(target, forced_key)
   end,
   calculate = function(self, card, context)
     if context.end_of_round then

--- a/consumables/05_mart_specific.lua
+++ b/consumables/05_mart_specific.lua
@@ -232,7 +232,11 @@ local meteorite = {
       end
       if deoxys.ability.extra.form ~= curr_index then
         deoxys.ability.extra.form = curr_index
-        pokermon.fake_evolve(deoxys, localize("poke_transform_success"), true)
+
+        pokermon.do_evolution_anim(
+          deoxys,
+          function(c) c:set_sprites(c.config.center) end,
+          localize("poke_transform_success"))
       end
     end
   end,

--- a/consumables/07_mart_jirachi.lua
+++ b/consumables/07_mart_jirachi.lua
@@ -20,7 +20,7 @@ local fake_banker = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_banker", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_banker", nil, nil)
             return
          end
       end
@@ -52,7 +52,7 @@ local fake_booster = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_booster", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_booster", nil, nil)
             return
          end
       end
@@ -84,7 +84,7 @@ local fake_power = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_power", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_power", nil, nil)
             return
          end
       end
@@ -114,7 +114,7 @@ local fake_negging = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_negging", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_negging", nil, nil)
             return
          end
       end
@@ -146,7 +146,7 @@ local fake_copy = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_invis", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_invis", nil, nil)
             return
          end
       end
@@ -178,7 +178,7 @@ local fake_fixer = {
    use = function(self, card, area, copier)
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
-            pokermon.evolve(jirachi, "j_poke_jirachi_fixer", nil, nil, true)
+            pokermon.change_form(jirachi, "j_poke_jirachi_fixer", nil, nil)
             return
          end
       end
@@ -211,7 +211,7 @@ local fake_masterball = {
       for _,jirachi in pairs(G.jokers.cards) do
          if (jirachi.name or jirachi.ability.name) == "jirachi" then
             local forced_evo = pokermon.get_random_poke_key("masterball", "Legendary", nil, nil, nil, {j_poke_jirachi = true})
-            pokermon.evolve(jirachi, forced_evo, nil, nil, true)
+            pokermon.change_form(jirachi, forced_evo, nil, nil)
             return
          end
       end

--- a/consumables/08_mart_machine.lua
+++ b/consumables/08_mart_machine.lua
@@ -27,11 +27,11 @@ local function machine_transform(self, card, area, copier, machine)
   if not machine then machine = 'oven' end
   local machine_dict = {oven = 'j_poke_rotomh', washing_machine = 'j_poke_rotomw', fridge = 'j_poke_rotomf', fan = 'j_poke_rotomfan', lawn_mower = 'j_poke_rotomm'}
   if G.jokers.highlighted and #G.jokers.highlighted == 1 then
-    pokermon.evolve(G.jokers.highlighted[1], machine_dict[machine], nil, nil, true)
+    pokermon.change_form(G.jokers.highlighted[1], machine_dict[machine], nil, nil)
   else
     for k, v in pairs(G.jokers.cards) do
       if is_rotom(v.config.center_key) and v.config.center_key ~= machine_dict[machine] then
-        pokermon.evolve(v, machine_dict[machine], nil, nil, true)
+        pokermon.change_form(v, machine_dict[machine], nil, nil)
         break
       end
     end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -63,92 +63,72 @@ pokermon.copy_scaled_values = function(card)
   return values
 end
 
+---@deprecated use pokermon.do_evolution_anim instead
 pokermon.fake_evolve = function(card, evolve_message, set_sprites)
-    G.E_MANAGER:add_event(Event({
-      func = function()
-        if card.poke_evolution_timer then return true end
-        card.poke_evolution_timer = 0
-        G.E_MANAGER:add_event(Event({
-            trigger = 'ease',
-            ref_table = card,
-            ref_value = 'poke_evolution_timer',
-            ease_to = 1.5,
-            delay = 2.0,
-            func = (function(t) return t end)
-        }))
-        if set_sprites then
-          G.E_MANAGER:add_event(Event({
-            func = function()
-              card:set_sprites(card.config.center)
-              return true
-            end
-          }))
-        end
-        G.E_MANAGER:add_event(Event({
-            trigger = 'ease',
-            ref_table = card,
-            ref_value = 'poke_evolution_timer',
-            ease_to = 2.25,
-            delay = 1.0,
-            func = (function(t) return t end)
-        }))
+  local on_complete = function()
+    if set_sprites then
+      card:set_sprites(card.config.center)
+    end
+  end
+
+  pokermon.do_evolution_anim(card, on_complete, evolve_message)
+end
+
+pokermon.do_evolution_anim = function(card, on_complete, evo_message)
+  G.E_MANAGER:add_event(Event({
+    func = function()
+      if card.poke_evolution_timer then return true end
+      card.poke_evolution_timer = 0
+      G.E_MANAGER:add_event(Event({
+        trigger = 'ease',
+        ref_table = card,
+        ref_value = 'poke_evolution_timer',
+        ease_to = 1.5,
+        delay = 2.0,
+        func = (function(t) return t end)
+      }))
+      if type(on_complete) == 'function' then
         G.E_MANAGER:add_event(Event({
           func = function()
-            card.poke_evolution_timer = nil
-            play_sound('tarot1')
-            card_eval_status_text(card, 'extra', nil, nil, nil, { message = evolve_message or localize("poke_evolve_success"), colour = G.C.FILTER, instant = true})
+            on_complete(card)
             return true
           end
         }))
-        return true
       end
-    }))
+      G.E_MANAGER:add_event(Event({
+        trigger = 'ease',
+        ref_table = card,
+        ref_value = 'poke_evolution_timer',
+        ease_to = 2.25,
+        delay = 1.0,
+        func = (function(t) return t end)
+      }))
+      G.E_MANAGER:add_event(Event({
+        func = function()
+          card.poke_evolution_timer = nil
+          play_sound('tarot1')
+          card_eval_status_text(card, 'extra', nil, nil, nil, {message = evo_message or localize("poke_evolve_success"), colour = G.C.FILTER, instant = true})
+          return true
+        end
+      }))
+      return true
+    end
+  }))
 end
 
 pokermon.evolve = function(card, to_key, immediate, evolve_message, transformation, energize_amount)
   if G.GAME.modifiers.poke_apply_randomizer and not transformation then
     to_key = pokermon.get_random_poke_key('randomizer')
   end
-  if immediate then
+
+  local evolve = function()
     pokermon.backend_evolve(card, to_key, energize_amount)
-  else
-    G.E_MANAGER:add_event(Event({
-      func = function()
-        if card.poke_evolution_timer or G.P_CENTERS[to_key] == card.config.center then return true end
-        card.poke_evolution_timer = 0
-        G.E_MANAGER:add_event(Event({
-            trigger = 'ease',
-            ref_table = card,
-            ref_value = 'poke_evolution_timer',
-            ease_to = 1.5,
-            delay = 2.0,
-            func = (function(t) return t end)
-        }))
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            pokermon.backend_evolve(card, to_key, energize_amount)
-            return true
-          end
-        }))
-        G.E_MANAGER:add_event(Event({
-            trigger = 'ease',
-            ref_table = card,
-            ref_value = 'poke_evolution_timer',
-            ease_to = 2.25,
-            delay = 1.0,
-            func = (function(t) return t end)
-        }))
-        G.E_MANAGER:add_event(Event({
-          func = function()
-            card.poke_evolution_timer = nil
-            play_sound('tarot1')
-            card_eval_status_text(card, 'extra', nil, nil, nil, { message = evolve_message or localize("poke_evolve_success"), colour = G.C.FILTER, instant = true})
-            return true
-          end
-        }))
-        return true
-      end
-    }))
+  end
+
+  if immediate then
+    evolve()
+  elseif G.P_CENTERS[to_key] ~= card.config.center then
+    pokermon.do_evolution_anim(card, evolve, evolve_message)
   end
 end
 

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -116,20 +116,31 @@ pokermon.do_evolution_anim = function(card, on_complete, evo_message)
   }))
 end
 
+local call_backend_evolve = function(card, to_key, immediate, message, energize_amount)
+  if immediate then
+    pokermon.backend_evolve(card, to_key, energize_amount)
+  elseif G.P_CENTERS[to_key] ~= card.config.center then
+    pokermon.do_evolution_anim(
+      card,
+      function() pokermon.backend_evolve(card, to_key, energize_amount) end,
+      message)
+  end
+end
+
 pokermon.evolve = function(card, to_key, immediate, evolve_message, transformation, energize_amount)
   if G.GAME.modifiers.poke_apply_randomizer and not transformation then
     to_key = pokermon.get_random_poke_key('randomizer')
   end
 
-  local evolve = function()
-    pokermon.backend_evolve(card, to_key, energize_amount)
-  end
+  call_backend_evolve(card, to_key, immediate, evolve_message, energize_amount)
+end
 
-  if immediate then
-    evolve()
-  elseif G.P_CENTERS[to_key] ~= card.config.center then
-    pokermon.do_evolution_anim(card, evolve, evolve_message)
-  end
+pokermon.devolve = function(card, to_key, immediate, devolve_message)
+  call_backend_evolve(card, to_key, immediate, devolve_message or localize('poke_devolve_success'))
+end
+
+pokermon.change_form = function(card, to_key, immediate, transform_message)
+  call_backend_evolve(card, to_key, immediate, transform_message or localize('poke_transform_success'))
 end
 
 -- Stolen from Cardsauce

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -7480,6 +7480,7 @@ return {
             poke_plus_shop = "+1 Shop Card",
             poke_destroyed_ex = "Destroyed!",
             poke_evolve_success = "Evolved!",
+            poke_devolve_success = "Reverted",
             poke_transform_success = "Transformed!",
             poke_evolve_level = "Level up!",
             poke_tera = "Tera",


### PR DESCRIPTION
Splits `pokermon.evolve` into 4 separate functions: `pokermon.evolve`, `pokermon.devolve`, `pokermon.change_form`, and `pokermon.do_evolution_anim`.

Also changes Rotom and Jirachi to say "Transformed!" when changing forms.

Does not touch current Everstone functionality