### PR TITLE
Prefix Colours

### DIFF
--- a/backs/backs1.lua
+++ b/backs/backs1.lua
@@ -233,7 +233,7 @@ local diceydeck = {
         G.GAME.modifiers.poke_enhance_bonus = 'm_poke_hazard'
         G.GAME.modifiers.poke_money_per_enhancement = self.config.money
         G.GAME.modifiers.poke_enhance_bonus_text = localize('poke_hazards_in_deck')
-        G.GAME.modifiers.poke_enhance_bonus_color = G.ARGS.LOC_COLOURS["hazard"]
+        G.GAME.modifiers.poke_enhance_bonus_color = pokermon.colours.hazard
         return true
       end
     }))

--- a/boosters/packs1.lua
+++ b/boosters/packs1.lua
@@ -78,7 +78,7 @@ local create_pocket_card = function(self, card, i)
 end
 
 local pocket_background = function(self)
-  ease_background_colour{new_colour = G.ARGS.LOC_COLOURS.pocket, contrast = 3}
+  ease_background_colour{new_colour = pokermon.colours.pocket, contrast = 3}
 end
 local pocket_particle = function(self)
   G.booster_pack_sparkles = Particles(1, 1, 0,0, {

--- a/consumables/01_mart_energy.lua
+++ b/consumables/01_mart_energy.lua
@@ -46,7 +46,7 @@ local bird_energy = {
         for i = 1, 23 do
             r_mults[#r_mults + 1] = tostring(i)
         end
-        local gives_strings = {{ string = localize('poke_water_gun_ex'), colour = G.ARGS.LOC_COLOURS.water }, { string = localize('poke_sky_attack_ex'), colour = G.ARGS.LOC_COLOURS.colorless },
+        local gives_strings = {{ string = localize('poke_water_gun_ex'), colour = pokermon.colours.water }, { string = localize('poke_sky_attack_ex'), colour = pokermon.colours.colorless },
                                { string = 'HEX("FF7ABF")', colour = G.C.JOKER_GREY}, { string = '?????', colour = G.C.JOKER_GREY}
                              }
         local energy_strings = {{ string = '?????', colour = G.C.JOKER_GREY}, { string = self.name, colour = G.C.JOKER_GREY}, { string = localize('k_poke_pp'), colour = G.C.JOKER_GREY},

--- a/consumables/03_mart_items.lua
+++ b/consumables/03_mart_items.lua
@@ -678,7 +678,7 @@ local metalcoat = {
   set = "poke_item",
   config = {max_highlighted = 1},
   loc_vars = function(self, info_queue, center)
-    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {"Metal", colours = {G.ARGS.LOC_COLOURS.metal}}}
+    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {"Metal", colours = {pokermon.colours.metal}}}
     return {vars = {self.config.max_highlighted}}
   end,
   pos = { x = 6, y = 2 },
@@ -697,7 +697,7 @@ local metalcoat = {
     
     if choice then
       pokermon.apply_type_sticker(choice, "Metal")
-      card_eval_status_text(choice, 'extra', nil, nil, nil, {message = localize("poke_metal_ex"), colour = G.ARGS.LOC_COLOURS["metal"]})
+      card_eval_status_text(choice, 'extra', nil, nil, nil, {message = localize("poke_metal_ex"), colour = pokermon.colours.metal})
     end
     
     local copy = copy_card(G.hand.highlighted[1], nil, nil, G.playing_card)
@@ -715,7 +715,7 @@ local dragonscale = {
   key = "dragonscale",
   set = "poke_item",
   loc_vars = function(self, info_queue, center)
-    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {"Dragon", colours = {G.ARGS.LOC_COLOURS.dragon}}}
+    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {"Dragon", colours = {pokermon.colours.dragon}}}
   end,
   pos = { x = 7, y = 2 },
   atlas = "AtlasConsumablesBasic",
@@ -736,7 +736,7 @@ local dragonscale = {
     end
     
     pokermon.apply_type_sticker(choice, "Dragon")
-    card_eval_status_text(choice, 'extra', nil, nil, nil, {localize("poke_dragon_ex"), colour = G.ARGS.LOC_COLOURS["dragon"]})
+    card_eval_status_text(choice, 'extra', nil, nil, nil, {localize("poke_dragon_ex"), colour = pokermon.colours.dragon})
     
     for i = 1, 3 do
       if #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then

--- a/consumables/04_mart_rare.lua
+++ b/consumables/04_mart_rare.lua
@@ -148,9 +148,9 @@ local teraorb = {
   loc_vars = function(self, info_queue, center)
     info_queue[#info_queue+1] = {set = 'Other', key = 'energize'}
     local info = center.ability.extra or self.config.extra
-    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {info.change_to_type, colours = {G.ARGS.LOC_COLOURS[string.lower(info.change_to_type)]}}}
+    info_queue[#info_queue+1] = {set = 'Other', key = 'typechanger', vars = {info.change_to_type, colours = {pokermon.colours[string.lower(info.change_to_type)]}}}
     local highlight_colour = info.change_to_type ~= "Lightning" and G.C.WHITE or G.C.BLACK
-    return {vars = {info.change_to_type, colours = {G.ARGS.LOC_COLOURS[string.lower(info.change_to_type)], highlight_colour}}}
+    return {vars = {info.change_to_type, colours = {pokermon.colours[string.lower(info.change_to_type)], highlight_colour}}}
   end,
   pos = { x = 2, y = 9 },
   soul_pos = { x = 3, y = 9 },
@@ -190,7 +190,7 @@ local teraorb = {
       }))
       return {
         message = card.ability.extra.change_to_type,
-        colour = G.ARGS.LOC_COLOURS[string.lower(card.ability.extra.change_to_type)]
+        colour = pokermon.colours[string.lower(card.ability.extra.change_to_type)]
       }
     end
   end,

--- a/functions/energyfunctions.lua
+++ b/functions/energyfunctions.lua
@@ -155,7 +155,7 @@ pokermon.energy.energize = function(card, etype, evolving, silent, amount, cente
     pokermon.energy.energize_other(card, etype, center, c_penalty, amount)
   end
   if not silent then
-    card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_energized_ex"), colour = G.ARGS.LOC_COLOURS.pink})
+    card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_energized_ex"), colour = pokermon.colours.pink})
   end
 end
 

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -754,7 +754,7 @@ pokermon.set_type_badge = function(self, card, badges)
     if lower_ptype == "bird" then
       if math.random(0,5) == 5 then ptype = nil end
     end
-    badges[#badges+1] = create_badge(ptype, G.ARGS.LOC_COLOURS[lower_ptype], text_colour, 1.2 )
+    badges[#badges+1] = create_badge(ptype, pokermon.colours[lower_ptype], text_colour, 1.2 )
   end
 end
 

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -44,7 +44,7 @@ return {
                     "Beginne den Durchlauf mit dem",
                     "{C:tarot,T:v_crystal_ball}#1#{}-Gutschein",
                     "und {C:attention}2{} Kopien",
-                    "von {C:item,T:c_poke_twisted_spoon}#2#"
+                    "von {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             b_poke_obituarydeck = {
@@ -57,8 +57,8 @@ return {
                 name = "Leuchtendes Deck",
                 text = {
                     "Alle Joker haben einen",
-                    "zufälligen {C:pink}Typ{}",
-                    "und haben {C:attention}+1{} {C:pink}Energie"
+                    "zufälligen {C:poke_pink}Typ{}",
+                    "und haben {C:attention}+1{} {C:poke_pink}Energie"
                 }
             },
         },
@@ -189,7 +189,7 @@ return {
             c_poke_teraorb = {
                 name = "Terakristall-Orb",
                 text = {
-                    "Gibt {C:attention}+1{} {C:pink}Energie{}",
+                    "Gibt {C:attention}+1{} {C:poke_pink}Energie{}",
                     "einem ausgewählten Joker{} oder Joker{} ganz link",
                     "{C:attention}Typänderung{}"
                 },
@@ -206,7 +206,7 @@ return {
                 name = "Drachenschuppe",
                 text = {
                     "Erzeugt bis zu {C:attention}3{} zufällige",
-                    "{C:item}Item{} oder {C:pink}Energie{} Karten",
+                    "{C:poke_item}Item{} oder {C:poke_pink}Energie{} Karten",
                     "{C:attention}Typänderung{}",
                     "{C:inactive}(Muss Platz haben){}"
                 },
@@ -260,9 +260,9 @@ return {
                 name = "Krummlöffel",
                 text = {
                     "Erzeugt die letzte benutzte",
-                    "{C:item}Item{} Karte oder {C:pink}Energie{} Karte",
+                    "{C:poke_item}Item{} Karte oder {C:poke_pink}Energie{} Karte",
                     "von diesem Durchlauf",
-                    "{s:0.8,C:item}Krummlöffel und wiederverwendbare Materialien{s:0.8} ausgenommen"
+                    "{s:0.8,C:poke_item}Krummlöffel und wiederverwendbare Materialien{s:0.8} ausgenommen"
                 }
             },
             c_poke_prismscale = {
@@ -1043,7 +1043,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1#-zu-#2#{}-Chance eine",
-                    "{C:attention}Der Narr{} oder {C:item}Krummlöffel{} Karte zu erzeugen",
+                    "{C:attention}Der Narr{} oder {C:poke_item}Krummlöffel{} Karte zu erzeugen",
                     "wenn gespielte {C:attention}Poker Hand{} bereits",
                     "diese Runde gespielt wurde",
                     "{C:inactive}(Entwicklung mit einer {C:attention}Linkkabel{}{C:inactive} Karte)"
@@ -1054,7 +1054,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} Slot für Verbrauchsgegenstände",
                     "{C:green}#1#-zu-#2#{}-Chance eine",
-                    "{C:attention}Der Narr{} oder {C:item}Krummlöffel{} Karte zu erzeugen",
+                    "{C:attention}Der Narr{} oder {C:poke_item}Krummlöffel{} Karte zu erzeugen",
                     "wenn gespielte {C:attention}Poker Hand{} bereits",
                     "diese Runde gespielt wurde",
                 } 
@@ -1064,7 +1064,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} Slot für Verbrauchsgegenstände",
                     "Jeder {C:attention}Verbrauchsgegenstand{} im Besitz gibt {X:mult,C:white}X#1#{} Mult",
-                    "{C:item}Krummlöffel{} gibt {X:mult,C:white}X#2#{} Mult",
+                    "{C:poke_item}Krummlöffel{} gibt {X:mult,C:white}X#2#{} Mult",
                 } 
             },
             j_poke_machop = {
@@ -1225,7 +1225,7 @@ return {
                 text = {
                     "Gespielte {C:attention}Stahl-Karten{} geben {X:red,C:white}X#1#{} Mult",
                     "plus {X:red,C:white}X#2#{} Mult für jeden",
-                    "benachbarten {X:metal,C:white}Stahl{} Joker",
+                    "benachbarten {X:poke_metal,C:white}Stahl{} Joker",
                     "{C:inactive}(Aktuell {X:red,C:white}X#3#{}{C:inactive} Mult){}",
                     "{C:inactive}(Entwicklung mit einer {C:attention}Donnerstein{}{C:inactive} Karte)"
                 } 
@@ -1359,7 +1359,7 @@ return {
                     "Die ganz linke wertende Karte",
                     "der {C:attention}ersten Hand{} jeder Runde",
                     "wird eine {C:attention}Stein-Karte{}",
-                    "{C:inactive}(Entwicklung mit einem {C:metal}Stahl{} {C:inactive}Sticker){}"
+                    "{C:inactive}(Entwicklung mit einem {C:poke_metal}Stahl{} {C:inactive}Sticker){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1574,7 +1574,7 @@ return {
                     "Wird verdoppelt wenn ein {C:attention}König{}",
                     "auf der Hand gehalten wird",
                     "{C:inactive}(Aktuell {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive}(Entwicklung mit einem {C:dragon}Drachen{} {C:inactive}Sticker){}"
+                    "{C:inactive}(Entwicklung mit einem {C:poke_dragon}Drachen{} {C:inactive}Sticker){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1624,7 +1624,7 @@ return {
                     "wird der rechte Joker zerstört und erhalte {C:mult}+#2#{} Mult",
                     "Erhalte {C:attention}Foil{}, {C:attention}Holografisch{}, or {C:attention}Polychrom{}",
                     "wenn der Joker {C:red}Selten{} oder höher war",
-                    "{C:inactive}(Entwicklung mit einem {C:dragon}Stahl{} {C:inactive}Sticker){}",
+                    "{C:inactive}(Entwicklung mit einem {C:poke_dragon}Stahl{} {C:inactive}Sticker){}",
                     "{C:inactive}(Aktuell {C:mult}+#1#{C:inactive} Mult)"
                 } 
             },
@@ -1633,7 +1633,7 @@ return {
                 text = {
                     "{C:attention}Spielkarten{} die dem Deck hinzugefügt werden",
                     "aus dem {C:attention}Shop{}, {C:attention}Standardpaketen{},",
-                    "{C:spectral}Cryptid{}, {C:item}Items{} und bestimmten Jokern",
+                    "{C:spectral}Cryptid{}, {C:poke_item}Items{} und bestimmten Jokern",
                     "werden {C:attention}verdoppelt{}"
                 } 
             },
@@ -1723,7 +1723,7 @@ return {
                     "Verkaufe diese Karte um den Joker",
                     "ganz links zu duplizieren",
                     "mit {C:attention}Verderblich{}",
-                    "und einem {C:colorless}Normal{} Sticker",
+                    "und einem {C:poke_colorless}Normal{} Sticker",
                     "{C:inactive}(entfernt Ewig, ausgenommen Dittos){}",
                 } 
             },
@@ -1765,8 +1765,8 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} Energie Limit",
-                    "Erzeuge eine {C:pink}Energie{} Karte",
+                    "{C:poke_pink}+1{} Energie Limit",
+                    "Erzeuge eine {C:poke_pink}Energie{} Karte",
                     "wenn ein {C:attention}Booster-Paket{}",
                     "geöffnet wird",
                     "{C:inactive}(Entwicklung mit einer {C:attention}Upgrade{}{C:inactive} Karte)"
@@ -1790,7 +1790,7 @@ return {
                     "{X:attention,C:white}Eins{} : Erhalte {C:money}$#2#{} des Verkaufswerts",
                     "{X:attention,C:white}Zwei{} : Erhalte {C:money}$#3#{}",
                     "{X:attention,C:white}Drei{} : Erzeuge eine zufällige {C:attention}Tarot-Karte{}",
-                    "{X:attention,C:white}Vier+{} : Erzeuge ein zufälliges {C:item}Item{}",
+                    "{X:attention,C:white}Vier+{} : Erzeuge ein zufälliges {C:poke_item}Item{}",
                     "{C:inactive}(Muss Platz haben){}"
                 } 
             },
@@ -1903,7 +1903,7 @@ return {
                 text = {
                     "Am Ende des Shops, erzeuge ein",
                     "{C:dark_edition}Polychromes{} {C:attention}Duplikat{} von",
-                    "dem {C:attention}Joker{} ganz links mit {C:attention}+1{} {C:pink}Energie{}",
+                    "dem {C:attention}Joker{} ganz links mit {C:attention}+1{} {C:poke_pink}Energie{}",
                     "und zerstöre dann den {C:attention}Joker{} ganz links",
                     "{C:dark_edition}Polychrome{} Joker geben {X:mult,C:white} X#1# {} Mult",
                     "{C:inactive}(Kann sich nicht selbst zerstören)",
@@ -1919,8 +1919,8 @@ return {
                 name = "Mega Mewtu Y",
                 text = {
                     "Gibt dem Joker ganz links ",
-                    "am Ende des Shops {C:attention}+2{} {C:pink}Energie{}",
-                    "{C:pink}+1{} Energie Limit wenn der",
+                    "am Ende des Shops {C:attention}+2{} {C:poke_pink}Energie{}",
+                    "{C:poke_pink}+1{} Energie Limit wenn der",
                     "{C:attention}Boss Blind{} besiegt wird"
                 } 
             },
@@ -1929,7 +1929,7 @@ return {
                 text = {
                     "Am Ende des Shops, erzeuge",
                     "eine zufällige {C:dark_edition}Negative{} {C:attention}Tarot-Karte{},",
-                    "{C:spectral}Geister-Karte{} oder {C:item}Item{}",
+                    "{C:spectral}Geister-Karte{} oder {C:poke_item}Item{}",
                     "Erzeugt manchmal {C:attention}stattdessen{} einen",
                     "{C:dark_edition}Negativen{} Joker",
                 } 
@@ -2008,7 +2008,7 @@ return {
                     "Gespielte Karten mit {V:1}#2#{}-Farbe geben",
                     "{C:mult}+#1#{} Mult wenn gezählt",
                     "Diese Karten lösen erneut aus je nachdem",
-                    "wie viele {X:water,C:white}Wasser{} Joker im Besitz",
+                    "wie viele {X:poke_water,C:white}Wasser{} Joker im Besitz",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} Auslösungen werden gleichmäßig auf die wertenden Karten verteilt){}",
                     "Farben ändern in der Reihenfolge {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -2093,9 +2093,9 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} Energie Limit",
-                    "Erzeuge eine {C:pink}Energie{} Karte",
-                    "von demselben {C:pink}Typ{} wie",
+                    "{C:poke_pink}+2{} Energie Limit",
+                    "Erzeuge eine {C:poke_pink}Energie{} Karte",
+                    "von demselben {C:poke_pink}Typ{} wie",
                     "der Joker ganz links wenn ein",
                     "{C:attention}Booster-Paket{} geöffnet wird",
                     "{C:inactive}(Entwicklung mit einer {C:attention}Dubiosdisc{}{C:inactive} Karte)"
@@ -2175,7 +2175,7 @@ return {
                     "{C:attention}+#3#{} Handgröße, {C:attention}Natur{}",
                     "Gespielt {C:attention}#6#, #7# oder #8#{} haben",
                     "eine {C:green}#4#-zu-#5#{}-Chance {C:money}$#1#{} zu geben wenn gezählt",
-                    "Garantiert wenn eine andere {X:grass,C:white}Pflanze{} Karte im Besitz",
+                    "Garantiert wenn eine andere {X:poke_grass,C:white}Pflanze{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Entwicklung nach Ertag von {C:money}$#2#/16{})"
                 } 
@@ -2186,7 +2186,7 @@ return {
                     "{C:attention}+#3#{} Handgröße, {C:attention}Natur{}",
                     "Gespielte {C:attention}#6#, #7# oder #8#{} haben",
                     "eine {C:green}#4#-zu-#5#{}-Chance {C:money}$#1#{} zu geben wenn gezählt",
-                    "Garantiert wenn eine andere {X:grass,C:white}Pflanze{} Karte im Besitz",
+                    "Garantiert wenn eine andere {X:poke_grass,C:white}Pflanze{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Entwicklung nach Ertag von {C:money}$#2#/32{})"
                 } 
@@ -2197,7 +2197,7 @@ return {
                     "{C:attention}+#3#{} Handgröße, {C:attention}Natur{}",
                     "Gespielte {C:attention}#5#, #6# oder #7#{} geben {C:money}$#1#{} wenn gezählt",
                     "Erhalte {C:money}$#1#{} am Ende der Runde für",
-                    "jede andere {X:grass,C:white}Pflanze{} Karte im Besitz",
+                    "jede andere {X:poke_grass,C:white}Pflanze{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Aktuell {C:money}$#4#{}, Maximal {C:money}$14{}{C:inactive}){}"
                 } 
@@ -2207,7 +2207,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Abwurf, {C:attention}Natur{}",
                     "{C:mult}+#1#{} Mult für jede abgeworfene {C:attention}#5#, #6# oder #7#{} diese Runde",
-                    "Erhalte doppelt wenn eine andere {X:fire,C:white}Feuer{} oder {X:earth,C:white}Kampf{} Karte im Besitz",
+                    "Erhalte doppelt wenn eine andere {X:poke_fire,C:white}Feuer{} oder {X:poke_earth,C:white}Kampf{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Aktuell {C:mult}#4#{}{C:inactive} Mult){}",
                     "{C:inactive}(Entwicklung bei {C:mult}#2#/60{} {C:inactive}Mult)"
@@ -2218,7 +2218,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Abwurf, {C:attention}Natur{}",
                     "{C:mult}+#1#{} Mult für jede abgeworfene {C:attention}#5#, #6# oder #7#{} diese Runde",
-                    "Erhalte doppelt wenn eine andere {X:fire,C:white}Feuer{} oder {X:earth,C:white}Kampf{} Karte im Besitz",
+                    "Erhalte doppelt wenn eine andere {X:poke_fire,C:white}Feuer{} oder {X:poke_earth,C:white}Kampf{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Aktuell {C:mult}#4#{}{C:inactive} Mult){}",
                     "{C:inactive}(Entwicklung bei {C:mult}#2#/150{} {C:inactive}Mult)"
@@ -2230,7 +2230,7 @@ return {
                     "{C:mult}+#2#{} Abwurf, {C:attention}Natur{}",
                     "Für jede abgeworfene {C:attention}#6#, #7# oder #8#{} diese Runde",
                     "erhalte {C:mult}+#4#{} Mult und {X:red,C:white} X#1# {} Mult für",
-                    "jede {X:fire,C:white}Feuer{} oder {X:earth,C:white}Kampf{} Karte im Besitz",
+                    "jede {X:poke_fire,C:white}Feuer{} oder {X:poke_earth,C:white}Kampf{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Aktuell {C:mult}+#5#{}{C:inactive} Mult, {X:red,C:white} X#3# {}{C:inactive} Mult){}",
                 } 
@@ -2241,7 +2241,7 @@ return {
                     "{C:chips}+#3#{} Hand, {C:attention}Natur{}",
                     "Gespielte {C:attention}#4#, #5# oder #6#{} geben {C:chips}+#1#{} Chips",
                     "Erhalte doppelte Chips wenn eine",
-                    "andere {X:water,C:white}Wasser{} oder {X:earth,C:white}Boden{} Karte im Besitz",
+                    "andere {X:poke_water,C:white}Wasser{} oder {X:poke_earth,C:white}Boden{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Entwicklung bei {C:chips}#2#/400{} {C:inactive}Chips)"
                 } 
@@ -2252,7 +2252,7 @@ return {
                     "{C:chips}+#3#{} Hand, {C:attention}Natur{}",
                     "Gespielte {C:attention}#4#, #5# oder #6#{} geben {C:chips}+#1#{} Chips",
                     "Erhalte doppelte Chips wenn eine",
-                    "andere {X:water,C:white}Wasser{} oder {X:earth,C:white}Boden{} Karte im Besitz",
+                    "andere {X:poke_water,C:white}Wasser{} oder {X:poke_earth,C:white}Boden{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Entwicklung bei {C:chips}#2#/960{} {C:inactive}Chips)"
                 } 
@@ -2263,7 +2263,7 @@ return {
                     "{C:chips}+#3#{} Hand, {C:attention}Natur{}",
                     "Gespielte {C:attention}#6#, #7# oder #8#{} geben {C:chips}+#1#{} Chips",
                     "Geben zusätzlich {C:chips}+#5#{} Chips pro",
-                    "andere {X:water,C:white}Wasser{} oder {X:earth,C:white}Boden{} Karte im Besitz",
+                    "andere {X:poke_water,C:white}Wasser{} oder {X:poke_earth,C:white}Boden{} Karte im Besitz",
                     "{C:inactive,s:0.8}(beinhaltet Joker und Energie Karten){}",
                     "{C:inactive}(Aktuell {C:chips}+#4#{}{C:inactive} total)"
                 } 
@@ -2400,7 +2400,7 @@ return {
                 name = 'Mampfaxo',
                 text = {
                     "{C:attention}Baby{}, {X:red,C:white} X#1# {} Mult",
-                    "Erzeuge eine zufällige {C:item}Item{} Karte mit",
+                    "Erzeuge eine zufällige {C:poke_item}Item{} Karte mit",
                     "{C:dark_edition}Negativ{} am Ende der Runde",
                     "{C:inactive}(Ja, dies {C:attention}reduziert{C:inactive} dein Mult)",
                     "{C:inactive}(Entwicklung nach {C:attention}#2#{}{C:inactive} Runden)"
@@ -2422,7 +2422,7 @@ return {
                 text = {
                     "Gespielte {C:attention}Stahl-Karten{} geben {X:red,C:white}X#1#{} Mult",
                     "plus {X:red,C:white}X#2#{} Mult für jeden",
-                    "{X:metal,C:white}Stahl{} Joker im Besitz",
+                    "{X:poke_metal,C:white}Stahl{} Joker im Besitz",
                     "{C:inactive}(Aktuell {X:red,C:white}X#3#{}{C:inactive} Mult){}",
                 } 
             },
@@ -2442,7 +2442,7 @@ return {
                     "erhält permanent",
                     "{C:chips}+#1#{} Chips wenn gezählt",
                     "{C:attention}Stein-Karten{} lösen erneut aus für jeden",
-                    "{X:earth,C:white}Boden{} Joker im Besitz",
+                    "{X:poke_earth,C:white}Boden{} Joker im Besitz",
                     "{C:inactive}(Aktuell #2# mal ausgelöst)"
                 } 
             },
@@ -2498,8 +2498,8 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energie Limit",
-                    "{X:red,C:white} X#2# {} Mult pro benutzte {C:pink}Energie{}",
+                    "{C:poke_pink}+3{} Energie Limit",
+                    "{X:red,C:white} X#2# {} Mult pro benutzte {C:poke_pink}Energie{}",
                     "Karte in diesem {C:attention}Durchlauf{}",
                     "{C:inactive}(Aktuell {X:red,C:white} X#1# {}{C:inactive} Mult)"
                 } 
@@ -2508,7 +2508,7 @@ return {
                 name = "Frosdedje",
                 text = {
                   "Nimm bis zu {C:mult}-$#1#{} Schulden auf",
-                  "Erzeuge ein {C:item}Item{} wenn",
+                  "Erzeuge ein {C:poke_item}Item{} wenn",
                   "eine Hand gespielt wird während man Schulden hat",
                   "{C:inactive}(Muss Platz haben){}"
                 }
@@ -2550,7 +2550,7 @@ return {
                     "{C:mult}+#1#{} Mult",
                     "Karte punktet {C:attention}dreifach{}",
                     "Mult wenn ein",
-                    "{X:lightning, C:black}Elektro{} Joker im Besitz",
+                    "{X:poke_lightning, C:black}Elektro{} Joker im Besitz",
                     "{C:inactive}(Entwicklung nach {C:attention}#2#{}{C:inactive} Runden)"
                 }  
             },
@@ -2558,7 +2558,7 @@ return {
                 name = 'Akkup',
                 text = {
                     "{C:mult}+#1#{} Mult",
-                    "für jeden {X:lightning, C:black}Elektro{} Joker",
+                    "für jeden {X:poke_lightning, C:black}Elektro{} Joker",
                     "im Besitz {C:inactive}(inklusive sich selbst){}",
                      "{C:inactive}(Aktuell {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive}(Entwicklung mit einer {C:attention}Donnerstein{}{C:inactive} Karte)"
@@ -2569,7 +2569,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult für jeden",
-                    "anderen {X:lightning, C:black}Elektro{} Joker",
+                    "anderen {X:poke_lightning, C:black}Elektro{} Joker",
                     "im Besitz{}",
                      "{C:inactive}(Aktuell {X:red,C:white} X#2# {}{C:inactive} Mult)",
                 }  
@@ -2649,7 +2649,7 @@ return {
                   "Benötigter {C:attention}Rang{} wird bei jeder Verstärkung erhöht",
                   "{C:inactive,s:0.8}(Wenn der Rang der höchste ist, wird er zum niedrigsten)",
                   "{C:inactive}(Aktuell {C:chips}+#1#{C:inactive} Chips)",
-                  "{C:inactive}(Entwicklung wenn ein {X:fire,C:white}Feuer{}{C:inactive} Joker im Besitz)",
+                  "{C:inactive}(Entwicklung wenn ein {X:poke_fire,C:white}Feuer{}{C:inactive} Joker im Besitz)",
                 }
             },
             j_poke_dachsbun = {
@@ -2658,7 +2658,7 @@ return {
                   "Erhält {C:chips}+#2#{} Chips wenn gespielte Hand eine {C:attention}#3#{} enthält",
                   "Benötigter {C:attention}Rang{} wird bei jeder Verstärkung erhöht",
                   "Erhaltene Chips um {C:chips}+2{} erhöht für jeden",
-                  "{X:fire,C:white}Feuer{} Joker im Besitz",
+                  "{X:poke_fire,C:white}Feuer{} Joker im Besitz",
                   "{C:inactive,s:0.8}(Wenn der Rang der höchste ist, wird er zum niedrigsten)",
                   "{C:inactive}(Aktuell {C:chips}+#1#{C:inactive} Chips)",
                 }
@@ -2742,7 +2742,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult für jeden",
-                    "Joker mit einem {C:pink}Typ{} im Besitz",
+                    "Joker mit einem {C:poke_pink}Typ{} im Besitz",
                     "Es können {C:attention}Pokemon{} von der gleichen", 
                     "evolutionären Linie erscheinen",
                     "{C:inactive}(Aktuell {C:mult}+#1#{C:inactive} Mult)"
@@ -2768,8 +2768,8 @@ return {
             j_poke_jelly_donut = {
                 name = "Jelly Donut",
                 text = {
-                  "Erzeuge eine {C:colorless}Normal",
-                  "{C:pink}Energíe{} wenn Blind",
+                  "Erzeuge eine {C:poke_colorless}Normal",
+                  "{C:poke_pink}Energíe{} wenn Blind",
                   "ausgewählt wird",
                   "{C:inactive}({C:attention}#1#{}{C:inactive} Runden verbleibend){}"
                 }
@@ -2797,7 +2797,7 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
+                    "with random {C:poke_pink}Type{} stickers",
                 },
             },
         },
@@ -2831,7 +2831,7 @@ return {
             c_poke_obituary = {
                 name = "Nachruf",
                 text = {
-                    "Fügt ein {C:pink}Pinkes Siegel{}",
+                    "Fügt ein {C:poke_pink}Pinkes Siegel{}",
                     "zu {C:attention}1{} ausgewählten Karte hinzu",
                 }
             },
@@ -2840,13 +2840,13 @@ return {
                 text = {
                     "Zerstört einen zufälligen Pokemon",
                     "Joker und erzeugt {C:attention}3{}",
-                    "zufällige {C:pink}Energien{} mit {C:dark_edition}Negativ{}"
+                    "zufällige {C:poke_pink}Energien{} mit {C:dark_edition}Negativ{}"
                 },
             },
 			c_poke_revenant = {
                 name = "Rächer",
                 text = {
-                    "Fügt ein {C:item}Silbernes Siegel{}",
+                    "Fügt ein {C:poke_item}Silbernes Siegel{}",
                     "zu {C:attention}1{} ausgewählten Karte hinzu",
                 }
             },
@@ -2865,7 +2865,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Taschen-Tag",
                 text = {
-                    "Gibt ein kostenloses {C:pink}Mega-Taschen-Pack",
+                    "Gibt ein kostenloses {C:poke_pink}Mega-Taschen-Pack",
                     "{C:green}25%{} Chance Paket beinhaltet",
                     "einen {C:attention}Mega-Stein{} bei {C:attention}Ante 5+{}"
                 }, 
@@ -2875,7 +2875,7 @@ return {
                 text = {
                     "Nächster Basis-Edition Shop",
                     "Joker ist kostenlos und",
-                    "wird {C:colorless}Shiny{}",
+                    "wird {C:poke_colorless}Shiny{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -2889,7 +2889,7 @@ return {
                 name = "Safari-Tag",
                 text = {
                     "Shop hat einen kostenlosen",
-                    "{C:safari}Safari{} Joker",
+                    "{C:poke_safari}Safari{} Joker",
                 }, 
             },
         },
@@ -2915,13 +2915,13 @@ return {
             v_poke_energysearch = {
                 name = "Energiesuche",
                 text = {
-                    "{C:pink}+1{} Energie Limit"
+                    "{C:poke_pink}+1{} Energie Limit"
                 },
             },
             v_poke_energyresearch = {
                 name = "Energieforschung",
                 text = {
-                    "{C:pink}+1{} Energie Limit"
+                    "{C:poke_pink}+1{} Energie Limit"
                 },
             },
             v_poke_goodrod = {
@@ -2944,79 +2944,79 @@ return {
             Grass = {
                 name = "Typ",
                 text = {
-                  "{X:grass,C:white}Pflanze{}",
+                  "{X:poke_grass,C:white}Pflanze{}",
                 }
             },
             Fire = {
                 name = "Typ",
                 text = {
-                  "{X:fire,C:white}Feuer{}",
+                  "{X:poke_fire,C:white}Feuer{}",
                 }
             },
             Water = {
                 name = "Typ",
                 text = {
-                  "{X:water,C:white}Wasser{}",
+                  "{X:poke_water,C:white}Wasser{}",
                 }
             },
             Lightning = {
                 name = "Typ",
                 text = {
-                  "{X:lightning,C:black}Elektro{}",
+                  "{X:poke_lightning,C:black}Elektro{}",
                 }
             },
             Psychic = {
                 name = "Typ",
                 text = {
-                  "{X:psychic,C:white}Psycho{}",
+                  "{X:poke_psychic,C:white}Psycho{}",
                 }
             },
             Fighting = {
                 name = "Typ",
                 text = {
-                  "{X:fighting,C:white}Kampf{}",
+                  "{X:poke_fighting,C:white}Kampf{}",
                 }
             },
             Colorless = {
                 name = "Typ",
                 text = {
-                  "{X:colorless,C:white}Normal{}",
+                  "{X:poke_colorless,C:white}Normal{}",
                 }
             },
             Dark = {
                 name = "Typ",
                 text = {
-                  "{X:dark,C:white}Unlicht{}",
+                  "{X:poke_dark,C:white}Unlicht{}",
                 }
             },
             Metal = {
                 name = "Typ",
                 text = {
-                  "{X:metal,C:white}Stahl{}",
+                  "{X:poke_metal,C:white}Stahl{}",
                 }
             },
             Fairy = {
                 name = "Typ",
                 text = {
-                  "{X:fairy,C:white}Fee{}",
+                  "{X:poke_fairy,C:white}Fee{}",
                 }
             },
             Dragon = {
                 name = "Typ",
                 text = {
-                  "{X:dragon,C:white}Drache{}",
+                  "{X:poke_dragon,C:white}Drache{}",
                 }
             },
             Earth = {
                 name = "Typ",
                 text = {
-                  "{X:earth,C:white}Boden{}",
+                  "{X:poke_earth,C:white}Boden{}",
                 }
             },
             Bird = {
                 name = "Typ",
                 text = {
-                  "{X:bird,C:white}Flug{}",
+                  "{X:poke_bird,C:white}Flug{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -3180,7 +3180,7 @@ return {
                 name = "Geschenk",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}Item{} {C:attention}Karte",
+                    "{C:green}30%{} - {C:poke_item}Item{} {C:attention}Karte",
                     "{C:green}20%{} - {C:attention}Coupon-Tag",
                     "{C:green}15%{} - {C:dark_edition}Polychrom{} {C:attention}Geschenk Karte",
                 }
@@ -3196,14 +3196,14 @@ return {
 			eeveelution = {
                 name = "Entwicklungen",
                 text = {
-                    "{C:attention}Wasserstein{} - {X:water,C:white}Aquana{}",
-                    "{C:attention}Donnerstein{} - {X:lightning,C:black}Blitza{}",
-                    "{C:attention}Feuerstein{} - {X:fire,C:white}Flamara{}",
-                    "{C:attention}Sonnenstein{} - {X:psychic,C:white}Psiana{}",
-                    "{C:attention}Mondsteine{} - {X:dark,C:white}Nachtara{}",
-                    "{C:attention}Blattstein{} - {X:grass,C:white}Folipurba{}",
-                    "{C:attention}Eisstein{} - {X:water,C:white}Glaziola{}",
-                    "{C:attention}Funkelstein{} - {X:fairy,C:white}Feelinara{}"
+                    "{C:attention}Wasserstein{} - {X:poke_water,C:white}Aquana{}",
+                    "{C:attention}Donnerstein{} - {X:poke_lightning,C:black}Blitza{}",
+                    "{C:attention}Feuerstein{} - {X:poke_fire,C:white}Flamara{}",
+                    "{C:attention}Sonnenstein{} - {X:poke_psychic,C:white}Psiana{}",
+                    "{C:attention}Mondsteine{} - {X:poke_dark,C:white}Nachtara{}",
+                    "{C:attention}Blattstein{} - {X:poke_grass,C:white}Folipurba{}",
+                    "{C:attention}Eisstein{} - {X:poke_water,C:white}Glaziola{}",
+                    "{C:attention}Funkelstein{} - {X:poke_fairy,C:white}Feelinara{}"
                 }
             },
 			percent_chance = {
@@ -3217,7 +3217,7 @@ return {
 			precise_energy_tooltip = {
                 name = "Präzise Energie Skalierung",
                 text = {
-                    "{s:0.8}Nutze {C:attention,s:0.8}Dezimalstellen{} für alle Werte bei der Anwendung von {C:pink,s:0.8}Energie{}{s:0.8} Bonus{}",
+                    "{s:0.8}Nutze {C:attention,s:0.8}Dezimalstellen{} für alle Werte bei der Anwendung von {C:poke_pink,s:0.8}Energie{}{s:0.8} Bonus{}",
                     "{s:0.8}Wird diese Option {C:attention,s:0.8}ausgeschaltet{}{s:0.8} gilt folgendes für den Bonus:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Mult - Nutze Dezimalstellen",
                     "{C:attenion}2. {s:0.8}Flaches {C:mult,s:0.8}Mult{}{s:0.8} und {C:chips,s:0.8}Chips{}{s:0.8} - Werden zur nächsten Ganzen Zahl gerundet",
@@ -3254,7 +3254,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Pinkes Siegel",
                 text = {
-                    "Erzeugt eine {C:pink}Energie{} Karte",
+                    "Erzeugt eine {C:poke_pink}Energie{} Karte",
                     "wenn die Karte bei der",
                     "{C:attention}ersten Hand{} der Runde punktet"
                 },
@@ -3264,7 +3264,7 @@ return {
             poke_silver_seal = {
                 name = "Silbernes Siegel",
                 text = {
-                  "Erzeugt eine {C:item}Item{} Karte",
+                  "Erzeugt eine {C:poke_item}Item{} Karte",
                   "und wird {C:attention}abgelegt{} wenn auf der Hand {C:attention}gehalten{}",
                   "während der Punktezählung"
                 }
@@ -3273,73 +3273,73 @@ return {
             grass_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:grass,C:white}Pflanze{}"
+                    "{X:poke_grass,C:white}Pflanze{}"
                 } 
             },
             fire_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:fire,C:white}Feuer{}"
+                    "{X:poke_fire,C:white}Feuer{}"
                 } 
             },
             water_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:water,C:white}Wasser{}"
+                    "{X:poke_water,C:white}Wasser{}"
                 } 
             },
             lightning_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:lightning,C:white}Elektro{}"
+                    "{X:poke_lightning,C:white}Elektro{}"
                 } 
             },
             psychic_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:psychic,C:white}Psycho{}"
+                    "{X:poke_psychic,C:white}Psycho{}"
                 } 
             },
             fighting_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:fighting,C:white}Kampf{}"
+                    "{X:poke_fighting,C:white}Kampf{}"
                 } 
             },
             colorless_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:colorless,C:white}Normal{}"
+                    "{X:poke_colorless,C:white}Normal{}"
                 } 
             },
             dark_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:dark,C:white}Unlicht{}"
+                    "{X:poke_dark,C:white}Unlicht{}"
                 } 
             },
             metal_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:metal,C:white}Stahl{}"
+                    "{X:poke_metal,C:white}Stahl{}"
                 } 
             },
             fairy_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:fairy,C:white}Fee{}"
+                    "{X:poke_fairy,C:white}Fee{}"
                 } 
             },
             dragon_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:dragon,C:white}Drache{}"
+                    "{X:poke_dragon,C:white}Drache{}"
                 } 
             },
             earth_sticker = {
                 name = "Typ",
                 text = {
-                    "{X:earth,C:white}Boden{}"
+                    "{X:poke_earth,C:white}Boden{}"
                 } 
             },
             --Since these are normally discovered by default these will probably not matter
@@ -3367,7 +3367,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
@@ -3375,7 +3375,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
@@ -3383,7 +3383,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
@@ -3391,7 +3391,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
@@ -3399,7 +3399,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
@@ -3407,7 +3407,7 @@ return {
                 text = {
                    "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
@@ -3415,7 +3415,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
@@ -3423,7 +3423,7 @@ return {
                 text = {
                     "Wähle {C:attention}#1#{} von",
                     "bis zu {C:attention}#2#",
-                    "{C:pink}Energie{} oder {C:item}Item{} Karten{}",
+                    "{C:poke_pink}Energie{} oder {C:poke_item}Item{} Karten{}",
                 },
             },
         },

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -44,7 +44,7 @@ return {
                     "Start run with the",
                     "{C:tarot,T:v_crystal_ball}#1#{} voucher",
                     "and {C:attention}2{} copies",
-                    "of {C:item,T:c_poke_twisted_spoon}#2#"
+                    "of {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             --Fun fact: this and luminious deck had their descriptions mixed up
@@ -64,8 +64,8 @@ return {
                 name = "Luminous Deck",
                 text = {
                     "All Jokers are",
-                    "created {C:pink}Energized{} and",
-                    "with random {C:pink}Type{} stickers"
+                    "created {C:poke_pink}Energized{} and",
+                    "with random {C:poke_pink}Type{} stickers"
                 }
             },
             b_poke_ampeddeck = {
@@ -74,7 +74,7 @@ return {
                     "Start run with the",
                     "{C:tarot,T:v_poke_energysearch}#1#{} voucher",
                     "and a copy of",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             b_poke_futuredeck = {
@@ -112,7 +112,7 @@ return {
             b_poke_diceydeck = {
                 name = "Debris Deck",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer and limit, {C:attention}+#1#{} hand size",
+                    "{C:poke_hazard}+#1#{} hazard layer and limit, {C:attention}+#1#{} hand size",
                     "At end of each round:",
                     "Earn {C:money}$#4#{} for each {C:attention}Hazard{}",
                     "card in your {C:attention}full deck",
@@ -324,17 +324,17 @@ return {
                 name = "Tera Orb",
                 text = {
                     "{C:attention}Type Changer:{} {B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.8}({C:pink,s:0.8}Type{C:inactive,s:0.8} changes with every discard){}",
+                    "{C:inactive,s:0.8}({C:poke_pink,s:0.8}Type{C:inactive,s:0.8} changes with every discard){}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "{C:pink}Energize{} leftmost or",
+                    "{C:poke_pink}Energize{} leftmost or",
                     "selected Joker if it",
-                    "is already {B:1,V:2}#1#{} {C:pink}Type{}"
+                    "is already {B:1,V:2}#1#{} {C:poke_pink}Type{}"
                 },
             },
             c_poke_metalcoat = {
                 name = "Metal Coat",
                 text = {
-                    "{C:attention}Type Changer:{} {X:metal,C:white}Metal{}",
+                    "{C:attention}Type Changer:{} {X:poke_metal,C:white}Metal{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Creates a {C:attention}Steel{} copy of",
                     "{C:attention}1{} selected card",
@@ -343,10 +343,10 @@ return {
             c_poke_dragonscale = {
                 name = "Dragon Scale",
                 text = {
-                    "{C:attention}Type Changer:{} {X:dragon,C:white}Dragon{}",
+                    "{C:attention}Type Changer:{} {X:poke_dragon,C:white}Dragon{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Creates up to {C:attention}3{} random",
-                    "{C:item}Item{} or {C:pink}Energy{} cards",
+                    "{C:poke_item}Item{} or {C:poke_pink}Energy{} cards",
                     "{C:inactive}(Must have room){}"
                 },
             },
@@ -403,10 +403,10 @@ return {
                 name = "Twisted Spoon",
                 text = {
                     "Creates the last",
-                    "{C:item}Item{} card or {C:pink}Energy{} card",
+                    "{C:poke_item}Item{} card or {C:poke_pink}Energy{} card",
                     "used during this run",
-                    "{s:0.8,C:item}Twisted Spoon, Reusables",
-                    "{s:0.8,C:item}and Berry Juices{s:0.8} excluded"
+                    "{s:0.8,C:poke_item}Twisted Spoon, Reusables",
+                    "{s:0.8,C:poke_item}and Berry Juices{s:0.8} excluded"
                 }
             },
             c_poke_prismscale = {
@@ -450,7 +450,7 @@ return {
                     "{br:2}ERROR - CONTACT STEAK",
                     "Enhances {C:attention}1{} selected card into a",
                     "{C:attention}Stone{} card with {C:chips}+#2#{} extra Chips",
-                    "for each {X:earth,C:white}Earth{} Joker you have"
+                    "for each {X:poke_earth,C:white}Earth{} Joker you have"
                 }
             },
             c_poke_miracleseed = {
@@ -480,8 +480,8 @@ return {
             c_poke_berry_juice_energy = {
                 name = "Energized Berry Juice",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "Joker of any {C:pink}Type{}",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "Joker of any {C:poke_pink}Type{}",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
@@ -503,7 +503,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "Itemized Berry Juice",
                 text = {
-                    "Create a {C:item}Twisted Spoon{} card",
+                    "Create a {C:poke_item}Twisted Spoon{} card",
                     "{C:green}#1# in #2#{} chance to",
                     "create {C:attention}2{} instead",
                     "{C:inactive}(Must have room){}"
@@ -527,7 +527,7 @@ return {
                 name = "Mystery Berry Juice",
                 text = {
                     "Creates a random",
-                    "{C:item}Berry Juice{} card"
+                    "{C:poke_item}Berry Juice{} card"
                 }
             },
             c_poke_oven = {
@@ -586,73 +586,73 @@ return {
             c_poke_grass_energy = {
                 name = "Grass Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:grass,C:white}Grass{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_grass,C:white}Grass{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_fire_energy = {
                 name = "Fire Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:fire,C:white}Fire{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_fire,C:white}Fire{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_water_energy = {
                 name = "Water Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:water,C:white}Water{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_water,C:white}Water{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_lightning_energy = {
                 name = "Lightning Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:lightning,C:black}Lightning{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_lightning,C:black}Lightning{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_psychic_energy = {
                 name = "Psychic Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:psychic,C:white}Psychic{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_psychic,C:white}Psychic{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_fighting_energy = {
                 name = "Fighting Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:fighting,C:white}Fighting{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_fighting,C:white}Fighting{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_colorless_energy = {
                 name = "Colorless Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:colorless,C:white}Colorless{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_colorless,C:white}Colorless{} Joker if able",
                     "Half as effective with",
-                    "non-{X:colorless,C:white}Colorless{} Jokers",
+                    "non-{X:poke_colorless,C:white}Colorless{} Jokers",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)"
                 },
             },
             c_poke_darkness_energy = {
                 name = "Darkness Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:dark,C:white}Dark{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_dark,C:white}Dark{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_metal_energy = {
                 name = "Metal Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
+                    "{C:poke_pink}Energize{} leftmost or selected",
                     "{X:Metal,C:white}Metal{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
@@ -660,8 +660,8 @@ return {
             c_poke_fairy_energy = {
                 name = "Fairy Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:fairy,C:white}Fairy{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_fairy,C:white}Fairy{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
@@ -669,16 +669,16 @@ return {
             c_poke_dragon_energy = {
                 name = "Dragon Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:dragon,C:white}Dragon{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_dragon,C:white}Dragon{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
             c_poke_earth_energy = {
                 name = "Earth Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "{X:earth,C:white}Earth{} Joker if able",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "{X:poke_earth,C:white}Earth{} Joker if able",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
             },
@@ -1362,7 +1362,7 @@ return {
                 name = "Abra",
                 text = {
                     "{C:green}#1# in #2#{} chance to create a {C:tarot}Tarot{}",
-                    "or {C:item}Item{} card if played {C:attention}poker hand{}",
+                    "or {C:poke_item}Item{} card if played {C:attention}poker hand{}",
                     "has already been played this round",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#3#{C:inactive,s:0.8} rounds)",
                 } 
@@ -1371,7 +1371,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# in #2#{} chance to create a {C:tarot}Tarot{} or",
-                    "{C:item}Twisted Spoon{} card if {C:attention}poker hand{}",
+                    "{C:poke_item}Twisted Spoon{} card if {C:attention}poker hand{}",
                     "has already been played this round",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Linking Cord{C:inactive,s:0.8})"
                 } 
@@ -1381,7 +1381,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} consumable slot",
                     "{C:green}#1# in #2#{} chance to create a {C:attention}Fool{} or",
-                    "{C:item}Twisted Spoon{} card if {C:attention}poker hand{}",
+                    "{C:poke_item}Twisted Spoon{} card if {C:attention}poker hand{}",
                     "has already been played this round",
                 } 
             },
@@ -1390,7 +1390,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} consumable slot",
                     "Every held {C:attention}Consumable{} gives {X:mult,C:white}X#1#{} Mult",
-                    "{C:item}Twisted Spoons{} give {X:mult,C:white}X#2#{} Mult",
+                    "{C:poke_item}Twisted Spoons{} give {X:mult,C:white}X#2#{} Mult",
                 } 
             },
             j_poke_machop = {
@@ -1559,7 +1559,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards give {X:mult,C:white}X#1#{} Mult",
                     "plus {X:mult,C:white}X#2#{} Mult for each",
-                    "adjacent {X:metal,C:white}Metal{} Joker",
+                    "adjacent {X:poke_metal,C:white}Metal{} Joker",
                     "{C:inactive}(Currently {X:mult,C:white}X#3#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Thunder Stone{C:inactive,s:0.8})"
                 } 
@@ -1567,10 +1567,10 @@ return {
             j_poke_farfetchd = {
                 name = 'Farfetch\'d',      
                 text = {
-                    "{C:attention}Holding {C:item}Leek{}",
+                    "{C:attention}Holding {C:poke_item}Leek{}",
                     "{C:green}#2# in #3#{} chance to earn {C:money}$#1#",
                     "when a {C:attention}Consumable{} is used,",
-                    "{C:money}${} guaranteed when using {C:item}Leeks{}",
+                    "{C:money}${} guaranteed when using {C:poke_item}Leeks{}",
                 } 
             },
             j_poke_doduo = {
@@ -1690,7 +1690,7 @@ return {
                     "When a {C:attention}non-Stone{} card",
                     "is destroyed, add a",
                     "{C:attention}Stone{} card to {C:attention}deck",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Metal{C:inactive,s:0.8} sticker)"
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Metal{C:inactive,s:0.8} sticker)"
                 } 
             },
             j_poke_drowzee = {
@@ -1766,10 +1766,10 @@ return {
             j_poke_cubone = {
                 name = 'Cubone',
                 text = {
-                    "{C:attention}Holding {C:item}Thick Club{}",
+                    "{C:attention}Holding {C:poke_item}Thick Club{}",
                     "Gives {C:mult}+#1#{} Mult for",
                     "each {C:attention}held consumable",
-                    "{C:inactive,s:0.8}({C:item,s:0.8}Thick Clubs{C:inactive,s:0.8} count as double){}",
+                    "{C:inactive,s:0.8}({C:poke_item,s:0.8}Thick Clubs{C:inactive,s:0.8} count as double){}",
                     "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves after using {C:attention,s:0.8}#3#{C:inactive,s:0.8} consumables)",
                 } 
@@ -1897,7 +1897,7 @@ return {
                     "Gains {C:mult}+#2#{} Mult for each scored {C:attention}6{}",
                     "Doubled if a {C:attention}King{} is held in hand",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolves with a {C:dragon,s:0.8}Dragon{C:inactive,s:0.8} sticker)"
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_dragon,s:0.8}Dragon{C:inactive,s:0.8} sticker)"
                 } 
             },
             j_poke_goldeen = {
@@ -1945,7 +1945,7 @@ return {
                     "Gain {C:dark_edition}Foil{}, {C:dark_edition}Holographic{}, or {C:dark_edition}Polychrome{}",
                     "if it was {C:rare}Rare{} or higher",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Metal{C:inactive,s:0.8} sticker or a {C:attention,s:0.8}Hard Stone{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Metal{C:inactive,s:0.8} sticker or a {C:attention,s:0.8}Hard Stone{C:inactive,s:0.8})",
                 } 
             },
             j_poke_jynx = {
@@ -2051,7 +2051,7 @@ return {
                     "{C:attention}Volatile Right{}",
                     "{C:attention}Transforms{} into leftmost",
                     "Joker with {C:attention}Perishable{}",
-                    "and a {X:colorless,C:white}Colorless{} sticker",
+                    "and a {X:poke_colorless,C:white}Colorless{} sticker",
                     "at the end of {C:attention}shop",
                     "{C:inactive,s:0.8}(Excludes Dittos)",
                 } 
@@ -2094,10 +2094,10 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} Energy Limit",
-                    "Create an {C:pink}Energy{} card when",
+                    "{C:poke_pink}+1{} Energy Limit",
+                    "Create an {C:poke_pink}Energy{} card when",
                     "any {C:attention}Booster Pack{} is opened",
-                    "{C:inactive,s:0.8}(Evolves with an {C:item,s:0.8}Upgrade{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolves with an {C:poke_item,s:0.8}Upgrade{C:inactive,s:0.8})",
                 } 
             },
             j_poke_omanyte = {
@@ -2106,7 +2106,7 @@ return {
                     "{C:attention}Ancient #1#s{}",
                     "{X:attention,C:white}1+{} : Create a {C:tarot}Tarot{} card",
                     "{X:attention,C:white}2+{} : Earn {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Create an {C:item}Item{} card",
+                    "{X:attention,C:white}3+{} : Create an {C:poke_item}Item{} card",
                     "{C:inactive,s:0.8}(Must have room)",
                     "{C:inactive,s:0.8}(Trigger {X:attention,C:white,s:0.8}3+{C:inactive,s:0.8} ability {C:attention,s:0.8}#3#{C:inactive,s:0.8} times to evolve)"
                 } 
@@ -2117,7 +2117,7 @@ return {
                     "{C:attention}Ancient #1#s{}",
                     "{X:attention,C:white}1+{} : Create a {C:tarot}Tarot{} card",
                     "{X:attention,C:white}2+{} : Earn {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Create a {C:item}Item{} card",
+                    "{X:attention,C:white}3+{} : Create a {C:poke_item}Item{} card",
                     "{C:inactive,s:0.8}(Must have room)",
                     "{X:attention,C:white}4+{} : Create a {C:attention}Tag{} once per round{C:inactive}#3#{}",
                 } 
@@ -2167,9 +2167,9 @@ return {
             j_poke_snorlax = {
                 name = 'Snorlax',
                 text = {
-                    "{C:attention}Holding {C:item}Leftovers{}",
+                    "{C:attention}Holding {C:poke_item}Leftovers{}",
                     "At end of round gain {X:mult,C:white}X#1#{} Mult",
-                    "for each {C:item}Leftovers{} you have",
+                    "for each {C:poke_item}Leftovers{} you have",
                     "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)"
                 } 
             },
@@ -2230,7 +2230,7 @@ return {
                 text = {
                     "When {C:attention}Boss Blind{} is defeated, create a",
                     "{C:dark_edition}Polychrome{} {C:attention}duplicate{} of leftmost",
-                    "{C:attention}Joker{} and {C:pink}Energize{} the {C:attention}duplicate{}",
+                    "{C:attention}Joker{} and {C:poke_pink}Energize{} the {C:attention}duplicate{}",
                     "then destroy leftmost {C:attention}Joker{}",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:dark_edition}Polychrome{} Jokers give {X:mult,C:white} X#1# {} Mult",
@@ -2246,12 +2246,12 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "{C:pink}Energize{} leftmost {C:attention}Joker twice{}",
+                    "{C:poke_pink}Energize{} leftmost {C:attention}Joker twice{}",
                     "at the end of {C:attention}shop",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "{C:pink}+1{} Energy Limit when",
+                    "{C:poke_pink}+1{} Energy Limit when",
                     "{C:attention}Boss Blind{} is defeated",
-                    "{C:inactive}(Can't {C:pink}Energize{C:inactive} self)",
+                    "{C:inactive}(Can't {C:poke_pink}Energize{C:inactive} self)",
                 } 
             },
             j_poke_mew = {
@@ -2259,7 +2259,7 @@ return {
                 text = {
                     "At the end of the {C:attention}shop{},",
                     "create a {C:dark_edition}Negative{} {C:tarot}Tarot{},",
-                    "{C:spectral}Spectral{} or {C:item}Item{} card",
+                    "{C:spectral}Spectral{} or {C:poke_item}Item{} card",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:green}#1#%{} chance to create a",
                     "{C:dark_edition}Negative{} Joker {C:attention}instead{}",
@@ -2445,8 +2445,8 @@ return {
                   "Gives {C:chips}+#1#{} Chips and earns {C:money}$#2#{}",
                   "if played hand contains a {C:attention}Pair",
                   "{br:3}ERROR - CONTACT STEAK",
-                  "{C:chips}+#3#{} Chips extra per {X:water,C:white}Water{} Joker",
-                  "{C:money}$#4#{} extra per {X:lightning,C:black}Lightning{} Joker",
+                  "{C:chips}+#3#{} Chips extra per {X:poke_water,C:white}Water{} Joker",
+                  "{C:money}$#4#{} extra per {X:poke_lightning,C:black}Lightning{} Joker",
                   "{C:inactive}(Currently {C:chips}+#6#{C:inactive} Chips and {C:money}$#5#{C:inactive})"
                 }
             },
@@ -2577,11 +2577,11 @@ return {
             j_poke_weird_tree = {
                 name = "Weird Tree",
                 text = {
-                  "{C:attention}Type Changer: {X:grass,C:white}Grass{}",
+                  "{C:attention}Type Changer: {X:poke_grass,C:white}Grass{}",
                   "{C:}Transforms{} at end of round",
                   "if this Joker isn't",
-                  "a {X:grass,C:white}Grass{} type or you",
-                  "have a {X:water,C:white}Water{} type"
+                  "a {X:poke_grass,C:white}Grass{} type or you",
+                  "have a {X:poke_water,C:white}Water{} type"
                 }
             },
             j_poke_bellossom = {
@@ -2599,7 +2599,7 @@ return {
                 text = {
                     "Retrigger first scoring {V:1}#2#{}",
                     "then retrigger it again for",
-                    "each {X:water,C:white}Water{} Joker you have,",
+                    "each {X:poke_water,C:white}Water{} Joker you have,",
                     "suit cycles after scoring",
                     "{C:inactive,s:0.8}(#3#, #4#, #5#, #6#)"
                 } 
@@ -2714,7 +2714,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:mult,C:white} X#1# {} Mult for each",
-                "{X:dark,C:white}Dark{} Joker you have",
+                "{X:poke_dark,C:white}Dark{} Joker you have",
                 "{C:inactive}(Currently {X:mult,C:white} X#2#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Dusk Stone{C:inactive,s:0.8})"
               }
@@ -2849,7 +2849,7 @@ return {
             j_poke_qwilfish = {
                 name = 'Qwilfish',
                 text = {
-                    "{C:hazard}+#1#{} hazard layer",
+                    "{C:poke_hazard}+#1#{} hazard layer",
                     "Gain {C:chips}+#2#{} Chips when",
                     "an {C:attention}enhanced{} card",
                     "is destroyed",
@@ -2882,8 +2882,8 @@ return {
                 text = {
                   "When {C:attention}Blind{} is selected, destroy",
                   "leftmost {C:attention}Consumable{} and",
-                  "create a {C:item}Berry Juice{} card",
-                  "{C:inactive}(Can't destroy {C:item}Berry Juice{C:inactive})"
+                  "create a {C:poke_item}Berry Juice{} card",
+                  "{C:inactive}(Can't destroy {C:poke_item}Berry Juice{C:inactive})"
                 }
             },
             j_poke_sneasel = {
@@ -2907,7 +2907,7 @@ return {
               name = "Ursaring",
               text = {
                 "Gains {C:mult}+#2#{} Mult and",
-                "creates an {C:item}Item{} when any",
+                "creates an {C:poke_item}Item{} when any",
                 "{C:attention}Booster Pack{} is skipped {C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Moon Stone{C:inactive,s:0.8})",
@@ -2978,8 +2978,8 @@ return {
               name = 'Corsola',
               text = {
                 "When {C:attention}Blind{} is selected, gain {C:mult}+#1#{} Mult",
-                "for each {X:water,C:white}Water{} Joker you have,",
-                "then create a {C:attention}Basic{} {X:water,C:white}Water{} Joker",
+                "for each {X:poke_water,C:white}Water{} Joker you have,",
+                "then create a {C:attention}Basic{} {X:poke_water,C:white}Water{} Joker",
                 "{C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
               }
@@ -3020,7 +3020,7 @@ return {
             j_poke_skarmory = {
                 name = 'Skarmory',
                 text = {
-                    "{C:hazard}+#1#{} hazard layer and limit",
+                    "{C:poke_hazard}+#1#{} hazard layer and limit",
                     "{X:mult,C:white}X#2#{} Mult for each",
                     "{C:attention}Hazard{} or {C:attention}Steel{} card",
                     "{C:attention}held{} in hand",
@@ -3058,11 +3058,11 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} Energy Limit",
+                    "{C:poke_pink}+2{} Energy Limit",
                     "When any {C:attention}Booster Pack{} is opened",
-                    "create an {C:pink}Energy{} card of",
-                    "the same {C:pink}Type{} of leftmost Joker",
-                    "{C:inactive,s:0.8}(Evolves with a {C:item,s:0.8}Dubious Disc{C:inactive,s:0.8})",
+                    "create an {C:poke_pink}Energy{} card of",
+                    "the same {C:poke_pink}Type{} of leftmost Joker",
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_item,s:0.8}Dubious Disc{C:inactive,s:0.8})",
                 } 
             },
             j_poke_stantler = {
@@ -3162,7 +3162,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Earn {C:money}$#1#{} for each", 
-                  "{X:colorless,C:white}Colorless{} Joker you have",
+                  "{X:poke_colorless,C:white}Colorless{} Joker you have",
                   "at end of round",
                   "{C:inactive}(Currently {C:money}$#2#{C:inactive}){}"
                 }
@@ -3291,7 +3291,7 @@ return {
                     "{C:attention}+#3#{} hand size, {C:attention}Nature: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards earn {C:money}$#1#{}",
                     "when scored plus {C:money}$#5#{} for each",
-                    "{C:attention}other{} {X:grass,C:white}Grass{} Joker you have",
+                    "{C:attention}other{} {X:poke_grass,C:white}Grass{} Joker you have",
                     "{C:inactive}(Currently {C:money}$#4#{C:inactive} total){}"
                 } 
             },
@@ -3320,7 +3320,7 @@ return {
                     "Played {C:attention}Nature{} cards give {C:mult}+#1#{} Mult",
                     "when scored",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Each {X:fire,C:white}Fire{} or {X:fighting,C:white}Fighting{} Joker gives",
+                    "Each {X:poke_fire,C:white}Fire{} or {X:poke_fighting,C:white}Fighting{} Joker gives",
                     "{X:mult,C:white} X#2# {} Mult if you have discarded",
                     "{C:attention}#4# {C:inactive}[#5#] {C:attention}Nature{} cards this round"
                 } 
@@ -3351,7 +3351,7 @@ return {
                     "when scored",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Create a {C:tarot}Tarot{} card for every {C:attention}2{}",
-                    "{X:water,C:white}Water{} or {X:earth,C:white}Earth{} Jokers you have if",
+                    "{X:poke_water,C:white}Water{} or {X:poke_earth,C:white}Earth{} Jokers you have if",
                     "poker hand contains {C:attention}#3# Nature{} cards",
                     "{C:inactive}(Must have room){}"
                 } 
@@ -3372,7 +3372,7 @@ return {
                 "{C:attention}playing card{} is destroyed",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Gain increased by {C:mult}+#3#{} Mult",
-                "for each {X:dark,C:white}Dark{} Joker you have",
+                "for each {X:poke_dark,C:white}Dark{} Joker you have",
                 "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
               }
             },
@@ -3380,7 +3380,7 @@ return {
               name = "Zigzagoon",
               text = {
                 "{C:green}#1# in #2#{} chance to create a",
-                "{C:attention}Pickup{} {C:item}Item{} when hand is played",
+                "{C:attention}Pickup{} {C:poke_item}Item{} when hand is played",
                 "{C:inactive}(Must have room)",
                 "{C:inactive,s:0.8}(Evolves after {C:attention}#3#{C:inactive,s:0.8} rounds)",
               }
@@ -3389,7 +3389,7 @@ return {
               name = "Linoone",
               text = {
                 "{C:green}#1# in #2#{} chance to create a",
-                "{C:attention}Pickup{} {C:item}Item{} when hand is played",
+                "{C:attention}Pickup{} {C:poke_item}Item{} when hand is played",
                 "Guaranteed if hand",
                 "contains a {C:attention}Straight{}",
                 "{C:inactive}(Must have room)"
@@ -3476,13 +3476,13 @@ return {
                 "changes every round",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Earn {C:money}$#2#{} extra for each",
-                "{X:water,C:white}Water{} Joker you have"
+                "{X:poke_water,C:white}Water{} Joker you have"
               }
             }, 
             j_poke_ralts = {
               name = "Ralts",
               text = {
-                "{C:mult}+#1#{} Mult for each {C:pink}Energized{}",
+                "{C:mult}+#1#{} Mult for each {C:poke_pink}Energized{}",
                 "Joker and {C:attention}held{} {C:planet}Planet{} card",
                 "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
@@ -3491,7 +3491,7 @@ return {
             j_poke_kirlia = {
               name = "Kirlia",
               text = {
-                "{C:mult}+#1#{} Mult for each {C:pink}Energized{}",
+                "{C:mult}+#1#{} Mult for each {C:poke_pink}Energized{}",
                 "Joker and {C:attention}held{} {C:planet}Planet{} card",
                 "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves after using {C:attention,s:0.8}#3#{C:planet,s:0.8} Planet {C:inactive,s:0.8}cards)",
@@ -3503,7 +3503,7 @@ return {
               text = {
                 "{C:attention}Holding{} {C:spectral}Black Hole",
                 "{br:2}ERROR - CONTACT STEAK",
-                "{X:mult,C:white}X#1#{} Mult for each {C:pink}Energized{}",
+                "{X:mult,C:white}X#1#{} Mult for each {C:poke_pink}Energized{}",
                 "Joker and each level {C:attention}#3#+{} hand",
                 "{C:inactive}(Currently {X:mult,C:white} X#2#{C:inactive} Mult)",
               }
@@ -3579,8 +3579,8 @@ return {
                   "{C:inactive}(Currently {X:mult,C:white}X#1#{C:inactive} Mult)",
                   "{br:2.5}ERROR - CONTACT STEAK",
                   "{S:1.1,C:red,E:2}self destructs{} if you",
-                  "have a {X:fire,C:white}Fire{}, {X:dark,C:white}Dark{}, {X:earth,C:white}Earth{}, or",
-                  "{X:psychic,C:white}Psychic{} Joker at end of {C:attention}shop",
+                  "have a {X:poke_fire,C:white}Fire{}, {X:poke_dark,C:white}Dark{}, {X:poke_earth,C:white}Earth{}, or",
+                  "{X:poke_psychic,C:white}Psychic{} Joker at end of {C:attention}shop",
                   "{C:inactive}(Excludes Shedinjas){}"
                 }
             },
@@ -3597,7 +3597,7 @@ return {
                 text = {
                   "When {C:attention}Blind{} is selected,",
                   "gain {C:chips}+#1#{} hand for each",
-                  "{X:fighting,C:white}Fighting{} Joker you have",
+                  "{X:poke_fighting,C:white}Fighting{} Joker you have",
                 }
             },
             j_poke_azurill = {
@@ -3634,7 +3634,7 @@ return {
                   "Copies ability of",
                   "{B:1,V:2}#1#{} Joker",
                   "to the right",
-                  "with {C:pink}+#2#{} Energy",
+                  "with {C:poke_pink}+#2#{} Energy",
                   "{C:inactive,s:0.8}(Type changes every round){}",
                 }
             },
@@ -3712,7 +3712,7 @@ return {
                 "Gains {C:chips}+#2#{} Chips when",
                 "you use a {C:planet}Planet{} card",
                 "{br:2}ERROR - CONTACT STEAK",
-                "If you have another {X:grass,C:white}Grass{}",
+                "If you have another {X:poke_grass,C:white}Grass{}",
                 "Joker, gains {X:mult,C:white} X#4# {} Mult as well",
                 "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips, {X:mult,C:white} X#3# {C:inactive} Mult)"
               }
@@ -3722,7 +3722,7 @@ return {
               text = {
                 "When {C:attention}Blind{} is selected,",
                 "create a {C:planet}Planet{} card for",
-                "each {X:grass,C:white}Grass{} Joker you have",
+                "each {X:poke_grass,C:white}Grass{} Joker you have",
                 "{C:inactive}(Must have room){}",
               }
             },
@@ -3810,7 +3810,7 @@ return {
             j_poke_cacnea = {
               name = "Cacnea",
               text = {
-                "{C:hazard}+#1#{} hazard layer",
+                "{C:poke_hazard}+#1#{} hazard layer",
                 "Earn {C:money}$#2#{} when a",
                 "card is destroyed",
                 "{C:inactive}(Evolves after {C:attention}#3#{C:inactive} rounds)",
@@ -3819,7 +3819,7 @@ return {
             j_poke_cacturne = {
               name = "Cacturne",
               text = {
-                "{C:hazard}+#1#{} hazard layer",
+                "{C:poke_hazard}+#1#{} hazard layer",
                 "Earn {C:money}$#2#{} when a",
                 "card is destroyed",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -3846,7 +3846,7 @@ return {
                 "earn {C:money}$#3#{} as well",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Guaranteed if you have",
-                "another {X:dragon,C:white}Dragon{} Joker",
+                "another {X:poke_dragon,C:white}Dragon{} Joker",
                 "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
               }
             },
@@ -4050,7 +4050,7 @@ return {
                 "{br:2}ERROR - CONTACT STEAK",
                 "Gains {X:mult,C:white}X#2#{} Mult and destroys a",
                 "random card {C:attention}held{} in hand when",
-                "a {C:tarot}Tarot{} or {C:item}Item{} card is {C:attention}sold",
+                "a {C:tarot}Tarot{} or {C:poke_item}Item{} card is {C:attention}sold",
                 "while opening {C:attention}Booster Packs",
                 "{C:inactive}(Currently {X:mult,C:white} X#3# {C:inactive} Mult)"
               }
@@ -4062,7 +4062,7 @@ return {
                 "opening {C:attention}Booster Packs{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Gains {X:mult,C:white}X#2#{} Mult when a",
-                "{C:tarot}Tarot{} or {C:item}Item{} card is {C:attention}used",
+                "{C:tarot}Tarot{} or {C:poke_item}Item{} card is {C:attention}used",
                 "while opening {C:attention}Booster Packs",
                 "{C:inactive}(Currently {X:mult,C:white} X#3# {C:inactive} Mult)"
               }
@@ -4199,7 +4199,7 @@ return {
                     "Copies ability of",
                     "{C:attention}Joker{} to the right",
                     "if you have {C:attention}#1#+",
-                    "{C:pink}Energized{} Jokers ",
+                    "{C:poke_pink}Energized{} Jokers ",
                     "{C:inactive}(Currently {C:attention}#2#{C:inactive}/#1#){}"
                 }
             },
@@ -4207,7 +4207,7 @@ return {
                 name = 'Jirachi',
                 text = {
                     "Copies ability of {C:attention}Joker{} to the right",
-                    "as if it was {C:pink}Energized{} an extra time",
+                    "as if it was {C:poke_pink}Energized{} an extra time",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -4215,7 +4215,7 @@ return {
                 text = {
                     "If {C:attention}first discard{} has exactly {C:attention}1{} card,",
                     "{C:attention}destroy{} it and create a copy of",
-                    "{C:tarot}Death{}, {C:spectral}Cryptid{}, or {C:item}Metal Coat{}",
+                    "{C:tarot}Death{}, {C:spectral}Cryptid{}, or {C:poke_item}Metal Coat{}",
                     "{C:inactive}(Must have room)",
                 }
             },
@@ -4297,7 +4297,7 @@ return {
                 text = {
                     "{C:attention}Baby{}, {X:mult,C:white} X#1# {} Mult",
                     "Creates a {C:dark_edition}Negative{} copy of",
-                    "{C:item}Miracle Seed{} at end of round",
+                    "{C:poke_item}Miracle Seed{} at end of round",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }
             },
@@ -4383,7 +4383,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Each {X:dark,C:white}Dark{} Joker gives {X:mult,C:white}X#1#{} Mult",
+                  "Each {X:poke_dark,C:white}Dark{} Joker gives {X:mult,C:white}X#1#{} Mult",
                 }
             },
             j_poke_chingling = {
@@ -4428,7 +4428,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}, {X:mult,C:white} X#1# {} Mult",
-                    "Creates a {C:dark_edition}Negative{C:item} Item",
+                    "Creates a {C:dark_edition}Negative{C:poke_item} Item",
                     "at the end of the round",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }
@@ -4465,7 +4465,7 @@ return {
                 text = {
                   "{C:attention}Baby{}, {X:mult,C:white}X#2#{} Mult",
                   "Creates a {C:dark_edition}Negative{} copy of",
-                  "{C:item}The Devil{} at end of round",
+                  "{C:poke_item}The Devil{} at end of round",
                   "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#3#{C:inactive,s:0.8} rounds)",
                 }
             },
@@ -4484,7 +4484,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards give {X:mult,C:white}X#1#{} Mult",
                     "plus {X:mult,C:white}X#2#{} Mult for each",
-                    "{X:metal,C:white}Metal{} Joker you have",
+                    "{X:poke_metal,C:white}Metal{} Joker you have",
                     "{C:inactive}(Currently {X:mult,C:white}X#3#{C:inactive} Mult){}",
                 } 
             },
@@ -4507,7 +4507,7 @@ return {
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:attention}Stone{} cards retrigger an",
                     "additional time for every",
-                    "{C:attention}3{} {X:earth,C:white}Earth{} Jokers you have",
+                    "{C:attention}3{} {X:poke_earth,C:white}Earth{} Jokers you have",
                     "{C:inactive}(Currently #2# retriggers)"
                 } 
             },
@@ -4601,12 +4601,12 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energy Limit",
-                    "{X:mult,C:white} X#2# {} Mult per {C:pink}Energy{}",
+                    "{C:poke_pink}+3{} Energy Limit",
+                    "{X:mult,C:white} X#2# {} Mult per {C:poke_pink}Energy{}",
                     "card used this run",
                     "{br:2}text needs to be here to work",
-                    "Creates an {C:pink}Energy",
-                    "when you use an {C:pink}Energy",
+                    "Creates an {C:poke_pink}Energy",
+                    "when you use an {C:poke_pink}Energy",
                     "{C:inactive}(Must have room)",
                     "{C:inactive}(Currently {X:mult,C:white} X#1# {C:inactive} Mult)"
                 } 
@@ -4646,7 +4646,7 @@ return {
                 text = {
                   "Go up to {C:mult}-$#1#{} in debt",
                   "{br:2.5}ERROR - CONTACT STEAK",
-                  "Create an {C:item}Item{} card if",
+                  "Create an {C:poke_item}Item{} card if",
                   "hand is played while in debt",
                   "{C:inactive,s:0.8}(Must have room)",
                 }
@@ -4655,7 +4655,7 @@ return {
                 name = "Rotom",
                 text = {
                   "{C:green}#1# in #2#{} chance to create",
-                  "an {C:item}Item{} card when any",
+                  "an {C:poke_item}Item{} card when any",
                   "{C:attention}Booster Pack{} is opened",
                   "{C:inactive}(Must have room){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4667,7 +4667,7 @@ return {
                 name = "Rotom (Heat)",
                 text = {
                   "{C:green}#1# in #2#{} chance to create",
-                  "an {C:item}Item{} card when any",
+                  "an {C:poke_item}Item{} card when any",
                   "{C:attention}Booster Pack{} is opened",
                   "{C:inactive}(Must have room){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4681,7 +4681,7 @@ return {
                 name = "Rotom (Wash)",
                 text = {
                   "{C:green}#1# in #2#{} chance to create",
-                  "an {C:item}Item{} card when any",
+                  "an {C:poke_item}Item{} card when any",
                   "{C:attention}Booster Pack{} is opened",
                   "{C:inactive}(Must have room){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4695,7 +4695,7 @@ return {
               name = "Rotom (Frost)",
               text = {
                 "{C:green}#1# in #2#{} chance to create",
-                "an {C:item}Item{} card when any",
+                "an {C:poke_item}Item{} card when any",
                 "{C:attention}Booster Pack{} is opened",
                 "{C:inactive}(Must have room){}",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -4709,7 +4709,7 @@ return {
                 name = "Rotom (Fan)",
                 text = {
                   "{C:green}#1# in #2#{} chance to create",
-                  "an {C:item}Item{} card when any",
+                  "an {C:poke_item}Item{} card when any",
                   "{C:attention}Booster Pack{} is opened",
                   "{C:inactive}(Must have room){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4723,7 +4723,7 @@ return {
                 name = "Rotom (Mow)",
                 text = {
                   "{C:green}#1# in #2#{} chance to create",
-                  "an {C:item}Item{} card when any",
+                  "an {C:poke_item}Item{} card when any",
                   "{C:attention}Booster Pack{} is opened",
                   "{C:inactive}(Must have room){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4821,7 +4821,7 @@ return {
                 text = {
                   "When {C:attention}Blind{} is selected, gain",
                   "{C:purple}+#2# Foresight{} this round for",
-                  "each {X:psychic,C:white}Psychic{} Joker you have",
+                  "each {X:poke_psychic,C:white}Psychic{} Joker you have",
                   "{br:3}ERROR - CONTACT STEAK",
                   "Each {C:attention}Enhanced Foreseen{}",
                   "card gives {X:mult,C:white} X#1# {} Mult",
@@ -4831,7 +4831,7 @@ return {
             j_poke_roggenrola = {
                 name = "Roggenrola",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer",
+                    "{C:poke_hazard}+#1#{} hazard layer",
                     "Each card with {C:attention}no rank{}",
                     "held in hand gives {C:mult}+#2#{} Mult",
                     "{C:inactive,s:0.8}(Evolves after triggering {C:attention,s:0.8}#3#{C:inactive,s:0.8} times)",
@@ -4840,7 +4840,7 @@ return {
             j_poke_boldore = {
                 name = "Boldore",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer",
+                    "{C:poke_hazard}+#1#{} hazard layer",
                     "Each card with {C:attention}no rank{}",
                     "held in hand gives {C:mult}+#2#{} Mult",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Linking Cord{C:inactive,s:0.8})"
@@ -4849,7 +4849,7 @@ return {
             j_poke_gigalith = {
                 name = "Gigalith",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer",
+                    "{C:poke_hazard}+#1#{} hazard layer",
                     "Each card with {C:attention}no rank{}",
                     "held in hand gives {C:mult}+#2#{} Mult",
                     "and retriggers"
@@ -4993,7 +4993,7 @@ return {
             j_poke_ferroseed = {
                 name = "Ferroseed",
                 text = {
-                  "{C:hazard}+#2#{} hazard layer",
+                  "{C:poke_hazard}+#2#{} hazard layer",
                   "{C:attention}Wild{} cards and {C:attention}Hazard{} cards",
                   "are also {C:attention}Steel{} cards",
                   "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#1#{C:inactive,s:0.8} rounds)",
@@ -5002,7 +5002,7 @@ return {
             j_poke_ferrothorn = {
               name = "Ferrothorn",
               text = {
-                "{C:hazard}+#1#{} hazard layer",
+                "{C:poke_hazard}+#1#{} hazard layer",
                 "{C:attention}Wild{} cards and {C:attention}Hazard{} cards",
                 "are also {C:attention}Steel{} cards",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -5095,7 +5095,7 @@ return {
             j_poke_golett = {
                 name = "Golett",
                 text = {
-                  "{C:hazard}+#1#{} hazard layer",
+                  "{C:poke_hazard}+#1#{} hazard layer",
                   "{C:green}#4# in #5#{} chance for cards held",
                   "in hand to give {X:mult,C:white}X#2#{} Mult",
                   "Guaranteed for {C:attention}Hazard{} cards",
@@ -5105,7 +5105,7 @@ return {
             j_poke_golurk = {
                 name = "Golurk",
                 text = {
-                  "{C:hazard}+#1#{} hazard layer",
+                  "{C:poke_hazard}+#1#{} hazard layer",
                   "{C:green}#3# in #4#{} chance for cards held",
                   "in hand to give {X:mult,C:white}X#2#{} Mult", 
                   "Guaranteed for {C:attention}Hazard{} cards",
@@ -5191,7 +5191,7 @@ return {
                 text = {
                     "{C:chips}+#1#{} Chips if played hand contains a {C:attention}Flush{}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Create an {C:pink}Energy{} card if it",
+                    "Create an {C:poke_pink}Energy{} card if it",
                     "also contains a {C:attention}King{} or {C:attention}Queen{}"
                 } 
             },
@@ -5247,7 +5247,7 @@ return {
                   "{C:inactive}(Must have room)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Earn {C:money}$#3#{} when a {C:spectral}Spectral{} card",
-                  "is used and apply a {X:psychic,C:white}Psychic{}",
+                  "is used and apply a {X:poke_psychic,C:white}Psychic{}",
                   "sticker to leftmost {C:attention}Joker"
                 }
             },
@@ -5259,7 +5259,7 @@ return {
                   "{C:inactive}(Must have room)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Earn {C:money}$#3#{} when a {C:spectral}Spectral{} card",
-                  "is used and apply a {X:psychic,C:white}Psychic{}",
+                  "is used and apply a {X:poke_psychic,C:white}Psychic{}",
                   "sticker to leftmost {C:attention}Joker"
                 }
             },
@@ -5271,7 +5271,7 @@ return {
                   "{C:inactive}(Must have room)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Earn {C:money}$#3#{} when a {C:spectral}Spectral{} card",
-                  "is used and apply a {X:psychic,C:white}Psychic{}",
+                  "is used and apply a {X:poke_psychic,C:white}Psychic{}",
                   "sticker to leftmost {C:attention}Joker"
                 }
             },
@@ -5283,7 +5283,7 @@ return {
                   "{C:inactive}(Must have room)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Earn {C:money}$#3#{} when a {C:spectral}Spectral{} card",
-                  "is used and apply a {X:psychic,C:white}Psychic{}",
+                  "is used and apply a {X:poke_psychic,C:white}Psychic{}",
                   "sticker to leftmost {C:attention}Joker"
                 }
             },
@@ -5292,7 +5292,7 @@ return {
                 text = {
                     "{C:mult}+#1#{} Mult",
                     "{C:attention}Tripled{} if you have",
-                    "a {X:lightning, C:black}Lightning{} Joker",
+                    "a {X:poke_lightning, C:black}Lightning{} Joker",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }  
             },
@@ -5300,7 +5300,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult for each",
-                    "{X:lightning, C:black}Lightning{} Joker you have",
+                    "{X:poke_lightning, C:black}Lightning{} Joker you have",
                     "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Thunder Stone{C:inactive,s:0.8})"
                 }  
@@ -5309,7 +5309,7 @@ return {
                 name = 'Vikavolt',
                 text = {
                     "{X:mult,C:white} X#1# {} Mult for each",
-                    "{X:lightning, C:black}Lightning{} Joker you have",
+                    "{X:poke_lightning, C:black}Lightning{} Joker you have",
                     "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
                 }
             },
@@ -5493,7 +5493,7 @@ return {
               name = "Ursaluna",
               text = {
                 "Gains {C:mult}+#2#{} Mult and creates",
-                "an {C:item}Item{} with {C:dark_edition}Foil{}, {C:dark_edition}Holographic{},",
+                "an {C:poke_item}Item{} with {C:dark_edition}Foil{}, {C:dark_edition}Holographic{},",
                 "or {C:dark_edition}Polychrome{} when any",
                 "{C:attention}Booster Pack{} is skipped {C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
@@ -5502,14 +5502,14 @@ return {
             j_poke_tarountula = {
                 name = "Tarountula",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer, {C:attention}+#3#{} hand size",
+                    "{C:poke_hazard}+#1#{} hazard layer, {C:attention}+#3#{} hand size",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }
             },
             j_poke_spidops = {
                 name = "Spidops",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer, {C:attention}+#2#{} hand size",
+                    "{C:poke_hazard}+#1#{} hazard layer, {C:attention}+#2#{} hand size",
                     "Apply a random {C:attention}seal{} to",
                     "every {C:attention}#3#th{} {C:attention}playing card {C:inactive}[#4#]{}",
                     "added to your deck"
@@ -5522,7 +5522,7 @@ return {
                   "Required {C:attention}rank{} rises with each trigger",
                   "{C:inactive,s:0.8}(If rank is highest, it becomes lowest)",
                   "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
-                  "{C:inactive,s:0.8}(Evolves when you have a {X:fire,C:white,s:0.8}Fire{C:inactive,s:0.8} Joker)",
+                  "{C:inactive,s:0.8}(Evolves when you have a {X:poke_fire,C:white,s:0.8}Fire{C:inactive,s:0.8} Joker)",
                 }
             },
             j_poke_dachsbun = {
@@ -5532,7 +5532,7 @@ return {
                   "Required {C:attention}rank{} rises with each trigger",
                   "{br:4}ERROR - CONTACT STEAK",
                   "Increase Chip gain by {C:chips}+2{} for each",
-                  "{X:fire,C:white}Fire{} Joker you have",
+                  "{X:poke_fire,C:white}Fire{} Joker you have",
                   "{C:inactive,s:0.8}(If rank is highest, it becomes lowest)",
                   "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
                 }
@@ -5561,8 +5561,8 @@ return {
                 "{C:attention}every{} Joker and {C:attention}Consumable{}",
                 "at end of round",
                 "{br:2.5}ERROR - CONTACT STEAK",
-                "Adds {C:attention}double{} to {X:grass,C:white}Grass{} Jokers",
-                "and {X:grass,C:white}Grass{} {C:pink}Energy"
+                "Adds {C:attention}double{} to {X:poke_grass,C:white}Grass{} Jokers",
+                "and {X:poke_grass,C:white}Grass{} {C:poke_pink}Energy"
               }
             },
             j_poke_charcadet = {
@@ -5618,7 +5618,7 @@ return {
 						j_poke_rellor = {
 							name = 'Rellor',      
 							text = {
-								"{C:mult}+#1#{} Mult per {C:item}Item{}",
+								"{C:mult}+#1#{} Mult per {C:poke_item}Item{}",
 								"card used this run",
 								"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
 								"{C:inactive,s:0.8}(Evolves after using {C:attention,s:0.8}#3#{C:inactive,s:0.8} Items)",
@@ -5629,10 +5629,10 @@ return {
 							text = {
                 "{C:green}#3# in #4#{} chance to create",
                 "a {C:tarot}Tarot{} card when you",
-                "use an {C:item}Item{} card",
+                "use an {C:poke_item}Item{} card",
                 "{C:inactive}(Must have room){}",
                 "{br:2}ERROR - CONTACT STEAK",
-								"{C:mult}+#1#{} Mult per {C:item}Item{}",
+								"{C:mult}+#1#{} Mult per {C:poke_item}Item{}",
 								"card used this run",
 								"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
 							} 
@@ -5781,7 +5781,7 @@ return {
                 name = 'Rotom Dex',
                 text = {
                     "{C:attention}Booster Packs{} cost {C:money}$1{} less",
-                    "for each different {C:pink}Type",
+                    "for each different {C:poke_pink}Type",
                     "among your Jokers",
                     "{C:inactive}(Currently {C:money}$#1#{C:inactive} less)"
                 } 
@@ -5807,7 +5807,7 @@ return {
             j_poke_jelly_donut = {
                 name = "Jelly Donut",
                 text = {
-                  "Create a {X:colorless,C:white}Colorless{C:pink} Energy",
+                  "Create a {X:poke_colorless,C:white}Colorless{C:poke_pink} Energy",
                   "when {C:attention}Blind{} is selected",
                   "{C:inactive}({C:attention}#1#{C:inactive} rounds remaining){}"
                 }
@@ -5838,8 +5838,8 @@ return {
                 text = {
                   "{C:attention}Type Changer{}",
                   "{br:2}ERROR - CONTACT STEAK",
-                  "Convert the leftmost Joker's {C:pink}Type{}",
-                  "into the rightmost Joker's {C:pink}Type{}",
+                  "Convert the leftmost Joker's {C:poke_pink}Type{}",
+                  "into the rightmost Joker's {C:poke_pink}Type{}",
                   "when {C:attention}Blind{} is selected",
                   "{C:inactive}({C:attention}#1#{C:inactive} rounds remaining){}"
                 }
@@ -5907,7 +5907,7 @@ return {
                 text = {
                   "Transforms into a {C:attention}Basic{} or",
                   "{C:attention}Baby{} Joker after {C:attention}#1#{} rounds",
-                  "that is {C:pink}Energized{} if applicable"
+                  "that is {C:poke_pink}Energized{} if applicable"
                 }
             },
             j_poke_daycare = {
@@ -5931,7 +5931,7 @@ return {
                 name = 'A Billion Lions',
                 text = {
                     "When {C:attention}Blind{} is selected",
-                    "destroy each {C:pink}typed{} Joker you have",
+                    "destroy each {C:poke_pink}typed{} Joker you have",
                     "then gain {X:mult,C:white}X#2#{} Mult for each",
                     "{S:1.1,C:red,E:2}self destructs{} when out of lions",
                     "{C:inactive}(Currently {X:mult,C:white}X#1#{C:inactive} Mult, {C:attention}#3#{C:inactive} lions)"
@@ -5940,7 +5940,7 @@ return {
             j_poke_spiclops = {
                 name = "Spiclops",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer, {C:attention}+#2#{} hand size",
+                    "{C:poke_hazard}+#1#{} hazard layer, {C:attention}+#2#{} hand size",
                     "Apply a random {C:attention}seal{} to",
                     "every {C:attention}#3#th{} {C:attention}playing card {C:inactive}[#4#]{}",
                     "added to your deck",
@@ -6020,9 +6020,9 @@ return {
             sleeve_poke_obituarysleeve_alt = {
                 name = "Obituary Sleeve",
                 text = {
-                    "{C:pink}Pink Seals{} have a {C:green}#1# in #2#{} chance to",
+                    "{C:poke_pink}Pink Seals{} have a {C:green}#1# in #2#{} chance to",
                     "be removed after triggering",
-                    "Jokers create a {C:dark_edition}Negative {C:pink}Energy{} of",
+                    "Jokers create a {C:dark_edition}Negative {C:poke_pink}Energy{} of",
                     "their type when sold or destroyed",
                 },
             },
@@ -6036,7 +6036,7 @@ return {
               name = "Revenant Sleeve",
               text = {
                   "{C:blue}+#1#{} consumable slots",
-                  "{C:pink}Pocket Packs{} will not",
+                  "{C:poke_pink}Pocket Packs{} will not",
                   "appear in the shop",
               },
             },
@@ -6044,15 +6044,15 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
-                    "and are {C:pink}Energized{} once",
+                    "with random {C:poke_pink}Type{} stickers",
+                    "and are {C:poke_pink}Energized{} once",
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "Luminous Sleeve",
                 text = {
                     "Rerolls have a {C:green}#1# in #2#{} chance",
-                    "to spawn a {C:item}Tera Orb",
+                    "to spawn a {C:poke_item}Tera Orb",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -6061,13 +6061,13 @@ return {
                     "Start run with the",
                     "{C:tarot,T:v_crystal_ball}#1#{} voucher",
                     "and {C:attention}2{} copies",
-                    "of {C:item,T:c_poke_twisted_spoon}#2#"
+                    "of {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
 			sleeve_poke_telekineticsleeve_alt = {
                 name = "Telekinetic Sleeve",
                 text = {
-                    "{C:item,T:c_poke_twisted_spoon}#2#s{} in your",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#s{} in your",
                     "{C:attention}consumable{} area give",
                     "{C:blue}+1{} consumable slot",
                 }
@@ -6078,15 +6078,15 @@ return {
                     "Start run with the",
                     "{C:tarot,T:v_poke_energysearch}#1#{} voucher",
                     "and a copy of",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "Amped Sleeve",
                 text = {
                     "Start run with a {C:dark_edition}Negative {C:attention,T:j_poke_jelly_donut}#1#",
-                    "instead of a {C:pink,T:c_poke_double_rainbow_energy}#2#",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{} is no longer half as",
+                    "instead of a {C:poke_pink,T:c_poke_double_rainbow_energy}#2#",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{} is no longer half as",
                     "effective on non-Colorless Jokers",
                 } 
             },
@@ -6156,7 +6156,7 @@ return {
             sleeve_poke_diceysleeve = {
                 name = "Debris Sleeve",
                 text = {
-                    "{C:hazard}+#1#{} hazard layer and limit, {C:attention}+#1#{} hand size",
+                    "{C:poke_hazard}+#1#{} hazard layer and limit, {C:attention}+#1#{} hand size",
                     "At end of each round:",
                     "Earn {C:money}$#4#{} for each {C:attention}Hazard{}",
                     "card in your {C:attention}full deck",
@@ -6190,7 +6190,7 @@ return {
             c_poke_transformation = {
                 name = "Transformation",
                 text = {
-                    "{C:pink}Energizes{} leftmost or selected",
+                    "{C:poke_pink}Energizes{} leftmost or selected",
                     "Pokemon and {C:attention}evolves{} it to",
                     "the highest {C:attention}stage{} if able"
                 },
@@ -6209,7 +6209,7 @@ return {
             c_poke_obituary = {
                 name = "Obituary",
                 text = {
-                    "Adds a {C:pink}Pink{} seal",
+                    "Adds a {C:poke_pink}Pink{} seal",
                     "to {C:attention}1{} selected card",
                 }
             },
@@ -6218,22 +6218,22 @@ return {
                 text = {
                     "Destroys leftmost or selected",
                     "Joker and creates {C:attention}2{} {C:dark_edition}Negative{}",
-                    "{C:pink}Energy{} of that Joker's {C:pink}type{}",
-                    "{C:inactive}(Typeless jokers give {X:colorless,C:white}Colorless{C:inactive})"
+                    "{C:poke_pink}Energy{} of that Joker's {C:poke_pink}type{}",
+                    "{C:inactive}(Typeless jokers give {X:poke_colorless,C:white}Colorless{C:inactive})"
                 },
             },
             c_poke_revenant = {
                 name = "Revenant",
                 text = {
-                    "Adds a {C:item}Silver{} seal",
+                    "Adds a {C:poke_item}Silver{} seal",
                     "to {C:attention}1{} selected card",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "Double Rainbow Energy",
                 text = {
-                    "{C:pink}Energize{} leftmost or selected",
-                    "Joker of any {C:pink}Type{} {C:red}t{C:attention}w{C:green}i{C:blue}c{C:purple}e{}",
+                    "{C:poke_pink}Energize{} leftmost or selected",
+                    "Joker of any {C:poke_pink}Type{} {C:red}t{C:attention}w{C:green}i{C:blue}c{C:purple}e{}",
                     "Earn no interest this round",
                     "{C:inactive}(Max of {C:attention}#1#{C:inactive} increases per Joker)",
                 },
@@ -6299,7 +6299,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Pocket Tag",
                 text = {
-                    "Gives a free {C:pink}Mega Pocket Pack",
+                    "Gives a free {C:poke_pink}Mega Pocket Pack",
                     "{C:green}#1#%{} chance pack contains",
                     "a {C:attention}Mega Stone{} on {C:attention}Ante 5+{}",
                     "{C:inactive,s:0.8}(Odds can't be increased){}",
@@ -6310,7 +6310,7 @@ return {
                 text = {
                     "Next base edition shop",
                     "Joker is free and",
-                    "becomes {C:colorless}Shiny{}",
+                    "becomes {C:poke_colorless}Shiny{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -6324,7 +6324,7 @@ return {
                 name = "Safari Tag",
                 text = {
                     "Shop has a free",
-                    "{C:safari}Safari{} Joker",
+                    "{C:poke_safari}Safari{} Joker",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -6362,13 +6362,13 @@ return {
             v_poke_energysearch = {
                 name = "Energy Search",
                 text = {
-                    "{C:pink}+2{} Energy Limit"
+                    "{C:poke_pink}+2{} Energy Limit"
                 },
             },
             v_poke_energyresearch = {
                 name = "Energy Research",
                 text = {
-                    "{C:pink}+3{} Energy Limit"
+                    "{C:poke_pink}+3{} Energy Limit"
                 },
             },
             v_poke_goodrod = {
@@ -6381,7 +6381,7 @@ return {
             v_poke_superrod = {
                 name = "Super Rod",
                 text = {
-                    "You can {C:pink}Save{} cards",
+                    "You can {C:poke_pink}Save{} cards",
                     "from all {C:attention}consumable{} packs",
                 },
             },
@@ -6391,80 +6391,80 @@ return {
             Grass = {
                 name = "Type",
                 text = {
-                  "{X:grass,C:white}Grass{}",
+                  "{X:poke_grass,C:white}Grass{}",
                 }
             },
             Fire = {
                 name = "Type",
                 text = {
-                  "{X:fire,C:white}Fire{}",
+                  "{X:poke_fire,C:white}Fire{}",
                 }
             },
             Water = {
                 name = "Type",
                 text = {
-                  "{X:water,C:white}Water{}",
+                  "{X:poke_water,C:white}Water{}",
                 }
             },
             Lightning = {
                 name = "Type",
                 text = {
-                  "{X:lightning,C:black}Lightning{}",
+                  "{X:poke_lightning,C:black}Lightning{}",
                 }
             },
             Psychic = {
                 name = "Type",
                 text = {
-                  "{X:psychic,C:white}Psychic{}",
+                  "{X:poke_psychic,C:white}Psychic{}",
                 }
             },
             Fighting = {
                 name = "Type",
                 text = {
-                  "{X:fighting,C:white}Fighting{}",
+                  "{X:poke_fighting,C:white}Fighting{}",
                 }
             },
             Colorless = {
                 name = "Type",
                 text = {
-                  "{X:colorless,C:white}Colorless{}",
+                  "{X:poke_colorless,C:white}Colorless{}",
                 }
             },
             Dark = {
                 name = "Type",
                 text = {
-                  "{X:dark,C:white}Dark{}",
+                  "{X:poke_dark,C:white}Dark{}",
                 }
             },
             Metal = {
                 name = "Type",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Type",
                 text = {
-                  "{X:fairy,C:white}Fairy{}",
+                  "{X:poke_fairy,C:white}Fairy{}",
                 }
             },
             Dragon = {
                 name = "Type",
                 text = {
-                  "{X:dragon,C:white}Dragon{}",
+                  "{X:poke_dragon,C:white}Dragon{}",
                 }
             },
             Earth = {
                 name = "Type",
                 text = {
-                  "{X:earth,C:white}Earth{}",
+                  "{X:poke_earth,C:white}Earth{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "Type",
                 text = {
-                  "{X:bird,C:white}Bird{}",
+                  "{X:poke_bird,C:white}Bird{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -6716,7 +6716,7 @@ return {
                 name = "Presents",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}Item{} card",
+                    "{C:green}30%{} - {C:poke_item}Item{} card",
                     "{C:green}20%{} - {C:attention}Coupon Tag",
                     "{C:green}15%{} - {C:dark_edition}Polychrome{} {C:attention}Gift Card",
                 }
@@ -6733,9 +6733,9 @@ return {
             dril_treasure = {
                 name = "Treasure",
                 text = {
-                    "{C:green}30%{} - {C:attention}Evolution {C:item}Stone   ",
+                    "{C:green}30%{} - {C:attention}Evolution {C:poke_item}Stone   ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}2 Evolution {C:item}Stones",
+                    "{C:green}20%{} - {C:attention}2 Evolution {C:poke_item}Stones",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}5%{} - {C:money}$20{}             ",
                 }
@@ -6743,9 +6743,9 @@ return {
             exdril_treasure = {
                 name = "Treasure",
                 text = {
-                    "{C:green}30%{} - {C:attention}Evolution {C:item}Stone   ",
+                    "{C:green}30%{} - {C:attention}Evolution {C:poke_item}Stone   ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}2 Evolution {C:item}Stones",
+                    "{C:green}20%{} - {C:attention}2 Evolution {C:poke_item}Stones",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}4%{} - {C:money}$20{}             ",
                     "{C:green}1%{} - {C:attention}Mega Stone     ",
@@ -6754,10 +6754,10 @@ return {
             pickup = {
               name = "Pickup",
               text = {
-                "{C:green}34%{} - {C:item}Item{}",
-                "{C:green}25%{} - {C:item}Evolution Item",
-                "{C:green}20%{} - {C:item}Leftovers",
-                "{C:green}20%{} - {C:item}Twisted Spoon",
+                "{C:green}34%{} - {C:poke_item}Item{}",
+                "{C:green}25%{} - {C:poke_item}Evolution Item",
+                "{C:green}20%{} - {C:poke_item}Leftovers",
+                "{C:green}20%{} - {C:poke_item}Twisted Spoon",
                 "{C:green}1%{} - {C:spectral}Transformation",
               }
             },
@@ -6817,14 +6817,14 @@ return {
             eeveelution = {
                 name = "Evolutions",
                 text = {
-                    "{C:attention}Water Stone{} - {X:water,C:white}Vaporeon{}",
-                    "{C:attention}Thunder Stone{} - {X:lightning,C:black}Jolteon{}",
-                    "{C:attention}Fire Stone{} - {X:fire,C:white}Flareon{}",
-                    "{C:attention}Sun Stone{} - {X:psychic,C:white}Espeon{}",
-                    "{C:attention}Moon Stone{} - {X:dark,C:white}Umbreon{}",
-                    "{C:attention}Leaf Stone{} - {X:grass,C:white}Leafeon{}",
-                    "{C:attention}Ice Stone{} - {X:water,C:white}Glaceon{}",
-                    "{C:attention}Shiny Stone{} - {X:fairy,C:white}Sylveon{}"
+                    "{C:attention}Water Stone{} - {X:poke_water,C:white}Vaporeon{}",
+                    "{C:attention}Thunder Stone{} - {X:poke_lightning,C:black}Jolteon{}",
+                    "{C:attention}Fire Stone{} - {X:poke_fire,C:white}Flareon{}",
+                    "{C:attention}Sun Stone{} - {X:poke_psychic,C:white}Espeon{}",
+                    "{C:attention}Moon Stone{} - {X:poke_dark,C:white}Umbreon{}",
+                    "{C:attention}Leaf Stone{} - {X:poke_grass,C:white}Leafeon{}",
+                    "{C:attention}Ice Stone{} - {X:poke_water,C:white}Glaceon{}",
+                    "{C:attention}Shiny Stone{} - {X:poke_fairy,C:white}Sylveon{}"
                 }
             },
             poke_egg_tip = {
@@ -6884,14 +6884,14 @@ return {
             unlimited_energy_tooltip = {
               name = "Unlimited Energy",
               text = {
-                "Jokers can have {C:pink}Energy{} used",
+                "Jokers can have {C:poke_pink}Energy{} used",
                 "on them any number of times"
               }
             },
             precise_energy_tooltip = {
                 name = "Precise Energy Scaling",
                 text = {
-                    "{s:0.8}Use {C:attention,s:0.8}decimals{} for all values when applying {C:pink,s:0.8}Energy{}{s:0.8} bonus{}",
+                    "{s:0.8}Use {C:attention,s:0.8}decimals{} for all values when applying {C:poke_pink,s:0.8}Energy{}{s:0.8} bonus{}",
                     "{s:0.8}With this option {C:attention,s:0.8}off{}{s:0.8} the following will occur for the bonus:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Mult - Uses Decimals",
                     "{C:attenion}2. {s:0.8}Flat {C:mult,s:0.8}Mult{}{s:0.8} and {C:chips,s:0.8}Chips{}{s:0.8} - Rounds up to nearest whole number",
@@ -7079,7 +7079,7 @@ return {
             allowpokeballs_tooltip = {
               name = "Allow Pokeballs",
               text = {
-                "Allow Pokeball {C:item}items{} to appear",
+                "Allow Pokeball {C:poke_item}items{} to appear",
               }
             },
             pokemaster_tooltip = {
@@ -7133,8 +7133,8 @@ return {
             poke_pink_seal_seal = {
                 name = "Pink Seal",
                 text = {
-                    "Creates an {C:pink}Energy{} card that",
-                    "matches an owned Joker's {C:pink}Type",
+                    "Creates an {C:poke_pink}Energy{} card that",
+                    "matches an owned Joker's {C:poke_pink}Type",
                     "if scored in {C:attention}first hand{} of round",
                     "{C:inactive}(Must have room){}"
                 },
@@ -7144,7 +7144,7 @@ return {
             poke_silver_seal = {
                 name = "Silver Seal",
                 text = {
-                  "Creates an {C:item}Item{} card",
+                  "Creates an {C:poke_item}Item{} card",
                   "and is {C:attention}discarded{} if {C:attention}held{}",
                   "in hand when cards are scored"
                 }
@@ -7164,73 +7164,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Grass{}"
+                    "{X:poke_grass,C:white}Grass{}"
                 } 
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Fire{}"
+                    "{X:poke_fire,C:white}Fire{}"
                 } 
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Water{}"
+                    "{X:poke_water,C:white}Water{}"
                 } 
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Lightning{}"
+                    "{X:poke_lightning,C:white}Lightning{}"
                 } 
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psychic{}"
+                    "{X:poke_psychic,C:white}Psychic{}"
                 } 
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Fighting{}"
+                    "{X:poke_fighting,C:white}Fighting{}"
                 } 
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Colorless{}"
+                    "{X:poke_colorless,C:white}Colorless{}"
                 } 
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Dark{}"
+                    "{X:poke_dark,C:white}Dark{}"
                 } 
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fairy{}"
+                    "{X:poke_fairy,C:white}Fairy{}"
                 } 
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 } 
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Earth{}"
+                    "{X:poke_earth,C:white}Earth{}"
                 } 
             },
             --]]
@@ -7258,64 +7258,64 @@ return {
                 name = "Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "Jumbo Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "Mega Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "Jumbo Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "Mega Pocket Pack",
                 text = {
                     "Choose {C:attention}#1#{} from among",
-                    "{C:attention}#2#{} {C:item}Item{} Cards and",
-                    "{C:attention}#3#{} {C:pink}Energy{} Card",
+                    "{C:attention}#2#{} {C:poke_item}Item{} Cards and",
+                    "{C:attention}#3#{} {C:poke_pink}Energy{} Card",
                 },
             },
             p_poke_pokepack_wish_pack = {

--- a/localization/es_419.lua
+++ b/localization/es_419.lua
@@ -18,7 +18,7 @@ return {
                     "Comienza la partida con",
 					"el vale {C:tarot,T:v_crystal_ball}#1#{}",
 					"y {C:attention}2{} copias",
-					"de {C:item,T:c_poke_twisted_spoon}#2#"
+					"de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             b_poke_obituarydeck = {
@@ -38,8 +38,8 @@ return {
                 name = "Baraja luminosa",
                 text = {
                     "Todos los comodines son",
-					"creados con {C:pink}1 energía{} y",
-					"con un sticker de un {C:pink}Tipo{} al azar"
+					"creados con {C:poke_pink}1 energía{} y",
+					"con un sticker de un {C:poke_pink}Tipo{} al azar"
                 }
             },
             b_poke_ampeddeck = {
@@ -48,7 +48,7 @@ return {
                     "Comienza la partida con",
 					"el vale {C:tarot,T:v_poke_energysearch}#1#{}",
 					"y una copia de",
-					"{C:pink,T:c_poke_double_rainbow_energy}#2#"
+					"{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
 			b_poke_futuredeck = {
@@ -86,10 +86,10 @@ return {
             b_poke_diceydeck = {
                 name = "Baraja tramposa",
                 text = {
-                    "{C:hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
+                    "{C:poke_hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
                     "Al final de cada ronda:",
                     "Gana {C:money}#4# ${} por cada carta",
-                    "{C:hazard}trampa{} en tu {C:attention}baraja completa",
+                    "{C:poke_hazard}trampa{} en tu {C:attention}baraja completa",
                     "No ganas {C:attention}intereses"
                 } 
             },
@@ -289,7 +289,7 @@ return {
                     "Es {C:attention}reusable{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "La {C:green,E:1,S:1.1}probabilidad{} de que",
-					"las cartas {C:hazard}trampa{}",
+					"las cartas {C:poke_hazard}trampa{}",
 					"se destruyan se vuelve {C:attention}0",
 					"hasta el final de la ronda",
                     "{C:inactive}(Usable una vez por ronda)",
@@ -299,17 +299,17 @@ return {
                 name = "Orbe Teracristal",
                 text = {
                     "{C:attention}Cambia Tipo:{} {B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.9}({C:pink,s:0.9}El tipo{C:inactive,s:0.9} cambia con cada descarte){}",
+                    "{C:inactive,s:0.9}({C:poke_pink,s:0.9}El tipo{C:inactive,s:0.9} cambia con cada descarte){}",
 					"{br:2}ERROR - CONTACT STEAK",
-					"{C:pink}Energiza{} al comodín más",
+					"{C:poke_pink}Energiza{} al comodín más",
 					"a la izquierda o seleccionado",
-                    "si ya es de {C:pink}tipo{} {B:1,V:2}#1#{}",
+                    "si ya es de {C:poke_pink}tipo{} {B:1,V:2}#1#{}",
                 },
             },
             c_poke_metalcoat = {
                 name = "Revestimiento Metálico",
                 text = {
-                    "{C:attention}Cambia Tipo:{} {X:metal,C:white}Metal{}",
+                    "{C:attention}Cambia Tipo:{} {X:poke_metal,C:white}Metal{}",
 					"{br:2}ERROR - CONTACT STEAK",
 					"Crea una copia con","mejora de {C:attention}carta de acero{}","de {C:attention}1{} carta seleccionada",
                 },
@@ -317,10 +317,10 @@ return {
             c_poke_dragonscale = {
                 name = "Escama Dragón",
                 text = {
-                    "{C:attention}Cambia Tipo:{} {X:dragon,C:white}Dragón{}",
+                    "{C:attention}Cambia Tipo:{} {X:poke_dragon,C:white}Dragón{}",
 					"{br:2}ERROR - CONTACT STEAK",
 					"Crea hasta {C:attention}3{}",
-					"{C:item}objetos{} o {C:pink}energías{} al azar",
+					"{C:poke_item}objetos{} o {C:poke_pink}energías{} al azar",
 					"{C:inactive}(Debe haber espacio){}"
                 },
             },
@@ -373,8 +373,8 @@ return {
             c_poke_twisted_spoon = {
                 name = "Cuchara Torcida",
                 text = {
-                    "Genera la última","carta de {C:item}objeto{} o {C:pink}energía{}",
-					"usada en esta partida","a excepción de {s:0.8,C:item}Cuchara Torcida,","{s:0.8,C:item}Reusables y Zumo de Bayas{s:0.8}"
+                    "Genera la última","carta de {C:poke_item}objeto{} o {C:poke_pink}energía{}",
+					"usada en esta partida","a excepción de {s:0.8,C:poke_item}Cuchara Torcida,","{s:0.8,C:poke_item}Reusables y Zumo de Bayas{s:0.8}"
                 }
             },
             c_poke_prismscale = {
@@ -420,7 +420,7 @@ return {
 					"Mejora {C:attention}1{} carta seleccionada a",
 					"{C:attention}carta de piedra{} con {C:chips}+#2#{} fichas",
 					"extra por cada comodín de",
-					"tipo {X:earth,C:white}Tierra{} que tengas"
+					"tipo {X:poke_earth,C:white}Tierra{} que tengas"
                 }
             },
             c_poke_miracleseed = {
@@ -439,7 +439,7 @@ return {
             c_poke_berry_juice_energy = {
                 name = "Zumo de Baya Energizado",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado de cualquier {C:pink}tipo{}","{C:inactive}(Máximo de {C:attention}#1# {C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado de cualquier {C:poke_pink}tipo{}","{C:inactive}(Máximo de {C:attention}#1# {C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_berry_juice_spectral = {
@@ -457,7 +457,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "Zumo de Baya Objetizado",
                 text = {
-                    "Crea una {C:item}Cuchara Torcida{}",
+                    "Crea una {C:poke_item}Cuchara Torcida{}",
 					"{C:green}#1# en #2#{} probabilidades de",
 					"crear {C:attention}2{} en su lugar","{C:inactive}(Debe haber espacio){}"
                 },
@@ -478,7 +478,7 @@ return {
             c_poke_berry_juice_mystery = {
                 name = "Zumo de Baya Misterioso",
                 text = {
-                    "Crea un {C:item}Zumo de Baya{} al azar"
+                    "Crea un {C:poke_item}Zumo de Baya{} al azar"
                 }
             },
             c_poke_heartscale = {
@@ -548,74 +548,74 @@ return {
             c_poke_grass_energy = {
                 name = "Energía Planta",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:grass,C:white}Planta{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_grass,C:white}Planta{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fire_energy = {
                 name = "Energía Fuego",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fire,C:white}Fuego{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fire,C:white}Fuego{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_water_energy = {
                 name = "Energía Agua",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:water,C:white}Agua{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_water,C:white}Agua{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_lightning_energy = {
                 name = "Energía Rayo",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:lightning,C:black}Rayo{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_lightning,C:black}Rayo{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_psychic_energy = {
                 name = "Energía Psíquica",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:psychic,C:white}Psíquico{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_psychic,C:white}Psíquico{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fighting_energy = {
                 name = "Energía Lucha",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fighting,C:white}Lucha{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fighting,C:white}Lucha{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_colorless_energy = {
                 name = "Energía Incolora",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:colorless,C:white}Incoloro{} disponible","Tiene la mitad de efectividad con","comodines que no son de tipo {X:colorless,C:white}Incoloro{}","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)"
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_colorless,C:white}Incoloro{} disponible","Tiene la mitad de efectividad con","comodines que no son de tipo {X:poke_colorless,C:white}Incoloro{}","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)"
                 },
             },
             c_poke_darkness_energy = {
                 name = "Energía Oscura",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:dark,C:white}Oscuro{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_dark,C:white}Oscuro{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_metal_energy = {
                 name = "Energía Metal",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:Metal,C:white}Metal{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:Metal,C:white}Metal{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fairy_energy = {
                 name = "Energía Hada",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fairy,C:white}Hada{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fairy,C:white}Hada{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             --Dragon deez
             c_poke_dragon_energy = {
                 name = "Energía Dragón",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:dragon,C:white}Dragón{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_dragon,C:white}Dragón{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_earth_energy = {
                 name = "Energía Tierra",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:earth,C:white}Tierra{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_earth,C:white}Tierra{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_emergy = {
@@ -1296,7 +1296,7 @@ return {
                 name = "Abra",
                 text = {
                     "{C:green}#1# en #2#{} probabilidades de crear una carta",
-					"de {C:item}objeto o {C:tarot}tarot{} si la {C:attention}mano de póker{}",
+					"de {C:poke_item}objeto o {C:tarot}tarot{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
 					"{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
                 } 
@@ -1305,7 +1305,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# en #2#{} probabilidades de crear una carta de",
-					"{C:tarot}tarot{} o una {C:item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
+					"{C:tarot}tarot{} o una {C:poke_item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
 					"{C:inactive}(Evoluciona con un {C:attention}Cordón Unión{C:inactive})"
                 } 
@@ -1315,7 +1315,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} ranura de consumible",
 					"{C:green}#1# en #2#{} probabilidades de crear {C:attention}El loco{} o",
-					"una {C:item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
+					"una {C:poke_item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
                 } 
             },
@@ -1325,7 +1325,7 @@ return {
                     "{C:attention}+#3#{} ranura de consumible",
 					"Todos los {C:attention}consumibles{} que",
 					"tienes otorgan {X:mult,C:white}X#1#{} multi",
-					"Las {C:item}Cucharas Torcidas{}","otorgan {X:mult,C:white}X#2#{} multi",
+					"Las {C:poke_item}Cucharas Torcidas{}","otorgan {X:mult,C:white}X#2#{} multi",
                 } 
             },
             j_poke_machop = {
@@ -1485,7 +1485,7 @@ return {
                 text = {
                     "Las {C:attention}cartas de acero{} jugadas",
 					"otorgan {X:mult,C:white}X#1#{} multi más {X:mult,C:white}X#2#{} multi por",
-					"cada comodín tipo {X:metal,C:white}Metal{} adyacente",
+					"cada comodín tipo {X:poke_metal,C:white}Metal{} adyacente",
 					"{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi)",
 					"{C:inactive}(Evoluciona con una {C:attention}Piedra Trueno{C:inactive})"
                 } 
@@ -1493,7 +1493,7 @@ return {
             j_poke_farfetchd = {
                 name = 'Farfetch\'d',      
                 text = {
-                    "{C:attention}Equipado con{} {C:item}Puerro{}",
+                    "{C:attention}Equipado con{} {C:poke_item}Puerro{}",
 					"{C:green}#2# en #3#{} probabilidades de ganar {C:money}#1# $",
 					"cuando un {C:attention}consumible{} es usado",
 					"{C:money}${} garantizado cuando se usan {C:attention}Puerros{}",
@@ -1616,7 +1616,7 @@ return {
                     "Cuando una carta que no es",
                     "{C:attention}de piedra{} es destruida, agrega una ",
                     "{C:attention}carta de piedra{} a tu {C:attention}baraja",
-					"{C:inactive}(Evoluciona con un sticker {C:metal}Metal{C:inactive})"
+					"{C:inactive}(Evoluciona con un sticker {C:poke_metal}Metal{C:inactive})"
                 } 
             },
             j_poke_drowzee = {
@@ -1690,7 +1690,7 @@ return {
             j_poke_cubone = {
                 name = 'Cubone',
                 text = {
-                    "{C:attention}Equipado con{} {C:item}Hueso Grueso{}",
+                    "{C:attention}Equipado con{} {C:poke_item}Hueso Grueso{}",
 					"Otorga {C:mult}+#1#{} multi por",
 					"cada {C:attention}consumible{} que tengas",
 					"{C:inactive,s:0.8}(Los {C:attention,s:0.8}Huesos Gruesos{C:inactive,s:0.8} cuentan doble){}",
@@ -1824,7 +1824,7 @@ return {
                     "Obtiene {C:mult}+#2#{} multi por cada {C:attention}6{} jugado",
 					"Se duplica si un {C:attention}rey{} está en tu mano",
 					"{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
-					"{C:inactive}(Evoluciona con un sticker {C:dragon}Dragón{C:inactive})"
+					"{C:inactive}(Evoluciona con un sticker {C:poke_dragon}Dragón{C:inactive})"
                 } 
             },
             j_poke_goldeen = {
@@ -1873,7 +1873,7 @@ return {
 					"Obtiene edición {C:dark_edition}laminado{}, {C:dark_edition}holográfico{}, o",
 					"{C:dark_edition}polícromo{} si era {C:rare}Rara{} o superior",
 					"{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
-					"{C:inactive}(Evoluciona con un sticker {C:metal}Metal","{C:inactive}o una {C:attention}Piedra Dura{C:inactive})",
+					"{C:inactive}(Evoluciona con un sticker {C:poke_metal}Metal","{C:inactive}o una {C:attention}Piedra Dura{C:inactive})",
                 } 
             },
             j_poke_jynx = {
@@ -1981,7 +1981,7 @@ return {
 					"{C:attention}Volátil a la derecha{}",
                     "{C:attention}Se transforma{} en el comodín más",
 					"a la izquierda con {C:attention}perecedero{}",
-					"y un sticker {C:colorless}Incoloro{}",
+					"y un sticker {C:poke_colorless}Incoloro{}",
 					"al final de la tienda","{C:inactive,s:0.9}(Excluye Dittos)",
                 } 
             },
@@ -2023,10 +2023,10 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} límite de energía",
-					"Crea una carta de {C:pink}energía{} cuando",
+                    "{C:poke_pink}+1{} límite de energía",
+					"Crea una carta de {C:poke_pink}energía{} cuando",
 					"abres un {C:attention}paquete potenciador{}",
-					"{C:inactive}(Evoluciona con una {C:metal}Mejora{C:inactive})",
+					"{C:inactive}(Evoluciona con una {C:poke_metal}Mejora{C:inactive})",
                 } 
             },
             j_poke_omanyte = {
@@ -2035,7 +2035,7 @@ return {
                     "{C:attention}#1#s Ancestrales{}",
 					"{X:attention,C:white}1+{} : Crea una carta de {C:tarot}tarot{}",
 					"{X:attention,C:white}2+{} : Gana {C:money}#2# ${}",
-					"{X:attention,C:white}3+{} : Crea un {C:item}objeto{}",
+					"{X:attention,C:white}3+{} : Crea un {C:poke_item}objeto{}",
 					"{C:inactive}(Debe haber espacio)",
                     "{C:inactive,s:0.9}(Activa la habilidad de {X:attention,C:white,s:0.9}3+{C:inactive,s:0.9}",
 					"{C:attention,s:0.9}#3#{C:inactive,s:0.9} veces para evolucionar)",
@@ -2047,7 +2047,7 @@ return {
                     "{C:attention}#1#s Ancestrales{}",
 					"{X:attention,C:white}1+{} : Crea una carta de {C:tarot}tarot{}",
 					"{X:attention,C:white}2+{} : Gana {C:money}#2# ${}",
-					"{X:attention,C:white}3+{} : Crea un {C:item}objeto{}",
+					"{X:attention,C:white}3+{} : Crea un {C:poke_item}objeto{}",
 					"{C:inactive}(Debe haber espacio)",
 					"{X:attention,C:white}4+{} : Crea una {C:attention}etiqueta{}",
 					"{C:inactive,s:0.8}(una vez por ronda) {C:inactive}#3#{}",
@@ -2102,7 +2102,7 @@ return {
             j_poke_snorlax = {
                 name = 'Snorlax',
                 text = {
-                    "{C:attention}Equipado con {C:item}Restos{}",
+                    "{C:attention}Equipado con {C:poke_item}Restos{}",
 					"Al final de la ronda obtiene {X:mult,C:white}X#1#{} multi",
 					"por cada {C:attention}Restos{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white} X#2# {C:inactive} multi)"
@@ -2167,7 +2167,7 @@ return {
                 text = {
                     "Cuando la {C:attention}ciega jefe{} es derrotada, destruye",
 					"al {C:attention}comodín{} más a la izquierda y crea",
-					"una {C:attention}copia{} {C:dark_edition}polícroma{} y {C:pink}energizada{}",
+					"una {C:attention}copia{} {C:dark_edition}polícroma{} y {C:poke_pink}energizada{}",
 					"{br:3}ERROR - CONTACT STEAK",
 					"Los comodines {C:dark_edition}polícromos{} otorgan {X:mult,C:white} X#1# {} multi",
 					"{C:inactive}(No puede destruirse a sí mismo)",
@@ -2182,12 +2182,12 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la izquierda",
+                    "{C:poke_pink}Energiza{} al comodín más a la izquierda",
 					"{C:attention}dos veces{} al final de la tienda",
 					"{br:2}ERROR - CONTACT STEAK",
-					"{C:pink}+1{} límite de energía cuando",
+					"{C:poke_pink}+1{} límite de energía cuando",
 					"la {C:attention}ciega jefe{} es derrotada",
-					"{C:inactive}(No puede {C:pink}energizarse{C:inactive} a sí mismo)",
+					"{C:inactive}(No puede {C:poke_pink}energizarse{C:inactive} a sí mismo)",
                 } 
             },
             j_poke_mew = {
@@ -2195,7 +2195,7 @@ return {
                 text = {
                     "Al final de la {C:attention}tienda{},",
 					"crea una carta de {C:tarot}tarot{},",
-					"{C:spectral}espectral{} o un {C:item}objeto{} {C:dark_edition}negativo{}",
+					"{C:spectral}espectral{} o un {C:poke_item}objeto{} {C:dark_edition}negativo{}",
 					"{br:3}ERROR - CONTACT STEAK",
 					"{C:green}#1#%{} probabilidades de crear un",
 					"comodín {C:dark_edition}negativo{} {C:attention}en su lugar{}",
@@ -2385,8 +2385,8 @@ return {
                   "Otorga {C:chips}+#1#{} fichas y gana {C:money}#2# ${}",
 				  "si la mano jugada contiene un {C:attention}Par",
 				  "{br:3}ERROR - CONTACT STEAK",
-				  "{C:chips}+#3#{} fichas extra por cada comodín tipo {X:water,C:white}Agua{}",
-				  "{C:money}#4# ${} extra por cada comodín tipo {X:lightning,C:black}Rayo{}",
+				  "{C:chips}+#3#{} fichas extra por cada comodín tipo {X:poke_water,C:white}Agua{}",
+				  "{C:money}#4# ${} extra por cada comodín tipo {X:poke_lightning,C:black}Rayo{}",
 				  "{C:inactive}(Actual {C:chips}+#6#{C:inactive} fichas y {C:money}#5# ${C:inactive})"
                 }
             },
@@ -2522,11 +2522,11 @@ return {
             j_poke_weird_tree = {
                 name = "Árbol extraño",
                 text = {
-                  "{C:attention}Cambia Tipo: {X:grass,C:white}Planta{}",
+                  "{C:attention}Cambia Tipo: {X:poke_grass,C:white}Planta{}",
 				  "{C:}Se transforma{} al final de la",
 				  "ronda si este comodín no es",
-				  "de tipo {X:grass,C:white}Planta{} o tienes un",
-				  "comodín tipo {X:water,C:white}Agua{}"
+				  "de tipo {X:poke_grass,C:white}Planta{} o tienes un",
+				  "comodín tipo {X:poke_water,C:white}Agua{}"
                 }
             },
             j_poke_bellossom = {
@@ -2543,7 +2543,7 @@ return {
                 text = {
                     "Reactiva la primera carta {V:1}#2#{} que anota",
                     "y luego la reactiva una vez por cada",
-                    "comodín tipo {X:water,C:white}Agua{} que tengas",
+                    "comodín tipo {X:poke_water,C:white}Agua{} que tengas",
                     "El palo rota en orden después de jugar",
                     "{C:inactive,s:0.8}(#3#, #4#, #5#, #6#)"
                 } 
@@ -2654,7 +2654,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:mult,C:white} X#1# {} multi por cada comodín",
-				"tipo {X:dark,C:white}Oscuro{} que tengas",
+				"tipo {X:poke_dark,C:white}Oscuro{} que tengas",
 				"{C:inactive}(Actual {X:mult,C:white} X#2#{C:inactive} multi)",
 				"{C:inactive}(Evoluciona con una {C:attention}Piedra Noche{C:inactive})"
               }
@@ -2763,7 +2763,7 @@ return {
                 name = "Mega Steelix",
                 text = {
                     "Las {C:attention}cartas de piedra{} cuentan como",
-					"{C:attention}cartas de acero{} y {C:hazard}trampa",
+					"{C:attention}cartas de acero{} y {C:poke_hazard}trampa",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Reactiva todas las cartas",
                     "{C:attention}en tu mano{} por cada {C:attention}#1#{} cartas",
@@ -2785,7 +2785,7 @@ return {
             j_poke_qwilfish = {
                 name = 'Qwilfish',
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Obtiene {C:chips}+#2#{} fichas cuando",
                     "una carta {C:attention}mejorada{}",
                     "es destruida",
@@ -2815,8 +2815,8 @@ return {
                 text = {
                   "Cuando se selecciona la {C:attention}ciega{},",
 				  "destruye el {C:attention}consumible{} más a la",
-				  "izquierda y crea un {C:item}Zumo de Baya{}",
-				  "{C:inactive}(No puede destruir {C:item}Zumos de Baya{C:inactive})"
+				  "izquierda y crea un {C:poke_item}Zumo de Baya{}",
+				  "{C:inactive}(No puede destruir {C:poke_item}Zumos de Baya{C:inactive})"
                 }
             },
             j_poke_sneasel = {
@@ -2841,7 +2841,7 @@ return {
             j_poke_ursaring = {
               name = "Ursaring",
               text = {
-                "Obtiene {C:mult}+#2#{} multi y crea un {C:item}objeto{}",
+                "Obtiene {C:mult}+#2#{} multi y crea un {C:poke_item}objeto{}",
 				"cuando cualquier {C:attention}paquete",
 				"{C:attention}potenciador{} es omitido",
 				"{C:inactive}(Debe haber espacio)",
@@ -2915,8 +2915,8 @@ return {
               text = {
                 "Cuando se selecciona la {C:attention}ciega{},",
 				"obtiene {C:mult}+#1#{} multi por cada comodín",
-				"tipo {X:water,C:white}Agua{} que tengas y crea",
-				"un Pokémon tipo {X:water,C:white}Agua{} {C:attention}básico{}",
+				"tipo {X:poke_water,C:white}Agua{} que tengas y crea",
+				"un Pokémon tipo {X:poke_water,C:white}Agua{} {C:attention}básico{}",
                 "{C:inactive}(Debe haber espacio)",
                 "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
               }
@@ -2959,9 +2959,9 @@ return {
             j_poke_skarmory = {
                 name = 'Skarmory',
                 text = {
-					"{C:hazard}+#1# Nivel y límite de trampas",
+					"{C:poke_hazard}+#1# Nivel y límite de trampas",
                     "{X:mult,C:white}X#2#{} multi por cada",
-                    "carta {C:hazard}trampa{} o {C:attention}de acero{}",
+                    "carta {C:poke_hazard}trampa{} o {C:attention}de acero{}",
                     "{C:attention}en tu mano{}",
                     "{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi)",
                 }
@@ -2998,11 +2998,11 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} límite de energía",
-					"Crea una carta de {C:pink}energía{} del mismo",
-					"{C:pink}tipo{} del comodín más a la izquierda",
+                    "{C:poke_pink}+2{} límite de energía",
+					"Crea una carta de {C:poke_pink}energía{} del mismo",
+					"{C:poke_pink}tipo{} del comodín más a la izquierda",
 					"cuando abres un {C:attention}paquete potenciador{}",
-					"{C:inactive}(Evoluciona con un {C:metal}Disco extraño{C:inactive})",
+					"{C:inactive}(Evoluciona con un {C:poke_metal}Disco extraño{C:inactive})",
                 } 
             },
             j_poke_stantler = {
@@ -3102,7 +3102,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Gana {C:money}#1# ${} por cada comodín",
-				  "tipo {C:colorless}Incoloro{} que tengas",
+				  "tipo {C:poke_colorless}Incoloro{} que tengas",
 				  "al final de la ronda",
 				  "{C:inactive}(Actual {C:money}#2# ${C:inactive}){}"
                 }
@@ -3233,7 +3233,7 @@ return {
 					"{C:attention}Naturaleza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Las cartas de {C:attention}naturaleza{} otorgan {C:money}#1# ${}",
                     "cuando anotan más {C:money}#5# ${} por cada",
-					"{C:attention}otro{} comodín tipo {X:grass,C:white}Planta{} que tengas",
+					"{C:attention}otro{} comodín tipo {X:poke_grass,C:white}Planta{} que tengas",
 					"{C:inactive}(Actual {C:money}#4# ${C:inactive} total){}"
                 } 
             },
@@ -3265,7 +3265,7 @@ return {
 					"Las cartas de {C:attention}naturaleza{}",
 					"otorgan {C:mult}+#1#{} multi cuando anotan",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Cada comodín tipo {X:fire,C:white}Fuego{} o {X:fighting,C:white}Lucha{}",
+                    "Cada comodín tipo {X:poke_fire,C:white}Fuego{} o {X:poke_fighting,C:white}Lucha{}",
                     "otorga {X:mult,C:white} X#2# {} multi si descartas",
                     "{C:attention}#4# {C:inactive}[#5#]{} cartas de {C:attention}naturaleza{}","en esta ronda"
                 } 
@@ -3299,7 +3299,7 @@ return {
 					"otorgan {C:chips}+#1#{} fichas cuando anotan",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Crea una carta de {C:tarot}tarot{} por",
-					"cada {C:attention}2{} comodines tipo {X:water,C:white}Agua{} o {X:earth,C:white}Tierra{}",
+					"cada {C:attention}2{} comodines tipo {X:poke_water,C:white}Agua{} o {X:poke_earth,C:white}Tierra{}",
 					"que tengas si la mano de póker",
 					"contiene {C:attention}#3#{} cartas de {C:attention}Naturaleza",
                     "{C:inactive}(Debe haber espacio){}"
@@ -3321,7 +3321,7 @@ return {
                 "carta de juego es {C:attention}destruida",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {C:mult}+#3#{} multi más por cada",
-                "comodín tipo {X:dark,C:white}Oscuro{} que tengas",
+                "comodín tipo {X:poke_dark,C:white}Oscuro{} que tengas",
                 "{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
               }
             },
@@ -3329,7 +3329,7 @@ return {
               name = "Zigzagoon",
               text = {
                 "{C:green}#1# en #2#{} probabilidades",
-				"de {C:attention}recoger{} un {C:item}objeto{}",
+				"de {C:attention}recoger{} un {C:poke_item}objeto{}",
 				"cuando la mano es jugada",
 				"{C:inactive}(Debe haber espacio)",
 				"{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
@@ -3339,7 +3339,7 @@ return {
               name = "Linoone",
               text = {
                 "{C:green}#1# en #2#{} probabilidades",
-				"de {C:attention}recoger{} un {C:item}objeto{}",
+				"de {C:attention}recoger{} un {C:poke_item}objeto{}",
 				"cuando la mano es jugada",
 				"Garantizado si la mano",
 				"contiene una {C:attention}Escalera{}",
@@ -3436,14 +3436,14 @@ return {
                 "{s:0.9}La categoría cambia cada ronda",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Gana {C:money}#2# ${} más por cada",
-                "comodín tipo {X:water,C:white}Agua{} que tengas"
+                "comodín tipo {X:poke_water,C:white}Agua{} que tengas"
               }
             }, 
             j_poke_ralts = {
               name = "Ralts",
               text = {
                 "{C:mult}+#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y {C:planet}planeta{}",
+                "{C:poke_pink}energizado{} y {C:planet}planeta{}",
                 "en tus consumibles",
                 "{C:inactive}(Actual {C:mult}+#3#{C:inactive} multi)",
                 "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
@@ -3453,7 +3453,7 @@ return {
               name = "Kirlia",
               text = {
                 "{C:mult}+#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y {C:planet}planeta{}",
+                "{C:poke_pink}energizado{} y {C:planet}planeta{}",
                 "en tus consumibles",
                 "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                 "{C:inactive}(Evoluciona tras usar",
@@ -3467,7 +3467,7 @@ return {
                 "{C:attention}Equipado con{} {C:spectral}Agujero negro",
                 "{br:2}ERROR - CONTACT STEAK",
                 "{X:mult,C:white}X#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y cada mano",
+                "{C:poke_pink}energizado{} y cada mano",
 				"con nivel {C:attention}#3# o más{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#2#{C:inactive} multi)",
               }
@@ -3544,8 +3544,8 @@ return {
                   "{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi)",
                   "{br:2.5}ERROR - CONTACT STEAK",
                   "{S:1.1,C:red,E:2}Se autodestruye{} si tienes un",
-                  "comodín tipo {X:fire,C:white}Fuego{}, {X:dark,C:white}Oscuro{}, {X:earth,C:white}Tierra{} o",
-                  "{X:psychic,C:white}Psíquico{} al final de la {C:attention}tienda",
+                  "comodín tipo {X:poke_fire,C:white}Fuego{}, {X:poke_dark,C:white}Oscuro{}, {X:poke_earth,C:white}Tierra{} o",
+                  "{X:poke_psychic,C:white}Psíquico{} al final de la {C:attention}tienda",
                   "{C:inactive}(Excluye Shedinjas){}"
                 }
             },
@@ -3561,7 +3561,7 @@ return {
                 name = "Hariyama",
                 text = {
                   "Gana {C:chips}+#1#{} mano por cada",
-                  "comodín tipo {X:fighting,C:white}Lucha{} que tengas",
+                  "comodín tipo {X:poke_fighting,C:white}Lucha{} que tengas",
                   "cuando se selecciona la {C:attention}ciega{}",
                 }
             },
@@ -3599,7 +3599,7 @@ return {
                   "Copia la habilidad del",
                   "comodín tipo {B:1,V:2}#1#{}",
                   "de la derecha",
-                  "con {C:pink}+#2#{} energía",
+                  "con {C:poke_pink}+#2#{} energía",
                   "{C:inactive,s:0.9}(El tipo cambia cada ronda){}",
                 }
             },
@@ -3669,7 +3669,7 @@ return {
                 "usas una carta de {C:planet}planeta{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Si tienes otro comodín tipo",
-				"{X:grass,C:white}Planta{}, obtiene {X:mult,C:white} X#4# {} también",
+				"{X:poke_grass,C:white}Planta{}, obtiene {X:mult,C:white} X#4# {} también",
                 "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas, {X:mult,C:white} X#3# {C:inactive} multi)"
               }
             },
@@ -3678,7 +3678,7 @@ return {
               text = {
 				"Cuando se selecciona la {C:attention}ciega{},",
 				"crea una carta de {C:planet}planeta{} por",
-				"cada comodín tipo {X:grass,C:white}Planta{} que tengas",
+				"cada comodín tipo {X:poke_grass,C:white}Planta{} que tengas",
 				"{C:inactive}(Debe haber espacio){}",
               }
             },
@@ -3766,7 +3766,7 @@ return {
             j_poke_cacnea = {
               name = "Cacnea",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
+                "{C:poke_hazard}+#1# Nivel de trampas",
                 "Gana {C:money}#2# ${} cuando una",
                 "carta es destruida",
                 "{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
@@ -3775,12 +3775,12 @@ return {
             j_poke_cacturne = {
               name = "Cacturne",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
+                "{C:poke_hazard}+#1# Nivel de trampas",
                 "Gana {C:money}#2# ${} cuando una",
                 "carta es destruida",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Destruye todas las cartas",
-                "{C:hazard}trampa{} en la {C:attention}primera{} mano",
+                "{C:poke_hazard}trampa{} en la {C:attention}primera{} mano",
                 "tras jugar una mano",
               }
             },
@@ -3800,7 +3800,7 @@ return {
 				"cuando sacas un {C:attention}9{} durante una {C:attention}ciega",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Garantizado si tienes otro",
-                "comodín tipo {X:dragon,C:white}Dragón{}",
+                "comodín tipo {X:poke_dragon,C:white}Dragón{}",
                 "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
               }
             },
@@ -3996,7 +3996,7 @@ return {
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {X:mult,C:white}X#2#{} multi y destruye una",
                 "carta al azar {C:attention}en tu mano{} cuando",
-                "una carta de {C:item}objeto{} o {C:tarot}tarot{} es {C:attention}vendida",
+                "una carta de {C:poke_item}objeto{} o {C:tarot}tarot{} es {C:attention}vendida",
                 "mientras abres un {C:attention}paquete potenciador{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#3# {C:inactive} multi)"
               }
@@ -4008,7 +4008,7 @@ return {
                 "abres un {C:attention}paquete potenciador{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {X:mult,C:white}X#2#{} multi cuando una",
-                "una carta de {C:item}objeto{} o {C:tarot}tarot{} es {C:attention}usada",
+                "una carta de {C:poke_item}objeto{} o {C:tarot}tarot{} es {C:attention}usada",
                 "mientras abres un {C:attention}paquete potenciador{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#3# {C:inactive} multi)"
               }
@@ -4152,14 +4152,14 @@ return {
                     "Copia la habilidad del",
 					"{C:attention}comodín{} a su derecha",
                     "si tienees {C:attention}#1# o más",
-                    "comodines {C:pink}energizados{}",
+                    "comodines {C:poke_pink}energizados{}",
                     "{C:inactive}(Actual {C:attention}#2#{C:inactive}/#1#){}"
                 }
             },
             j_poke_jirachi_copy = {
                 name = 'Jirachi',
                 text = {
-                    "Copia la habilidad del {C:attention}comodín{} a la","derecha como si estuviera {C:pink}energizado{} una vez adicional",
+                    "Copia la habilidad del {C:attention}comodín{} a la","derecha como si estuviera {C:poke_pink}energizado{} una vez adicional",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -4168,7 +4168,7 @@ return {
 					"Si el {C:attention}primer descarte{} tiene",
 					"solo {C:attention}1{} carta, la {C:attention}destruye{}",
                     "y crea una copia de {C:tarot}La muerte{},",
-                    "{C:spectral}Críptido{}, o {C:item}Revestimiento Metálico{}",
+                    "{C:spectral}Críptido{}, o {C:poke_item}Revestimiento Metálico{}",
                     "{C:inactive}(Debe haber espacio)",
                 }
             },
@@ -4250,7 +4250,7 @@ return {
                 text = {
                     "{C:attention}Bebé{}, {X:mult,C:white} X#1# {} multi",
                     "Crea una copia {C:dark_edition}negativa{} de",
-                    "{C:item}Semilla Milagro{} al final de la ronda",
+                    "{C:poke_item}Semilla Milagro{} al final de la ronda",
                     "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }
             },
@@ -4335,7 +4335,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Cada comodín tipo {X:dark,C:white}Oscuro{}",
+                  "Cada comodín tipo {X:poke_dark,C:white}Oscuro{}",
 				  "otorga {X:mult,C:white}X#1#{} multi",
                 }
             },
@@ -4379,7 +4379,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Bebé{}, {X:mult,C:white} X#1# {} multi",
-					"Crea un {C:item}objeto {C:dark_edition}negativo",
+					"Crea un {C:poke_item}objeto {C:dark_edition}negativo",
 					"al final de la {C:attention}ronda",
 					"{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }
@@ -4435,7 +4435,7 @@ return {
                 text = {
                     "Las {C:attention}cartas de acero{} jugadas",
 					"otorgan {X:mult,C:white}X#1#{} multi más {X:mult,C:white}X#2#{} multi por",
-					"cada comodín tipo {X:metal,C:white}Metal{} que tengas",
+					"cada comodín tipo {X:poke_metal,C:white}Metal{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi){}",
                 } 
             },
@@ -4458,7 +4458,7 @@ return {
 					"{br:3}ERROR - CONTACT STEAK",
 					"Las {C:attention}cartas de piedra{} se reactivan",
 					"una vez adicional por cada {C:attention}3{}",
-					"comodines tipo {X:earth,C:white}Tierra{} que tengas",
+					"comodines tipo {X:poke_earth,C:white}Tierra{} que tengas",
 					"{C:inactive}(Actualmente se reactivan {C:attention}#2#{} veces)"
                 } 
             },
@@ -4558,12 +4558,12 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} límite de energía",
+                    "{C:poke_pink}+3{} límite de energía",
 					"{X:mult,C:white} X#2# {} multi por cada carta de",
-					"{C:pink}energía{} usada en esta {C:attention}partida{}",
+					"{C:poke_pink}energía{} usada en esta {C:attention}partida{}",
 					"{br:2}text needs to be here to work",
-					"Crea una {C:pink}energía",
-					"cuando usas una {C:pink}energía",
+					"Crea una {C:poke_pink}energía",
+					"cuando usas una {C:poke_pink}energía",
 					"{C:inactive}(Debe haber espacio)",
 					"{C:inactive}(Actual {X:mult,C:white} X#1# {C:inactive} multi)"
                 } 
@@ -4604,7 +4604,7 @@ return {
                 text = {
                   "Adquiere hasta {C:mult}-#1# ${} de deuda",
 				  "{br:2.5}ERROR - CONTACT STEAK",
-				  "Crea un {C:item}objeto{} si",
+				  "Crea un {C:poke_item}objeto{} si",
 				  "juegas una mano",
 				  "mientras estás endeudado",
 				  "{C:inactive}(Debe haber espacio)",
@@ -4614,7 +4614,7 @@ return {
                 name = "Rotom",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4628,7 +4628,7 @@ return {
                 name = "Rotom (Calor)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4643,7 +4643,7 @@ return {
                 name = "Rotom (Lavado)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4658,7 +4658,7 @@ return {
               name = "Rotom (Frío)",
               text = {
 				"{C:green}#1# en #2#{} probabilidades de crear",
-				"una carta de {C:item}objeto{} cuando abres",
+				"una carta de {C:poke_item}objeto{} cuando abres",
 				"un {C:attention}paquete potenciador{}",
 				"{C:inactive}(Debe haber espacio){}",
 				"{br:2}ERROR - CONTACT STEAK",
@@ -4673,7 +4673,7 @@ return {
                 name = "Rotom (Ventilador)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4688,7 +4688,7 @@ return {
                 name = "Rotom (Podadora)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4776,7 +4776,7 @@ return {
                 text = {
                   "Cuando se selecciona la {C:attention}ciega{}, gana",
                   "{C:purple}+#2# Profecía{} por esta ronda por cada",
-                  "comodín tipo {X:psychic,C:white}Psíquico{} que tengas",
+                  "comodín tipo {X:poke_psychic,C:white}Psíquico{} que tengas",
                   "{br:3}ERROR - CONTACT STEAK",
                   "Cada carta {C:attention}mejorada profetizada{}",
                   "otorga {X:mult,C:white} X#1# {} multi",
@@ -4786,7 +4786,7 @@ return {
             j_poke_roggenrola = {
                 name = "Roggenrola",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
                     "{C:inactive}(Evoluciona tras activarse {C:attention}#3#{C:inactive} veces)",
@@ -4795,7 +4795,7 @@ return {
             j_poke_boldore = {
                 name = "Boldore",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
 					"{C:inactive}(Evoluciona con un {C:attention}Cordón Unión{C:inactive})"
@@ -4804,7 +4804,7 @@ return {
             j_poke_gigalith = {
                 name = "Gigalith",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
                     "y se reactiva"
@@ -4944,8 +4944,8 @@ return {
             j_poke_ferroseed = {
                 name = "Ferroseed",
                 text = {
-                  "{C:hazard}+#2# Nivel de trampas",
-                  "Las cartas {C:attention}versátiles{} y {C:hazard}trampa{}",
+                  "{C:poke_hazard}+#2# Nivel de trampas",
+                  "Las cartas {C:attention}versátiles{} y {C:poke_hazard}trampa{}",
                   "también son {C:attention}cartas de acero{}",
                   "{C:inactive}(Evoluciona tras {C:attention}#1#{C:inactive} rondas)",
                 }
@@ -4953,8 +4953,8 @@ return {
             j_poke_ferrothorn = {
               name = "Ferrothorn",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
-                "Las cartas {C:attention}versátiles{} y {C:hazard}trampa{}",
+                "{C:poke_hazard}+#1# Nivel de trampas",
+                "Las cartas {C:attention}versátiles{} y {C:poke_hazard}trampa{}",
                 "también son {C:attention}cartas de acero{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Si la mano jugada contiene",
@@ -5021,20 +5021,20 @@ return {
             j_poke_golett = {
                 name = "Golett",
                 text = {
-                  "{C:hazard}+#1# Nivel de trampas",
+                  "{C:poke_hazard}+#1# Nivel de trampas",
                   "{C:green}#4# en #5#{} probabilidades para cada carta",
                   "{C:attention}en tu mano{} de otorgar {X:mult,C:white}X#2#{} multi",
-                  "Garantizado para cartas {C:hazard}trampa{}",
+                  "Garantizado para cartas {C:poke_hazard}trampa{}",
                   "{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)"
 				}
             },
             j_poke_golurk = {
                 name = "Golurk",
                 text = {
-                  "{C:hazard}+#1# Nivel de trampas",
+                  "{C:poke_hazard}+#1# Nivel de trampas",
                   "{C:green}#3# en #4#{} probabilidades para cada carta",
                   "{C:attention}en tu mano{} de otorgar {X:mult,C:white}X#2#{} multi", 
-                  "Garantizado para cartas {C:hazard}trampa{}",
+                  "Garantizado para cartas {C:poke_hazard}trampa{}",
 				}
             },
             j_poke_pawniard = {
@@ -5119,7 +5119,7 @@ return {
                     "{C:chips}+#1#{} fichas si la mano",
 					"jugada contiene un {C:attention}Color{}",
 					"{br:2}ERROR - CONTACT STEAK",
-					"Crea una carta de {C:pink}energía{} si",
+					"Crea una carta de {C:poke_pink}energía{} si",
 					"también contiene un {C:attention}rey{} o {C:attention}reina{}"
                 } 
             },
@@ -5177,7 +5177,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_average = {
@@ -5189,7 +5189,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_large = {
@@ -5201,7 +5201,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_super = {
@@ -5213,14 +5213,14 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_grubbin = {
                 name = 'Grubbin',
                 text = {
                     "{C:mult}+#1#{} multi","Se {C:attention}triplica{} si tienes",
-					"un comodín tipo {X:lightning, C:black}Rayo{}",
+					"un comodín tipo {X:poke_lightning, C:black}Rayo{}",
 					"{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }  
             },
@@ -5228,7 +5228,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} multi por cada comodín",
-					"tipo {X:lightning, C:black}Rayo{} que tengas",
+					"tipo {X:poke_lightning, C:black}Rayo{} que tengas",
 					"{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
 					"{C:inactive}(Evoluciona con una","{C:attention}Piedra Trueno{C:inactive})"
                 }  
@@ -5238,7 +5238,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} multi",
 					"{X:mult,C:white} X#1# {} multi por cada",
-					"comodín tipo {X:lightning, C:black}Rayo{} que tengas",
+					"comodín tipo {X:poke_lightning, C:black}Rayo{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white} X#2# {C:inactive} multi)",
                 }
             },
@@ -5379,10 +5379,10 @@ return {
             j_poke_hisuian_qwilfish = {
                 name = "Qwilfish (de Hisui)",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:inactive}(1 por cada #2# cartas en tu baraja)",
 					"Obtiene {C:chips}+#3#{} fichas cuando una",
-					"carta {C:hazard}trampa{} es sacada",
+					"carta {C:poke_hazard}trampa{} es sacada",
 					"{C:inactive}(Evoluciona cuando tiene",
 					"{C:chips}+#4#{C:inactive} / +#5# fichas)",
                 }
@@ -5390,10 +5390,10 @@ return {
             j_poke_overqwil = {
                 name = "Overqwil",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:inactive}(1 por cada #2# cartas en tu baraja)"
 					,"Obtiene {C:chips}+#3#{} fichas cuando una",
-					"carta {C:hazard}trampa{} es sacada",
+					"carta {C:poke_hazard}trampa{} es sacada",
 					"{br:3}ERROR - CONTACT STEAK",
 					"{C:attention}Divide a la mitad{} las fichas tras jugar una mano",
 					"{C:inactive}(Actual {C:chips}+#4#{C:inactive} fichas)",
@@ -5426,7 +5426,7 @@ return {
             j_poke_ursaluna = {
               name = "Ursaluna",
               text = {
-				"Obtiene {C:mult}+#2#{} multi y crea un {C:item}objeto",
+				"Obtiene {C:mult}+#2#{} multi y crea un {C:poke_item}objeto",
 				"con {C:dark_edition}laminado{}, {C:dark_edition}holográfico{}, o {C:dark_edition}policromía{}",
 				"cuando cualquier {C:attention}paquete potenciador{}",
 				"es omitido",
@@ -5437,7 +5437,7 @@ return {
             j_poke_tarountula = {
                 name = "Tarountula",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas{}",
+                    "{C:poke_hazard}+#1# Nivel de trampas{}",
 					"{C:attention}+#3#{} tamaño de mano",
                     "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
 				}
@@ -5445,7 +5445,7 @@ return {
             j_poke_spidops = {
                 name = "Spidops",
                 text = {
-					"{C:hazard}+#1# Nivel de trampas",
+					"{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:attention}+#2#{} tamaño de mano",
                     "Agrega un {C:attention}sello{} al azar a cada",
                     "{C:attention}octava{} {C:attention}carta de juego {C:inactive}[#4#]{}",
@@ -5462,7 +5462,7 @@ return {
 				  "{C:inactive,s:0.8}(Cuando es la más alta, se vuelve la menor)",
 				  "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
 				  "{C:inactive}(Evoluciona cuando tienes un",
-				  "{C:inactive}comodín tipo {X:fire,C:white}Fuego{C:inactive})",
+				  "{C:inactive}comodín tipo {X:poke_fire,C:white}Fuego{C:inactive})",
                 }
             },
             j_poke_dachsbun = {
@@ -5475,7 +5475,7 @@ return {
 				  "{C:inactive,s:0.9}(Cuando es la más alta, se vuelve la menor)",
 				  "{br:4}ERROR - CONTACT STEAK",
 				  "Aumenta las fichas ganadas en {C:chips}+2{} por",
-				  "cada comodín tipo {X:fire,C:white}Fuego{} que tengas",
+				  "cada comodín tipo {X:poke_fire,C:white}Fuego{} que tengas",
 				  "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
                 }
             },
@@ -5506,7 +5506,7 @@ return {
                 "al final de la ronda",
                 "{br:2.5}ERROR - CONTACT STEAK",
                 "Agrega el {C:attention}doble{} a comodines",
-				"tipo {X:grass,C:white}Planta{} y {C:pink}Energías {X:grass,C:white}Planta{}"
+				"tipo {X:poke_grass,C:white}Planta{} y {C:poke_pink}Energías {X:poke_grass,C:white}Planta{}"
               }
             },
             j_poke_charcadet = {
@@ -5566,7 +5566,7 @@ return {
             j_poke_rellor = {
                 name = 'Rellor',      
                 text = {
-                    "{C:mult}+#1#{} multi por cada {C:item}objeto{}",
+                    "{C:mult}+#1#{} multi por cada {C:poke_item}objeto{}",
                     "usado en esta partida",
                     "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                     "{C:inactive}(Evoluciona tras usar","{C:attention}#3#{C:inactive} objetos)",
@@ -5577,10 +5577,10 @@ return {
                 text = {
                     "{C:green}#3# en #4#{} probabilidades de crear",
                     "una carta de {C:tarot}tarot{} cuando",
-                    "usas un {C:item}objeto{}",
+                    "usas un {C:poke_item}objeto{}",
                     "{C:inactive}(Debe haber espacio){}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "{C:mult}+#1#{} multi por cada {C:item}objeto{}",
+                    "{C:mult}+#1#{} multi por cada {C:poke_item}objeto{}",
                     "usado en esta partida",
                     "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                 } 
@@ -5731,7 +5731,7 @@ return {
                 text = {
                     "Los {C:attention}paquetes potenciadores{}",
 					"cuestan {C:money}1 ${} menos",
-                    "por cada {C:pink}tipo{} diferente",
+                    "por cada {C:poke_pink}tipo{} diferente",
                     "de tus comodines",
                     "{C:inactive}(Actual {C:money}#1# ${C:inactive} menos)"
                 } 
@@ -5758,7 +5758,7 @@ return {
             j_poke_jelly_donut = {
                 name = "Rosquilla rellena",
                 text = {
-                  "Crea una {C:pink}energía{} {X:colorless,C:white}Incolora",
+                  "Crea una {C:poke_pink}energía{} {X:poke_colorless,C:white}Incolora",
 				  "cuando se selecciona la {C:attention}ciega",
 				  "{C:inactive}({C:attention}#1#{C:inactive} rondas restantes){}"
                 }
@@ -5790,8 +5790,8 @@ return {
                 text = {
                   "{C:attention}Cambia Tipo{}",
 				  "{br:2}ERROR - CONTACT STEAK",
-				  "Cambia el {C:pink}tipo{} del comodín más a la izquierda",
-				  "por el {C:pink}tipo{} del comodín más a la derecha",
+				  "Cambia el {C:poke_pink}tipo{} del comodín más a la izquierda",
+				  "por el {C:poke_pink}tipo{} del comodín más a la derecha",
 				  "cuando seleccionas la {C:attention}ciega",
 				  "{C:inactive}({C:attention}#1#{C:inactive} rondas restantes){}"
                 }
@@ -5859,7 +5859,7 @@ return {
             j_poke_mystery_egg = {
                 name = "Huevo misterioso",
                 text = {
-                  "Eclosiona en un Pokémon {C:attention}Básico{} o","{C:attention}Bebé{} tras {C:attention}#1#{} rondas y","{C:pink}energizado{} una vez si se puede"
+                  "Eclosiona en un Pokémon {C:attention}Básico{} o","{C:attention}Bebé{} tras {C:attention}#1#{} rondas y","{C:poke_pink}energizado{} una vez si se puede"
                 }
             },
             j_poke_daycare = {
@@ -5882,13 +5882,13 @@ return {
             j_poke_billion_lions = {
                 name = 'Un billón de leones',
                 text = {
-                    "Cuando la ciega es seleccionada, destruye","todos los comodines con un {C:pink}tipo{} que tengas","y obtiene {X:mult,C:white}X#2#{} multi por cada uno","{S:1.1,C:red,E:2}Se autodestruye{} cuando se quedá sin leones","{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi, {C:attention}#3#{C:inactive} leones)"
+                    "Cuando la ciega es seleccionada, destruye","todos los comodines con un {C:poke_pink}tipo{} que tengas","y obtiene {X:mult,C:white}X#2#{} multi por cada uno","{S:1.1,C:red,E:2}Se autodestruye{} cuando se quedá sin leones","{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi, {C:attention}#3#{C:inactive} leones)"
                 } 
             },
             j_poke_spiclops = {
                 name = "Spiclops",
                 text = {
-                    "{C:hazard}+#1#{} Nivel de trampas, {C:attention}+#2#{} tamaño de mano",
+                    "{C:poke_hazard}+#1#{} Nivel de trampas, {C:attention}+#2#{} tamaño de mano",
                     "Apply a random {C:attention}seal{} to",
                     "every {C:attention}#3#th{} {C:attention}playing card {C:inactive}[#4#]{}",
                     "added to your deck",
@@ -5961,9 +5961,9 @@ return {
             sleeve_poke_obituarysleeve_alt = {
                 name = "Funda Obituaria",
                 text = {
-                    "Los {C:pink}sellos rosados{} tienen {C:green}#1# en #2#{} probabilidades",
+                    "Los {C:poke_pink}sellos rosados{} tienen {C:green}#1# en #2#{} probabilidades",
                     "de ser removidos tras activarse",
-                    "Los comodines crean una {C:pink}energía {C:dark_edition}negativa{} de",
+                    "Los comodines crean una {C:poke_pink}energía {C:dark_edition}negativa{} de",
                     "su tipo cuando son vendidos o destruidos",
                 },
             },
@@ -5977,7 +5977,7 @@ return {
               name = "Funda Renacida",
               text = {
                   "{C:blue}+#1#{} ranuras de consumible",
-                  "Los {C:pink}paquetes pokémon{} no",
+                  "Los {C:poke_pink}paquetes pokémon{} no",
                   "aparecerán en la tienda",
               },
             },
@@ -5985,27 +5985,27 @@ return {
                 name = "Funda Luminosa",
                 text = {
                     "Todos los comodines son",
-					"creados con {C:pink}1 energía{} y",
-					"con un sticker de un {C:pink}tipo{} al azar"
+					"creados con {C:poke_pink}1 energía{} y",
+					"con un sticker de un {C:poke_pink}tipo{} al azar"
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "Funda Luminosa",
                 text = {
                     "Los cambios tienen una {C:green}#1# en #2#{} probabilidades",
-                    "de crear un {C:item}Orbe Teracristal",
+                    "de crear un {C:poke_item}Orbe Teracristal",
                 },
             },
             sleeve_poke_telekineticsleeve = {
                 name = "Funda Telequinética",
                 text = {
-                    "Comienza la partida con","el vale {C:tarot,T:v_crystal_ball}#1#{}","y {C:attention}2{} copias","de la {C:item,T:c_poke_twisted_spoon}#2#"
+                    "Comienza la partida con","el vale {C:tarot,T:v_crystal_ball}#1#{}","y {C:attention}2{} copias","de la {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
 			sleeve_poke_telekineticsleeve_alt = {
                 name = "Funda Telequinética",
                 text = {
-                    "Las {C:item,T:c_poke_twisted_spoon}#2#s{}",
+                    "Las {C:poke_item,T:c_poke_twisted_spoon}#2#s{}",
                     "que tengas otorgan",
                     "{C:blue}+1{} ranura de consumible",
                 }
@@ -6013,15 +6013,15 @@ return {
             sleeve_poke_ampedsleeve = {
                 name = "Funda Energizada",
                 text = {
-                    "Comienza la partida con","el vale {C:tarot,T:v_poke_energysearch}#1#{}","y una copia de","{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "Comienza la partida con","el vale {C:tarot,T:v_poke_energysearch}#1#{}","y una copia de","{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "Funda Energizada",
                 text = {
                     "Comienza la partida con una {C:attention,T:j_poke_jelly_donut}#1#{} {C:dark_edition}negativa",
-                    "en vez de una {C:pink,T:c_poke_double_rainbow_energy}#2#",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{} ya no es la mitad de",
+                    "en vez de una {C:poke_pink,T:c_poke_double_rainbow_energy}#2#",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{} ya no es la mitad de",
                     "efectiva en comodines que no son tipo Normal",
                 } 
             },
@@ -6091,17 +6091,17 @@ return {
             sleeve_poke_diceysleeve = {
                 name = "Funda tramposa",
                 text = {
-                    "{C:hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
+                    "{C:poke_hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
                     "Al final de cada ronda:",
                     "Gana {C:money}#4# ${} por cada carta",
-                    "{C:hazard}trampa{} en tu {C:attention}baraja completa",
+                    "{C:poke_hazard}trampa{} en tu {C:attention}baraja completa",
                     "No ganas {C:attention}intereses"
                 } 
             },
             sleeve_poke_diceysleeve_alt = {
                 name = "Funda tramposa",
                 text = {
-                    "Todas las {C:hazard}trampas{} otorgan {C:attention}+1{} tamaño de mano",
+                    "Todas las {C:poke_hazard}trampas{} otorgan {C:attention}+1{} tamaño de mano",
                 } 
             },
         },
@@ -6124,7 +6124,7 @@ return {
                     "Evoluciona al Pokémon más",
 					"a la izquierda o seleccionado a su",
                     "{C:attention}etapa{} más alta {C:inactive}(si puede){} y",
-                    "lo {C:pink}energiza{}", 
+                    "lo {C:poke_pink}energiza{}", 
                 },
             },
             c_poke_megastone = {
@@ -6141,30 +6141,30 @@ return {
             c_poke_obituary = {
                 name = "Obituario",
                 text = {
-                    "Agrega un {C:pink}sello rosado{}",
+                    "Agrega un {C:poke_pink}sello rosado{}",
 					"a {C:attention}1{} carta seleccionada",
                 }
             },
             c_poke_nightmare = {
                 name = "Pesadilla",
                 text = {
-                    "Destruye al comodín más a la izquierda","o seleccionado con {C:pink}tipo{}",
-					"y crea {C:attention}2{} {C:pink}energías{} {C:dark_edition}negativas{}","del {C:pink}tipo{} de ese comodín"
+                    "Destruye al comodín más a la izquierda","o seleccionado con {C:poke_pink}tipo{}",
+					"y crea {C:attention}2{} {C:poke_pink}energías{} {C:dark_edition}negativas{}","del {C:poke_pink}tipo{} de ese comodín"
                 },
             },
             c_poke_revenant = {
                 name = "Renacido",
                 text = {
-                    "Agrega un {C:item}sello plateado{}",
+                    "Agrega un {C:poke_item}sello plateado{}",
 					"a {C:attention}1{} carta seleccionada",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "Doble Energía Arcoíris",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la",
+                    "{C:poke_pink}Energiza{} al comodín más a la",
 					"izquierda o seleccionado de",
-					"cualquier {C:pink}tipo{} {C:red}d{C:attention}o{C:green}s{} {C:red}v{C:attention}e{C:green}c{C:blue}e{C:purple}s{}",
+					"cualquier {C:poke_pink}tipo{} {C:red}d{C:attention}o{C:green}s{} {C:red}v{C:attention}e{C:green}c{C:blue}e{C:purple}s{}",
 					"No ganas intereses esta ronda","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
@@ -6229,7 +6229,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Etiqueta Pokémon",
                 text = {
-                    "Otorga gratis un {C:pink}megapaquete Pokémon",
+                    "Otorga gratis un {C:poke_pink}megapaquete Pokémon",
 					"{C:green}#1#%{} de probabilidad de que contenga",
 					"una {C:attention}Megapiedra{} en una {C:attention}apuesta mayor a 5{}",
 					"{C:inactive,s:0.8}(La probabilidad no puede ser aumentada){}",
@@ -6239,7 +6239,7 @@ return {
                 name = "Etiqueta variocolor",
                 text = {
                     "El próximo comodín de la",
-					"tienda de la edición base es gratis y","se vuelve {C:colorless}variocolor{}",
+					"tienda de la edición base es gratis y","se vuelve {C:poke_colorless}variocolor{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -6251,7 +6251,7 @@ return {
             tag_poke_safari_tag = {
                 name = "Etiqueta de safari",
                 text = {
-                    "La tienda tiene un","Pokémon de {C:safari}Safari{} gratis",
+                    "La tienda tiene un","Pokémon de {C:poke_safari}Safari{} gratis",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -6285,13 +6285,13 @@ return {
             v_poke_energysearch = {
                 name = "Búsqueda de Energía",
                 text = {
-                    "{C:pink}+2{} límite de energía"
+                    "{C:poke_pink}+2{} límite de energía"
                 },
             },
             v_poke_energyresearch = {
                 name = "Investigación de Energía",
                 text = {
-                    "{C:pink}+3{} límite de energía"
+                    "{C:poke_pink}+3{} límite de energía"
                 },
             },
             v_poke_goodrod = {
@@ -6303,7 +6303,7 @@ return {
             v_poke_superrod = {
                 name = "Supercaña",
                 text = {
-                    "Puedes {C:pink}guardar{} cartas","de cualquier paquete de {C:attention}consumibles{}",
+                    "Puedes {C:poke_pink}guardar{} cartas","de cualquier paquete de {C:attention}consumibles{}",
                 },
             },
         },
@@ -6312,80 +6312,80 @@ return {
             Grass = {
                 name = "Tipo",
                 text = {
-                  "{X:grass,C:white}Planta{}",
+                  "{X:poke_grass,C:white}Planta{}",
                 }
             },
             Fire = {
                 name = "Tipo",
                 text = {
-                  "{X:fire,C:white}Fuego{}",
+                  "{X:poke_fire,C:white}Fuego{}",
                 }
             },
             Water = {
                 name = "Tipo",
                 text = {
-                  "{X:water,C:white}Agua{}",
+                  "{X:poke_water,C:white}Agua{}",
                 }
             },
             Lightning = {
                 name = "Tipo",
                 text = {
-                  "{X:lightning,C:black}Rayo{}",
+                  "{X:poke_lightning,C:black}Rayo{}",
                 }
             },
             Psychic = {
                 name = "Tipo",
                 text = {
-                  "{X:psychic,C:white}Psíquico{}",
+                  "{X:poke_psychic,C:white}Psíquico{}",
                 }
             },
             Fighting = {
                 name = "Tipo",
                 text = {
-                  "{X:fighting,C:white}Lucha{}",
+                  "{X:poke_fighting,C:white}Lucha{}",
                 }
             },
             Colorless = {
                 name = "Tipo",
                 text = {
-                  "{X:colorless,C:white}Incoloro{}",
+                  "{X:poke_colorless,C:white}Incoloro{}",
                 }
             },
             Dark = {
                 name = "Tipo",
                 text = {
-                  "{X:dark,C:white}Oscuro{}",
+                  "{X:poke_dark,C:white}Oscuro{}",
                 }
             },
             Metal = {
                 name = "Tipo",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Tipo",
                 text = {
-                  "{X:fairy,C:white}Hada{}",
+                  "{X:poke_fairy,C:white}Hada{}",
                 }
             },
             Dragon = {
                 name = "Tipo",
                 text = {
-                  "{X:dragon,C:white}Dragón{}",
+                  "{X:poke_dragon,C:white}Dragón{}",
                 }
             },
             Earth = {
                 name = "Tipo",
                 text = {
-                  "{X:earth,C:white}Tierra{}",
+                  "{X:poke_earth,C:white}Tierra{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "Tipo",
                 text = {
-                  "{X:bird,C:white}¿Pájaro?{}",
+                  "{X:poke_bird,C:white}¿Pájaro?{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -6534,8 +6534,8 @@ return {
               name = "Nivel de trampas",
               text = {
                   "Cuando sacas la {C:attention}primera{} mano, agrega",
-                  "tantas cartas {C:hazard}trampa{} a tu mano",
-                  "como tu {C:hazard}nivel de trampas",
+                  "tantas cartas {C:poke_hazard}trampa{} a tu mano",
+                  "como tu {C:poke_hazard}nivel de trampas",
                   "{C:inactive}(Nivel de trampas actual {C:attention}#1#{C:inactive}/#2#){}"
               }
             },
@@ -6543,8 +6543,8 @@ return {
               name = "Nivel de trampas",
               text = {
                   "Cuando sacas la {C:attention}primera{} mano, agrega",
-                  "tantas cartas {C:hazard}trampa{} a tu mano",
-                  "igual a tu {C:hazard}nivel de trampas",
+                  "tantas cartas {C:poke_hazard}trampa{} a tu mano",
+                  "igual a tu {C:poke_hazard}nivel de trampas",
                   "{C:inactive}(Nivel de trampas actual {C:attention}#1#{C:inactive}/#2#){}",
                   "{C:inactive}(Nivel de trampas extra aumentan el límite){}"
               }
@@ -6607,7 +6607,7 @@ return {
                 name = "Regalos",
                 text = {
                     "{C:green}35%{} - {C:money}8 ${}",
-					"{C:green}30%{} - {C:attention}Carta de {C:item}objeto{}",
+					"{C:green}30%{} - {C:attention}Carta de {C:poke_item}objeto{}",
 					"{C:green}20%{} - {C:attention}Etiqueta de cupón",
 					"{C:green}15%{} - {C:attention}Carta de regalo{}",
 					"con {C:dark_edition}policromía{}",
@@ -6625,9 +6625,9 @@ return {
             dril_treasure = {
                 name = "Tesoros",
                 text = {
-                    "{C:green}30%{} - {C:item}Piedra {C:attention}evolutiva   ",
+                    "{C:green}30%{} - {C:poke_item}Piedra {C:attention}evolutiva   ",
                     "{C:green}30%{} - {C:money}5 ${}               ",
-                    "{C:green}20%{} - {C:attention}2 {C:item}Piedras {C:attention}evolutivas",
+                    "{C:green}20%{} - {C:attention}2 {C:poke_item}Piedras {C:attention}evolutivas",
                     "{C:green}15%{} - {C:money}10 ${}              ",
                     "{C:green}5%{} - {C:money}20 ${}             ",
                 }
@@ -6635,9 +6635,9 @@ return {
             exdril_treasure = {
                 name = "Tesoros",
                 text = {
-                    "{C:green}30%{} - {C:item}Piedra {C:attention}evolutiva   ",
+                    "{C:green}30%{} - {C:poke_item}Piedra {C:attention}evolutiva   ",
                     "{C:green}30%{} - {C:money}5 ${}               ",
-                    "{C:green}20%{} - {C:attention}2 {C:item}Piedras {C:attention}evolutivas",
+                    "{C:green}20%{} - {C:attention}2 {C:poke_item}Piedras {C:attention}evolutivas",
                     "{C:green}15%{} - {C:money}10 ${}              ",
                     "{C:green}4%{} - {C:money}20 ${}             ",
                     "{C:green}1%{} - {C:attention}Megapiedra       ",
@@ -6646,10 +6646,10 @@ return {
             pickup = {
               name = "Recogida",
               text = {
-                "{C:green}34%{} - {C:item}Carta de objeto{}",
-				"{C:green}25%{} - {C:item}Carta evolutiva",
-				"{C:green}20%{} - {C:item}Restos",
-				"{C:green}20%{} - {C:item}Cuchara Torcida",
+                "{C:green}34%{} - {C:poke_item}Carta de objeto{}",
+				"{C:green}25%{} - {C:poke_item}Carta evolutiva",
+				"{C:green}20%{} - {C:poke_item}Restos",
+				"{C:green}20%{} - {C:poke_item}Cuchara Torcida",
 				"{C:green}1%{} - {C:spectral}Transformación",
               }
             },
@@ -6709,7 +6709,7 @@ return {
             eeveelution = {
                 name = "Evoluciones",
                 text = {
-                    "{C:attention}Piedra Agua{} - {X:water,C:white}Vaporeon{}","{C:attention}Piedra Trueno{} - {X:lightning,C:black}Jolteon{}","{C:attention}Piedra Fuego{} - {X:fire,C:white}Flareon{}","{C:attention}Piedra Solar{} - {X:psychic,C:white}Espeon{}","{C:attention}Piedra Lunar{} - {X:dark,C:white}Umbreon{}","{C:attention}Piedra Hoja{} - {X:grass,C:white}Leafeon{}","{C:attention}Piedra Hielo{} - {X:water,C:white}Glaceon{}","{C:attention}Piedra Día{} - {X:fairy,C:white}Sylveon{}"
+                    "{C:attention}Piedra Agua{} - {X:poke_water,C:white}Vaporeon{}","{C:attention}Piedra Trueno{} - {X:poke_lightning,C:black}Jolteon{}","{C:attention}Piedra Fuego{} - {X:poke_fire,C:white}Flareon{}","{C:attention}Piedra Solar{} - {X:poke_psychic,C:white}Espeon{}","{C:attention}Piedra Lunar{} - {X:poke_dark,C:white}Umbreon{}","{C:attention}Piedra Hoja{} - {X:poke_grass,C:white}Leafeon{}","{C:attention}Piedra Hielo{} - {X:poke_water,C:white}Glaceon{}","{C:attention}Piedra Día{} - {X:poke_fairy,C:white}Sylveon{}"
                 }
             },
             poke_egg_tip = {
@@ -6767,14 +6767,14 @@ return {
             unlimited_energy_tooltip = {
               name = "Energía ilimitada",
               text = {
-                "Puedes usar {C:pink}energías{} en comodines",
+                "Puedes usar {C:poke_pink}energías{} en comodines",
 				"cuantas veces quieras"
               }
             },
             precise_energy_tooltip = {
                 name = "Escalado preciso de energía",
                 text = {
-                    "{s:0.8}Usa {C:attention,s:0.8}decimales{} para todos los valores cuando se aplican los {s:0.8}aumentos{} por {C:pink,s:0.8}energías{}",
+                    "{s:0.8}Usa {C:attention,s:0.8}decimales{} para todos los valores cuando se aplican los {s:0.8}aumentos{} por {C:poke_pink,s:0.8}energías{}",
 					"{s:0.8}Con esta opción {C:attention,s:0.8}apagada{}{s:0.8} lo siguiente ocurrirá para el aumento:{}",
 					"{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}multi - Usa decimales",
 					"{C:attenion}2. {s:0.8}+ {C:mult,s:0.8}multi{}{s:0.8} y {C:chips,s:0.8}fichas{}{s:0.8} - Se aproxima al número entero más cercano",
@@ -6857,7 +6857,7 @@ return {
             hazards_on_tooltip = {
               name = "Cartas trampa permitidas",
               text = {
-                "Aparecerán comodines {C:attention}Pokémon{}","que agreguen cartas {C:hazard}trampa{}"
+                "Aparecerán comodines {C:attention}Pokémon{}","que agreguen cartas {C:poke_hazard}trampa{}"
               }
             },
             shinyplayingcard_tooltip = {
@@ -6946,7 +6946,7 @@ return {
             allowpokeballs_tooltip = {
               name = "Permitir Poké Balls",
               text = {
-                "Permite que los {C:item}objetos{} de Poké Balls aparezcan",
+                "Permite que los {C:poke_item}objetos{} de Poké Balls aparezcan",
               }
             },
             pokemaster_tooltip = {
@@ -6990,7 +6990,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Sello rosado",
                 text = {
-                    "Crea una carta de {C:pink}energía{}",
+                    "Crea una carta de {C:poke_pink}energía{}",
 					"del {C:attention}tipo{} de un comodín",
 					"que tienes si anota en la",
 					"{C:attention}primera mano{} de la ronda",
@@ -7002,7 +7002,7 @@ return {
             poke_silver_seal = {
                 name = "Sello plateado",
                 text = {
-                  "Crea una carta de {C:item}objeto{}",
+                  "Crea una carta de {C:poke_item}objeto{}",
 				  "y es {C:attention}descartada{} si está en",
 				  "{C:attention}en tu mano{} cuando anotas fichas"
                 }
@@ -7020,73 +7020,73 @@ return {
             grass_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:grass,C:white}Planta{}"
+                    "{X:poke_grass,C:white}Planta{}"
                 } 
             },
             fire_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fire,C:white}Fuego{}"
+                    "{X:poke_fire,C:white}Fuego{}"
                 } 
             },
             water_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:water,C:white}Agua{}"
+                    "{X:poke_water,C:white}Agua{}"
                 } 
             },
             lightning_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:lightning,C:white}Rayo{}"
+                    "{X:poke_lightning,C:white}Rayo{}"
                 } 
             },
             psychic_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:psychic,C:white}Psíquico{}"
+                    "{X:poke_psychic,C:white}Psíquico{}"
                 } 
             },
             fighting_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fighting,C:white}Lucha{}"
+                    "{X:poke_fighting,C:white}Lucha{}"
                 } 
             },
             colorless_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:colorless,C:white}Incoloro{}"
+                    "{X:poke_colorless,C:white}Incoloro{}"
                 } 
             },
             dark_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dark,C:white}Oscuro{}"
+                    "{X:poke_dark,C:white}Oscuro{}"
                 } 
             },
             metal_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fairy,C:white}Hada{}"
+                    "{X:poke_fairy,C:white}Hada{}"
                 } 
             },
             dragon_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dragon,C:white}Dragón{}"
+                    "{X:poke_dragon,C:white}Dragón{}"
                 } 
             },
             earth_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:earth,C:white}Tierra{}"
+                    "{X:poke_earth,C:white}Tierra{}"
                 } 
             },
             --]]
@@ -7107,49 +7107,49 @@ return {
             p_poke_pokepack_normal_1 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "Paquete Pokémon jumbo",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "Paquete Pokémon mega",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "Paquete Pokémon jumbo",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "Paquete Pokémon mega",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_wish_pack = {
@@ -7177,7 +7177,7 @@ return {
                 text = {
                     "Cuando se selecciona la {C:attention}ciega{},",
 					"{C:attention}#1#{} cartas sin mejora en tu baraja",
-                    "se vuelven cartas {C:hazard}trampa{}",
+                    "se vuelven cartas {C:poke_hazard}trampa{}",
                 },
             },
             poke_elite_sticker = {

--- a/localization/es_ES.lua
+++ b/localization/es_ES.lua
@@ -21,7 +21,7 @@ return {
                     "Comienza la partida con",
 					"el vale {C:tarot,T:v_crystal_ball}#1#{}",
 					"y {C:attention}2{} copias",
-					"de {C:item,T:c_poke_twisted_spoon}#2#"
+					"de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             b_poke_obituarydeck = {
@@ -41,8 +41,8 @@ return {
                 name = "Baraja luminosa",
                 text = {
                     "Todos los comodines son",
-					"creados con {C:pink}1 energía{} y",
-					"con un sticker de un {C:pink}Tipo{} al azar"
+					"creados con {C:poke_pink}1 energía{} y",
+					"con un sticker de un {C:poke_pink}Tipo{} al azar"
                 }
             },
             b_poke_ampeddeck = {
@@ -51,7 +51,7 @@ return {
                     "Comienza la partida con",
 					"el vale {C:tarot,T:v_poke_energysearch}#1#{}",
 					"y una copia de",
-					"{C:pink,T:c_poke_double_rainbow_energy}#2#"
+					"{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
 			b_poke_futuredeck = {
@@ -89,10 +89,10 @@ return {
             b_poke_diceydeck = {
                 name = "Baraja tramposa",
                 text = {
-                    "{C:hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
+                    "{C:poke_hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
                     "Al final de cada ronda:",
                     "Gana {C:money}#4# ${} por cada carta",
-                    "{C:hazard}trampa{} en tu {C:attention}baraja completa",
+                    "{C:poke_hazard}trampa{} en tu {C:attention}baraja completa",
                     "No ganas {C:attention}intereses"
                 } 
             },
@@ -292,7 +292,7 @@ return {
                     "Es {C:attention}reusable{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "La {C:green,E:1,S:1.1}probabilidad{} de que",
-					"las cartas {C:hazard}trampa{}",
+					"las cartas {C:poke_hazard}trampa{}",
 					"se destruyan se vuelve {C:attention}0",
 					"hasta el final de la ronda",
                     "{C:inactive}(Usable una vez por ronda)",
@@ -302,17 +302,17 @@ return {
                 name = "Orbe Teracristal",
                 text = {
                     "{C:attention}Cambia Tipo:{} {B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.9}({C:pink,s:0.9}El tipo{C:inactive,s:0.9} cambia con cada descarte){}",
+                    "{C:inactive,s:0.9}({C:poke_pink,s:0.9}El tipo{C:inactive,s:0.9} cambia con cada descarte){}",
 					"{br:2}ERROR - CONTACT STEAK",
-					"{C:pink}Energiza{} al comodín más",
+					"{C:poke_pink}Energiza{} al comodín más",
 					"a la izquierda o seleccionado",
-                    "si ya es de {C:pink}tipo{} {B:1,V:2}#1#{}",
+                    "si ya es de {C:poke_pink}tipo{} {B:1,V:2}#1#{}",
                 },
             },
             c_poke_metalcoat = {
                 name = "Revestimiento Metálico",
                 text = {
-                    "{C:attention}Cambia Tipo:{} {X:metal,C:white}Metal{}",
+                    "{C:attention}Cambia Tipo:{} {X:poke_metal,C:white}Metal{}",
 					"{br:2}ERROR - CONTACT STEAK",
 					"Crea una copia con","mejora de {C:attention}carta de acero{}","de {C:attention}1{} carta seleccionada",
                 },
@@ -320,10 +320,10 @@ return {
             c_poke_dragonscale = {
                 name = "Escama Dragón",
                 text = {
-                    "{C:attention}Cambia Tipo:{} {X:dragon,C:white}Dragón{}",
+                    "{C:attention}Cambia Tipo:{} {X:poke_dragon,C:white}Dragón{}",
 					"{br:2}ERROR - CONTACT STEAK",
 					"Crea hasta {C:attention}3{}",
-					"{C:item}objetos{} o {C:pink}energías{} al azar",
+					"{C:poke_item}objetos{} o {C:poke_pink}energías{} al azar",
 					"{C:inactive}(Debe haber espacio){}"
                 },
             },
@@ -376,8 +376,8 @@ return {
             c_poke_twisted_spoon = {
                 name = "Cuchara Torcida",
                 text = {
-                    "Genera la última","carta de {C:item}objeto{} o {C:pink}energía{}",
-					"usada en esta partida","a excepción de {s:0.8,C:item}Cuchara Torcida,","{s:0.8,C:item}Reusables y Zumo de Bayas{s:0.8}"
+                    "Genera la última","carta de {C:poke_item}objeto{} o {C:poke_pink}energía{}",
+					"usada en esta partida","a excepción de {s:0.8,C:poke_item}Cuchara Torcida,","{s:0.8,C:poke_item}Reusables y Zumo de Bayas{s:0.8}"
                 }
             },
             c_poke_prismscale = {
@@ -423,7 +423,7 @@ return {
 					"Mejora {C:attention}1{} carta seleccionada a",
 					"{C:attention}carta de piedra{} con {C:chips}+#2#{} fichas",
 					"extra por cada comodín de",
-					"tipo {X:earth,C:white}Tierra{} que tengas"
+					"tipo {X:poke_earth,C:white}Tierra{} que tengas"
                 }
             },
             c_poke_miracleseed = {
@@ -442,7 +442,7 @@ return {
             c_poke_berry_juice_energy = {
                 name = "Zumo de Baya Energizado",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado de cualquier {C:pink}tipo{}","{C:inactive}(Máximo de {C:attention}#1# {C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado de cualquier {C:poke_pink}tipo{}","{C:inactive}(Máximo de {C:attention}#1# {C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_berry_juice_spectral = {
@@ -460,7 +460,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "Zumo de Baya Objetizado",
                 text = {
-                    "Crea una {C:item}Cuchara Torcida{}",
+                    "Crea una {C:poke_item}Cuchara Torcida{}",
 					"{C:green}#1# en #2#{} probabilidades de",
 					"crear {C:attention}2{} en su lugar","{C:inactive}(Debe haber espacio){}"
                 },
@@ -481,7 +481,7 @@ return {
             c_poke_berry_juice_mystery = {
                 name = "Zumo de Baya Misterioso",
                 text = {
-                    "Crea un {C:item}Zumo de Baya{} al azar"
+                    "Crea un {C:poke_item}Zumo de Baya{} al azar"
                 }
             },
             c_poke_heartscale = {
@@ -551,74 +551,74 @@ return {
             c_poke_grass_energy = {
                 name = "Energía Planta",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:grass,C:white}Planta{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_grass,C:white}Planta{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fire_energy = {
                 name = "Energía Fuego",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fire,C:white}Fuego{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fire,C:white}Fuego{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_water_energy = {
                 name = "Energía Agua",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:water,C:white}Agua{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_water,C:white}Agua{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_lightning_energy = {
                 name = "Energía Rayo",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:lightning,C:black}Rayo{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_lightning,C:black}Rayo{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_psychic_energy = {
                 name = "Energía Psíquica",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:psychic,C:white}Psíquico{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_psychic,C:white}Psíquico{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fighting_energy = {
                 name = "Energía Lucha",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fighting,C:white}Lucha{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fighting,C:white}Lucha{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_colorless_energy = {
                 name = "Energía Incolora",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:colorless,C:white}Incoloro{} disponible","Tiene la mitad de efectividad con","comodines que no son de tipo {X:colorless,C:white}Incoloro{}","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)"
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_colorless,C:white}Incoloro{} disponible","Tiene la mitad de efectividad con","comodines que no son de tipo {X:poke_colorless,C:white}Incoloro{}","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)"
                 },
             },
             c_poke_darkness_energy = {
                 name = "Energía Oscura",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:dark,C:white}Oscuro{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_dark,C:white}Oscuro{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_metal_energy = {
                 name = "Energía Metal",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:Metal,C:white}Metal{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:Metal,C:white}Metal{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_fairy_energy = {
                 name = "Energía Hada",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:fairy,C:white}Hada{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_fairy,C:white}Hada{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             --Dragon deez
             c_poke_dragon_energy = {
                 name = "Energía Dragón",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:dragon,C:white}Dragón{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_dragon,C:white}Dragón{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_earth_energy = {
                 name = "Energía Tierra",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:earth,C:white}Tierra{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
+                    "{C:poke_pink}Energiza{} al comodín más a la","izquierda o seleccionado","de tipo {X:poke_earth,C:white}Tierra{} disponible","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
             c_poke_emergy = {
@@ -1299,7 +1299,7 @@ return {
                 name = "Abra",
                 text = {
                     "{C:green}#1# en #2#{} probabilidades de crear una carta",
-					"de {C:item}objeto o {C:tarot}tarot{} si la {C:attention}mano de póker{}",
+					"de {C:poke_item}objeto o {C:tarot}tarot{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
 					"{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
                 } 
@@ -1308,7 +1308,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# en #2#{} probabilidades de crear una carta de",
-					"{C:tarot}tarot{} o una {C:item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
+					"{C:tarot}tarot{} o una {C:poke_item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
 					"{C:inactive}(Evoluciona con un {C:attention}Cordón Unión{C:inactive})"
                 } 
@@ -1318,7 +1318,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} ranura de consumible",
 					"{C:green}#1# en #2#{} probabilidades de crear {C:attention}El loco{} o",
-					"una {C:item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
+					"una {C:poke_item}Cuchara Torcida{} si la {C:attention}mano de póker{}",
 					"jugada ya ha sido jugada en esta ronda",
                 } 
             },
@@ -1328,7 +1328,7 @@ return {
                     "{C:attention}+#3#{} ranura de consumible",
 					"Todos los {C:attention}consumibles{} que",
 					"tienes otorgan {X:mult,C:white}X#1#{} multi",
-					"Las {C:item}Cucharas Torcidas{}","otorgan {X:mult,C:white}X#2#{} multi",
+					"Las {C:poke_item}Cucharas Torcidas{}","otorgan {X:mult,C:white}X#2#{} multi",
                 } 
             },
             j_poke_machop = {
@@ -1488,7 +1488,7 @@ return {
                 text = {
                     "Las {C:attention}cartas de acero{} jugadas",
 					"otorgan {X:mult,C:white}X#1#{} multi más {X:mult,C:white}X#2#{} multi por",
-					"cada comodín tipo {X:metal,C:white}Metal{} adyacente",
+					"cada comodín tipo {X:poke_metal,C:white}Metal{} adyacente",
 					"{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi)",
 					"{C:inactive}(Evoluciona con una {C:attention}Piedra Trueno{C:inactive})"
                 } 
@@ -1496,7 +1496,7 @@ return {
             j_poke_farfetchd = {
                 name = 'Farfetch\'d',      
                 text = {
-                    "{C:attention}Equipado con{} {C:item}Puerro{}",
+                    "{C:attention}Equipado con{} {C:poke_item}Puerro{}",
 					"{C:green}#2# en #3#{} probabilidades de ganar {C:money}#1# $",
 					"cuando un {C:attention}consumible{} es usado",
 					"{C:money}${} garantizado cuando se usan {C:attention}Puerros{}",
@@ -1619,7 +1619,7 @@ return {
                     "Cuando una carta que no es",
                     "{C:attention}de piedra{} es destruida, agrega una ",
                     "{C:attention}carta de piedra{} a tu {C:attention}baraja",
-					"{C:inactive}(Evoluciona con un sticker {C:metal}Metal{C:inactive})"
+					"{C:inactive}(Evoluciona con un sticker {C:poke_metal}Metal{C:inactive})"
                 } 
             },
             j_poke_drowzee = {
@@ -1693,7 +1693,7 @@ return {
             j_poke_cubone = {
                 name = 'Cubone',
                 text = {
-                    "{C:attention}Equipado con{} {C:item}Hueso Grueso{}",
+                    "{C:attention}Equipado con{} {C:poke_item}Hueso Grueso{}",
 					"Otorga {C:mult}+#1#{} multi por",
 					"cada {C:attention}consumible{} que tengas",
 					"{C:inactive,s:0.8}(Los {C:attention,s:0.8}Huesos Gruesos{C:inactive,s:0.8} cuentan doble){}",
@@ -1827,7 +1827,7 @@ return {
                     "Obtiene {C:mult}+#2#{} multi por cada {C:attention}6{} jugado",
 					"Se duplica si un {C:attention}rey{} está en tu mano",
 					"{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
-					"{C:inactive}(Evoluciona con un sticker {C:dragon}Dragón{C:inactive})"
+					"{C:inactive}(Evoluciona con un sticker {C:poke_dragon}Dragón{C:inactive})"
                 } 
             },
             j_poke_goldeen = {
@@ -1876,7 +1876,7 @@ return {
 					"Obtiene edición {C:dark_edition}laminado{}, {C:dark_edition}holográfico{}, o",
 					"{C:dark_edition}polícromo{} si era {C:rare}Rara{} o superior",
 					"{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
-					"{C:inactive}(Evoluciona con un sticker {C:metal}Metal","{C:inactive}o una {C:attention}Piedra Dura{C:inactive})",
+					"{C:inactive}(Evoluciona con un sticker {C:poke_metal}Metal","{C:inactive}o una {C:attention}Piedra Dura{C:inactive})",
                 } 
             },
             j_poke_jynx = {
@@ -1984,7 +1984,7 @@ return {
 					"{C:attention}Volátil a la derecha{}",
                     "{C:attention}Se transforma{} en el comodín más",
 					"a la izquierda con {C:attention}perecedero{}",
-					"y un sticker {C:colorless}Incoloro{}",
+					"y un sticker {C:poke_colorless}Incoloro{}",
 					"al final de la tienda","{C:inactive,s:0.9}(Excluye Dittos)",
                 } 
             },
@@ -2026,10 +2026,10 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} límite de energía",
-					"Crea una carta de {C:pink}energía{} cuando",
+                    "{C:poke_pink}+1{} límite de energía",
+					"Crea una carta de {C:poke_pink}energía{} cuando",
 					"abres un {C:attention}paquete potenciador{}",
-					"{C:inactive}(Evoluciona con una {C:metal}Mejora{C:inactive})",
+					"{C:inactive}(Evoluciona con una {C:poke_metal}Mejora{C:inactive})",
                 } 
             },
             j_poke_omanyte = {
@@ -2038,7 +2038,7 @@ return {
                     "{C:attention}#1#s Ancestrales{}",
 					"{X:attention,C:white}1+{} : Crea una carta de {C:tarot}tarot{}",
 					"{X:attention,C:white}2+{} : Gana {C:money}#2# ${}",
-					"{X:attention,C:white}3+{} : Crea un {C:item}objeto{}",
+					"{X:attention,C:white}3+{} : Crea un {C:poke_item}objeto{}",
 					"{C:inactive}(Debe haber espacio)",
                     "{C:inactive,s:0.9}(Activa la habilidad de {X:attention,C:white,s:0.9}3+{C:inactive,s:0.9}",
 					"{C:attention,s:0.9}#3#{C:inactive,s:0.9} veces para evolucionar)",
@@ -2050,7 +2050,7 @@ return {
                     "{C:attention}#1#s Ancestrales{}",
 					"{X:attention,C:white}1+{} : Crea una carta de {C:tarot}tarot{}",
 					"{X:attention,C:white}2+{} : Gana {C:money}#2# ${}",
-					"{X:attention,C:white}3+{} : Crea un {C:item}objeto{}",
+					"{X:attention,C:white}3+{} : Crea un {C:poke_item}objeto{}",
 					"{C:inactive}(Debe haber espacio)",
 					"{X:attention,C:white}4+{} : Crea una {C:attention}etiqueta{}",
 					"{C:inactive,s:0.8}(una vez por ronda) {C:inactive}#3#{}",
@@ -2105,7 +2105,7 @@ return {
             j_poke_snorlax = {
                 name = 'Snorlax',
                 text = {
-                    "{C:attention}Equipado con {C:item}Restos{}",
+                    "{C:attention}Equipado con {C:poke_item}Restos{}",
 					"Al final de la ronda obtiene {X:mult,C:white}X#1#{} multi",
 					"por cada {C:attention}Restos{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white} X#2# {C:inactive} multi)"
@@ -2170,7 +2170,7 @@ return {
                 text = {
                     "Cuando la {C:attention}ciega jefe{} es derrotada, destruye",
 					"al {C:attention}comodín{} más a la izquierda y crea",
-					"una {C:attention}copia{} {C:dark_edition}polícroma{} y {C:pink}energizada{}",
+					"una {C:attention}copia{} {C:dark_edition}polícroma{} y {C:poke_pink}energizada{}",
 					"{br:3}ERROR - CONTACT STEAK",
 					"Los comodines {C:dark_edition}polícromos{} otorgan {X:mult,C:white} X#1# {} multi",
 					"{C:inactive}(No puede destruirse a sí mismo)",
@@ -2185,12 +2185,12 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la izquierda",
+                    "{C:poke_pink}Energiza{} al comodín más a la izquierda",
 					"{C:attention}dos veces{} al final de la tienda",
 					"{br:2}ERROR - CONTACT STEAK",
-					"{C:pink}+1{} límite de energía cuando",
+					"{C:poke_pink}+1{} límite de energía cuando",
 					"la {C:attention}ciega jefe{} es derrotada",
-					"{C:inactive}(No puede {C:pink}energizarse{C:inactive} a sí mismo)",
+					"{C:inactive}(No puede {C:poke_pink}energizarse{C:inactive} a sí mismo)",
                 } 
             },
             j_poke_mew = {
@@ -2198,7 +2198,7 @@ return {
                 text = {
                     "Al final de la {C:attention}tienda{},",
 					"crea una carta de {C:tarot}tarot{},",
-					"{C:spectral}espectral{} o un {C:item}objeto{} {C:dark_edition}negativo{}",
+					"{C:spectral}espectral{} o un {C:poke_item}objeto{} {C:dark_edition}negativo{}",
 					"{br:3}ERROR - CONTACT STEAK",
 					"{C:green}#1#%{} probabilidades de crear un",
 					"comodín {C:dark_edition}negativo{} {C:attention}en su lugar{}",
@@ -2388,8 +2388,8 @@ return {
                   "Otorga {C:chips}+#1#{} fichas y gana {C:money}#2# ${}",
 				  "si la mano jugada contiene un {C:attention}Pareja",
 				  "{br:3}ERROR - CONTACT STEAK",
-				  "{C:chips}+#3#{} fichas extra por cada comodín tipo {X:water,C:white}Agua{}",
-				  "{C:money}#4# ${} extra por cada comodín tipo {X:lightning,C:black}Rayo{}",
+				  "{C:chips}+#3#{} fichas extra por cada comodín tipo {X:poke_water,C:white}Agua{}",
+				  "{C:money}#4# ${} extra por cada comodín tipo {X:poke_lightning,C:black}Rayo{}",
 				  "{C:inactive}(Actual {C:chips}+#6#{C:inactive} fichas y {C:money}#5# ${C:inactive})"
                 }
             },
@@ -2525,11 +2525,11 @@ return {
             j_poke_weird_tree = {
                 name = "Árbol extraño",
                 text = {
-                  "{C:attention}Cambia Tipo: {X:grass,C:white}Planta{}",
+                  "{C:attention}Cambia Tipo: {X:poke_grass,C:white}Planta{}",
 				  "{C:}Se transforma{} al final de la",
 				  "ronda si este comodín no es",
-				  "de tipo {X:grass,C:white}Planta{} o tienes un",
-				  "comodín tipo {X:water,C:white}Agua{}"
+				  "de tipo {X:poke_grass,C:white}Planta{} o tienes un",
+				  "comodín tipo {X:poke_water,C:white}Agua{}"
                 }
             },
             j_poke_bellossom = {
@@ -2546,7 +2546,7 @@ return {
                 text = {
                     "Reactiva la primera carta {V:1}#2#{} que anota",
                     "y luego la reactiva una vez por cada",
-                    "comodín tipo {X:water,C:white}Agua{} que tengas",
+                    "comodín tipo {X:poke_water,C:white}Agua{} que tengas",
                     "El palo rota en orden después de jugar",
                     "{C:inactive,s:0.8}(#3#, #4#, #5#, #6#)"
                 } 
@@ -2657,7 +2657,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:mult,C:white} X#1# {} multi por cada comodín",
-				"tipo {X:dark,C:white}Oscuro{} que tengas",
+				"tipo {X:poke_dark,C:white}Oscuro{} que tengas",
 				"{C:inactive}(Actual {X:mult,C:white} X#2#{C:inactive} multi)",
 				"{C:inactive}(Evoluciona con una {C:attention}Piedra Noche{C:inactive})"
               }
@@ -2766,7 +2766,7 @@ return {
                 name = "Mega Steelix",
                 text = {
                     "Las {C:attention}cartas de piedra{} cuentan como",
-					"{C:attention}cartas de acero{} y {C:hazard}trampa",
+					"{C:attention}cartas de acero{} y {C:poke_hazard}trampa",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Reactiva todas las cartas",
                     "{C:attention}en tu mano{} por cada {C:attention}#1#{} cartas",
@@ -2788,7 +2788,7 @@ return {
             j_poke_qwilfish = {
                 name = 'Qwilfish',
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Obtiene {C:chips}+#2#{} fichas cuando",
                     "una carta {C:attention}mejorada{}",
                     "es destruida",
@@ -2818,8 +2818,8 @@ return {
                 text = {
                   "Cuando se selecciona la {C:attention}ciega{},",
 				  "destruye el {C:attention}consumible{} más a la",
-				  "izquierda y crea un {C:item}Zumo de Baya{}",
-				  "{C:inactive}(No puede destruir {C:item}Zumos de Baya{C:inactive})"
+				  "izquierda y crea un {C:poke_item}Zumo de Baya{}",
+				  "{C:inactive}(No puede destruir {C:poke_item}Zumos de Baya{C:inactive})"
                 }
             },
             j_poke_sneasel = {
@@ -2844,7 +2844,7 @@ return {
             j_poke_ursaring = {
               name = "Ursaring",
               text = {
-                "Obtiene {C:mult}+#2#{} multi y crea un {C:item}objeto{}",
+                "Obtiene {C:mult}+#2#{} multi y crea un {C:poke_item}objeto{}",
 				"cuando cualquier {C:attention}paquete",
 				"{C:attention}potenciador{} es omitido",
 				"{C:inactive}(Debe haber espacio)",
@@ -2918,8 +2918,8 @@ return {
               text = {
                 "Cuando se selecciona la {C:attention}ciega{},",
 				"obtiene {C:mult}+#1#{} multi por cada comodín",
-				"tipo {X:water,C:white}Agua{} que tengas y crea",
-				"un Pokémon tipo {X:water,C:white}Agua{} {C:attention}básico{}",
+				"tipo {X:poke_water,C:white}Agua{} que tengas y crea",
+				"un Pokémon tipo {X:poke_water,C:white}Agua{} {C:attention}básico{}",
                 "{C:inactive}(Debe haber espacio)",
                 "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
               }
@@ -2962,9 +2962,9 @@ return {
             j_poke_skarmory = {
                 name = 'Skarmory',
                 text = {
-					"{C:hazard}+#1# Nivel y límite de trampas",
+					"{C:poke_hazard}+#1# Nivel y límite de trampas",
                     "{X:mult,C:white}X#2#{} multi por cada",
-                    "carta {C:hazard}trampa{} o {C:attention}de acero{}",
+                    "carta {C:poke_hazard}trampa{} o {C:attention}de acero{}",
                     "{C:attention}en tu mano{}",
                     "{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi)",
                 }
@@ -3001,11 +3001,11 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} límite de energía",
-					"Crea una carta de {C:pink}energía{} del mismo",
-					"{C:pink}tipo{} del comodín más a la izquierda",
+                    "{C:poke_pink}+2{} límite de energía",
+					"Crea una carta de {C:poke_pink}energía{} del mismo",
+					"{C:poke_pink}tipo{} del comodín más a la izquierda",
 					"cuando abres un {C:attention}paquete potenciador{}",
-					"{C:inactive}(Evoluciona con un {C:metal}Disco extraño{C:inactive})",
+					"{C:inactive}(Evoluciona con un {C:poke_metal}Disco extraño{C:inactive})",
                 } 
             },
             j_poke_stantler = {
@@ -3105,7 +3105,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Gana {C:money}#1# ${} por cada comodín",
-				  "tipo {C:colorless}Incoloro{} que tengas",
+				  "tipo {C:poke_colorless}Incoloro{} que tengas",
 				  "al final de la ronda",
 				  "{C:inactive}(Actual {C:money}#2# ${C:inactive}){}"
                 }
@@ -3236,7 +3236,7 @@ return {
 					"{C:attention}Naturaleza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Las cartas de {C:attention}naturaleza{} otorgan {C:money}#1# ${}",
                     "cuando anotan más {C:money}#5# ${} por cada",
-					"{C:attention}otro{} comodín tipo {X:grass,C:white}Planta{} que tengas",
+					"{C:attention}otro{} comodín tipo {X:poke_grass,C:white}Planta{} que tengas",
 					"{C:inactive}(Actual {C:money}#4# ${C:inactive} total){}"
                 } 
             },
@@ -3268,7 +3268,7 @@ return {
 					"Las cartas de {C:attention}naturaleza{}",
 					"otorgan {C:mult}+#1#{} multi cuando anotan",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Cada comodín tipo {X:fire,C:white}Fuego{} o {X:fighting,C:white}Lucha{}",
+                    "Cada comodín tipo {X:poke_fire,C:white}Fuego{} o {X:poke_fighting,C:white}Lucha{}",
                     "otorga {X:mult,C:white} X#2# {} multi si descartas",
                     "{C:attention}#4# {C:inactive}[#5#]{} cartas de {C:attention}naturaleza{}","en esta ronda"
                 } 
@@ -3302,7 +3302,7 @@ return {
 					"otorgan {C:chips}+#1#{} fichas cuando anotan",
                     "{br:2}ERROR - CONTACT STEAK",
                     "Crea una carta de {C:tarot}tarot{} por",
-					"cada {C:attention}2{} comodines tipo {X:water,C:white}Agua{} o {X:earth,C:white}Tierra{}",
+					"cada {C:attention}2{} comodines tipo {X:poke_water,C:white}Agua{} o {X:poke_earth,C:white}Tierra{}",
 					"que tengas si la mano de póker",
 					"contiene {C:attention}#3#{} cartas de {C:attention}Naturaleza",
                     "{C:inactive}(Debe haber espacio){}"
@@ -3324,7 +3324,7 @@ return {
                 "carta de juego es {C:attention}destruida",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {C:mult}+#3#{} multi más por cada",
-                "comodín tipo {X:dark,C:white}Oscuro{} que tengas",
+                "comodín tipo {X:poke_dark,C:white}Oscuro{} que tengas",
                 "{C:inactive}(Actual {C:mult}+#1#{C:inactive} multi)",
               }
             },
@@ -3332,7 +3332,7 @@ return {
               name = "Zigzagoon",
               text = {
                 "{C:green}#1# en #2#{} probabilidades",
-				"de {C:attention}recoger{} un {C:item}objeto{}",
+				"de {C:attention}recoger{} un {C:poke_item}objeto{}",
 				"cuando la mano es jugada",
 				"{C:inactive}(Debe haber espacio)",
 				"{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
@@ -3342,7 +3342,7 @@ return {
               name = "Linoone",
               text = {
                 "{C:green}#1# en #2#{} probabilidades",
-				"de {C:attention}recoger{} un {C:item}objeto{}",
+				"de {C:attention}recoger{} un {C:poke_item}objeto{}",
 				"cuando la mano es jugada",
 				"Garantizado si la mano",
 				"contiene una {C:attention}Escalera{}",
@@ -3439,14 +3439,14 @@ return {
                 "{s:0.9}La categoría cambia cada ronda",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Gana {C:money}#2# ${} más por cada",
-                "comodín tipo {X:water,C:white}Agua{} que tengas"
+                "comodín tipo {X:poke_water,C:white}Agua{} que tengas"
               }
             }, 
             j_poke_ralts = {
               name = "Ralts",
               text = {
                 "{C:mult}+#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y {C:planet}planeta{}",
+                "{C:poke_pink}energizado{} y {C:planet}planeta{}",
                 "en tus consumibles",
                 "{C:inactive}(Actual {C:mult}+#3#{C:inactive} multi)",
                 "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
@@ -3456,7 +3456,7 @@ return {
               name = "Kirlia",
               text = {
                 "{C:mult}+#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y {C:planet}planeta{}",
+                "{C:poke_pink}energizado{} y {C:planet}planeta{}",
                 "en tus consumibles",
                 "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                 "{C:inactive}(Evoluciona tras usar",
@@ -3470,7 +3470,7 @@ return {
                 "{C:attention}Equipado con{} {C:spectral}Agujero negro",
                 "{br:2}ERROR - CONTACT STEAK",
                 "{X:mult,C:white}X#1#{} multi por cada comodín",
-                "{C:pink}energizado{} y cada mano",
+                "{C:poke_pink}energizado{} y cada mano",
 				"con nivel {C:attention}#3# o más{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#2#{C:inactive} multi)",
               }
@@ -3547,8 +3547,8 @@ return {
                   "{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi)",
                   "{br:2.5}ERROR - CONTACT STEAK",
                   "{S:1.1,C:red,E:2}Se autodestruye{} si tienes un",
-                  "comodín tipo {X:fire,C:white}Fuego{}, {X:dark,C:white}Oscuro{}, {X:earth,C:white}Tierra{} o",
-                  "{X:psychic,C:white}Psíquico{} al final de la {C:attention}tienda",
+                  "comodín tipo {X:poke_fire,C:white}Fuego{}, {X:poke_dark,C:white}Oscuro{}, {X:poke_earth,C:white}Tierra{} o",
+                  "{X:poke_psychic,C:white}Psíquico{} al final de la {C:attention}tienda",
                   "{C:inactive}(Excluye Shedinjas){}"
                 }
             },
@@ -3564,7 +3564,7 @@ return {
                 name = "Hariyama",
                 text = {
                   "Gana {C:chips}+#1#{} mano por cada",
-                  "comodín tipo {X:fighting,C:white}Lucha{} que tengas",
+                  "comodín tipo {X:poke_fighting,C:white}Lucha{} que tengas",
                   "cuando se selecciona la {C:attention}ciega{}",
                 }
             },
@@ -3602,7 +3602,7 @@ return {
                   "Copia la habilidad del",
                   "comodín tipo {B:1,V:2}#1#{}",
                   "de la derecha",
-                  "con {C:pink}+#2#{} energía",
+                  "con {C:poke_pink}+#2#{} energía",
                   "{C:inactive,s:0.9}(El tipo cambia cada ronda){}",
                 }
             },
@@ -3672,7 +3672,7 @@ return {
                 "usas una carta de {C:planet}planeta{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Si tienes otro comodín tipo",
-				"{X:grass,C:white}Planta{}, obtiene {X:mult,C:white} X#4# {} también",
+				"{X:poke_grass,C:white}Planta{}, obtiene {X:mult,C:white} X#4# {} también",
                 "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas, {X:mult,C:white} X#3# {C:inactive} multi)"
               }
             },
@@ -3681,7 +3681,7 @@ return {
               text = {
 				"Cuando se selecciona la {C:attention}ciega{},",
 				"crea una carta de {C:planet}planeta{} por",
-				"cada comodín tipo {X:grass,C:white}Planta{} que tengas",
+				"cada comodín tipo {X:poke_grass,C:white}Planta{} que tengas",
 				"{C:inactive}(Debe haber espacio){}",
               }
             },
@@ -3769,7 +3769,7 @@ return {
             j_poke_cacnea = {
               name = "Cacnea",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
+                "{C:poke_hazard}+#1# Nivel de trampas",
                 "Gana {C:money}#2# ${} cuando una",
                 "carta es destruida",
                 "{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)",
@@ -3778,12 +3778,12 @@ return {
             j_poke_cacturne = {
               name = "Cacturne",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
+                "{C:poke_hazard}+#1# Nivel de trampas",
                 "Gana {C:money}#2# ${} cuando una",
                 "carta es destruida",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Destruye todas las cartas",
-                "{C:hazard}trampa{} en la {C:attention}primera{} mano",
+                "{C:poke_hazard}trampa{} en la {C:attention}primera{} mano",
                 "tras jugar una mano",
               }
             },
@@ -3803,7 +3803,7 @@ return {
 				"cuando sacas un {C:attention}9{} durante una {C:attention}ciega",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Garantizado si tienes otro",
-                "comodín tipo {X:dragon,C:white}Dragón{}",
+                "comodín tipo {X:poke_dragon,C:white}Dragón{}",
                 "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
               }
             },
@@ -3999,7 +3999,7 @@ return {
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {X:mult,C:white}X#2#{} multi y destruye una",
                 "carta al azar {C:attention}en tu mano{} cuando",
-                "una carta de {C:item}objeto{} o {C:tarot}tarot{} es {C:attention}vendida",
+                "una carta de {C:poke_item}objeto{} o {C:tarot}tarot{} es {C:attention}vendida",
                 "mientras abres un {C:attention}paquete potenciador{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#3# {C:inactive} multi)"
               }
@@ -4011,7 +4011,7 @@ return {
                 "abres un {C:attention}paquete potenciador{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Obtiene {X:mult,C:white}X#2#{} multi cuando una",
-                "una carta de {C:item}objeto{} o {C:tarot}tarot{} es {C:attention}usada",
+                "una carta de {C:poke_item}objeto{} o {C:tarot}tarot{} es {C:attention}usada",
                 "mientras abres un {C:attention}paquete potenciador{}",
                 "{C:inactive}(Actual {X:mult,C:white} X#3# {C:inactive} multi)"
               }
@@ -4155,14 +4155,14 @@ return {
                     "Copia la habilidad del",
 					"{C:attention}comodín{} a su derecha",
                     "si tienees {C:attention}#1# o más",
-                    "comodines {C:pink}energizados{}",
+                    "comodines {C:poke_pink}energizados{}",
                     "{C:inactive}(Actual {C:attention}#2#{C:inactive}/#1#){}"
                 }
             },
             j_poke_jirachi_copy = {
                 name = 'Jirachi',
                 text = {
-                    "Copia la habilidad del {C:attention}comodín{} a la","derecha como si estuviera {C:pink}energizado{} una vez adicional",
+                    "Copia la habilidad del {C:attention}comodín{} a la","derecha como si estuviera {C:poke_pink}energizado{} una vez adicional",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -4171,7 +4171,7 @@ return {
 					"Si el {C:attention}primer descarte{} tiene",
 					"solo {C:attention}1{} carta, la {C:attention}destruye{}",
                     "y crea una copia de {C:tarot}La muerte{},",
-                    "{C:spectral}Críptido{}, o {C:item}Revestimiento Metálico{}",
+                    "{C:spectral}Críptido{}, o {C:poke_item}Revestimiento Metálico{}",
                     "{C:inactive}(Debe haber espacio)",
                 }
             },
@@ -4253,7 +4253,7 @@ return {
                 text = {
                     "{C:attention}Bebé{}, {X:mult,C:white} X#1# {} multi",
                     "Crea una copia {C:dark_edition}negativa{} de",
-                    "{C:item}Semilla Milagro{} al final de la ronda",
+                    "{C:poke_item}Semilla Milagro{} al final de la ronda",
                     "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }
             },
@@ -4338,7 +4338,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Cada comodín tipo {X:dark,C:white}Oscuro{}",
+                  "Cada comodín tipo {X:poke_dark,C:white}Oscuro{}",
 				  "otorga {X:mult,C:white}X#1#{} multi",
                 }
             },
@@ -4382,7 +4382,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Bebé{}, {X:mult,C:white} X#1# {} multi",
-					"Crea un {C:item}objeto {C:dark_edition}negativo",
+					"Crea un {C:poke_item}objeto {C:dark_edition}negativo",
 					"al final de la {C:attention}ronda",
 					"{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }
@@ -4438,7 +4438,7 @@ return {
                 text = {
                     "Las {C:attention}cartas de acero{} jugadas",
 					"otorgan {X:mult,C:white}X#1#{} multi más {X:mult,C:white}X#2#{} multi por",
-					"cada comodín tipo {X:metal,C:white}Metal{} que tengas",
+					"cada comodín tipo {X:poke_metal,C:white}Metal{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white}X#3#{C:inactive} multi){}",
                 } 
             },
@@ -4461,7 +4461,7 @@ return {
 					"{br:3}ERROR - CONTACT STEAK",
 					"Las {C:attention}cartas de piedra{} se reactivan",
 					"una vez adicional por cada {C:attention}3{}",
-					"comodines tipo {X:earth,C:white}Tierra{} que tengas",
+					"comodines tipo {X:poke_earth,C:white}Tierra{} que tengas",
 					"{C:inactive}(Actualmente se reactivan {C:attention}#2#{} veces)"
                 } 
             },
@@ -4561,12 +4561,12 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} límite de energía",
+                    "{C:poke_pink}+3{} límite de energía",
 					"{X:mult,C:white} X#2# {} multi por cada carta de",
-					"{C:pink}energía{} usada en esta {C:attention}partida{}",
+					"{C:poke_pink}energía{} usada en esta {C:attention}partida{}",
 					"{br:2}text needs to be here to work",
-					"Crea una {C:pink}energía",
-					"cuando usas una {C:pink}energía",
+					"Crea una {C:poke_pink}energía",
+					"cuando usas una {C:poke_pink}energía",
 					"{C:inactive}(Debe haber espacio)",
 					"{C:inactive}(Actual {X:mult,C:white} X#1# {C:inactive} multi)"
                 } 
@@ -4607,7 +4607,7 @@ return {
                 text = {
                   "Adquiere hasta {C:mult}-#1# ${} de deuda",
 				  "{br:2.5}ERROR - CONTACT STEAK",
-				  "Crea un {C:item}objeto{} si",
+				  "Crea un {C:poke_item}objeto{} si",
 				  "juegas una mano",
 				  "mientras estás endeudado",
 				  "{C:inactive}(Debe haber espacio)",
@@ -4617,7 +4617,7 @@ return {
                 name = "Rotom",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4631,7 +4631,7 @@ return {
                 name = "Rotom (Calor)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4646,7 +4646,7 @@ return {
                 name = "Rotom (Lavado)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4661,7 +4661,7 @@ return {
               name = "Rotom (Frío)",
               text = {
 				"{C:green}#1# en #2#{} probabilidades de crear",
-				"una carta de {C:item}objeto{} cuando abres",
+				"una carta de {C:poke_item}objeto{} cuando abres",
 				"un {C:attention}paquete potenciador{}",
 				"{C:inactive}(Debe haber espacio){}",
 				"{br:2}ERROR - CONTACT STEAK",
@@ -4676,7 +4676,7 @@ return {
                 name = "Rotom (Ventilador)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4691,7 +4691,7 @@ return {
                 name = "Rotom (Podadora)",
                 text = {
                   "{C:green}#1# en #2#{} probabilidades de crear",
-                  "una carta de {C:item}objeto{} cuando abres",
+                  "una carta de {C:poke_item}objeto{} cuando abres",
                   "un {C:attention}paquete potenciador{}",
                   "{C:inactive}(Debe haber espacio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4779,7 +4779,7 @@ return {
                 text = {
                   "Cuando se selecciona la {C:attention}ciega{}, gana",
                   "{C:purple}+#2# Profecía{} por esta ronda por cada",
-                  "comodín tipo {X:psychic,C:white}Psíquico{} que tengas",
+                  "comodín tipo {X:poke_psychic,C:white}Psíquico{} que tengas",
                   "{br:3}ERROR - CONTACT STEAK",
                   "Cada carta {C:attention}mejorada profetizada{}",
                   "otorga {X:mult,C:white} X#1# {} multi",
@@ -4789,7 +4789,7 @@ return {
             j_poke_roggenrola = {
                 name = "Roggenrola",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
                     "{C:inactive}(Evoluciona tras activarse {C:attention}#3#{C:inactive} veces)",
@@ -4798,7 +4798,7 @@ return {
             j_poke_boldore = {
                 name = "Boldore",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
 					"{C:inactive}(Evoluciona con un {C:attention}Cordón Unión{C:inactive})"
@@ -4807,7 +4807,7 @@ return {
             j_poke_gigalith = {
                 name = "Gigalith",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
                     "Cada carta {C:attention}sin categoría{}",
                     "{C:attention}en tu mano{} otorga {C:mult}+#2#{} multi",
                     "y se reactiva"
@@ -4947,8 +4947,8 @@ return {
             j_poke_ferroseed = {
                 name = "Ferroseed",
                 text = {
-                  "{C:hazard}+#2# Nivel de trampas",
-                  "Las cartas {C:attention}versátiles{} y {C:hazard}trampa{}",
+                  "{C:poke_hazard}+#2# Nivel de trampas",
+                  "Las cartas {C:attention}versátiles{} y {C:poke_hazard}trampa{}",
                   "también son {C:attention}cartas de acero{}",
                   "{C:inactive}(Evoluciona tras {C:attention}#1#{C:inactive} rondas)",
                 }
@@ -4956,8 +4956,8 @@ return {
             j_poke_ferrothorn = {
               name = "Ferrothorn",
               text = {
-                "{C:hazard}+#1# Nivel de trampas",
-                "Las cartas {C:attention}versátiles{} y {C:hazard}trampa{}",
+                "{C:poke_hazard}+#1# Nivel de trampas",
+                "Las cartas {C:attention}versátiles{} y {C:poke_hazard}trampa{}",
                 "también son {C:attention}cartas de acero{}",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Si la mano jugada contiene",
@@ -5024,20 +5024,20 @@ return {
             j_poke_golett = {
                 name = "Golett",
                 text = {
-                  "{C:hazard}+#1# Nivel de trampas",
+                  "{C:poke_hazard}+#1# Nivel de trampas",
                   "{C:green}#4# en #5#{} probabilidades para cada carta",
                   "{C:attention}en tu mano{} de otorgar {X:mult,C:white}X#2#{} multi",
-                  "Garantizado para cartas {C:hazard}trampa{}",
+                  "Garantizado para cartas {C:poke_hazard}trampa{}",
                   "{C:inactive}(Evoluciona tras {C:attention}#3#{C:inactive} rondas)"
 				}
             },
             j_poke_golurk = {
                 name = "Golurk",
                 text = {
-                  "{C:hazard}+#1# Nivel de trampas",
+                  "{C:poke_hazard}+#1# Nivel de trampas",
                   "{C:green}#3# en #4#{} probabilidades para cada carta",
                   "{C:attention}en tu mano{} de otorgar {X:mult,C:white}X#2#{} multi", 
-                  "Garantizado para cartas {C:hazard}trampa{}",
+                  "Garantizado para cartas {C:poke_hazard}trampa{}",
 				}
             },
             j_poke_pawniard = {
@@ -5122,7 +5122,7 @@ return {
                     "{C:chips}+#1#{} fichas si la mano",
 					"jugada contiene un {C:attention}Color{}",
 					"{br:2}ERROR - CONTACT STEAK",
-					"Crea una carta de {C:pink}energía{} si",
+					"Crea una carta de {C:poke_pink}energía{} si",
 					"también contiene un {C:attention}rey{} o {C:attention}reina{}"
                 } 
             },
@@ -5180,7 +5180,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_average = {
@@ -5192,7 +5192,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_large = {
@@ -5204,7 +5204,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_gourgeist_super = {
@@ -5216,14 +5216,14 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "Gana {C:money}#3# ${} cuando una carta {C:spectral}espectral{}",
                   "es usada y aplica un sticker",
-                  "{X:psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
+                  "{X:poke_psychic,C:white}Psíquico{} al {C:attention}comodín{} más a la izquierda"
                 }
             },
             j_poke_grubbin = {
                 name = 'Grubbin',
                 text = {
                     "{C:mult}+#1#{} multi","Se {C:attention}triplica{} si tienes",
-					"un comodín tipo {X:lightning, C:black}Rayo{}",
+					"un comodín tipo {X:poke_lightning, C:black}Rayo{}",
 					"{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
                 }  
             },
@@ -5231,7 +5231,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} multi por cada comodín",
-					"tipo {X:lightning, C:black}Rayo{} que tengas",
+					"tipo {X:poke_lightning, C:black}Rayo{} que tengas",
 					"{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
 					"{C:inactive}(Evoluciona con una","{C:attention}Piedra Trueno{C:inactive})"
                 }  
@@ -5241,7 +5241,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} multi",
 					"{X:mult,C:white} X#1# {} multi por cada",
-					"comodín tipo {X:lightning, C:black}Rayo{} que tengas",
+					"comodín tipo {X:poke_lightning, C:black}Rayo{} que tengas",
 					"{C:inactive}(Actual {X:mult,C:white} X#2# {C:inactive} multi)",
                 }
             },
@@ -5382,10 +5382,10 @@ return {
             j_poke_hisuian_qwilfish = {
                 name = "Qwilfish (de Hisui)",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:inactive}(1 por cada #2# cartas en tu baraja)",
 					"Obtiene {C:chips}+#3#{} fichas cuando una",
-					"carta {C:hazard}trampa{} es sacada",
+					"carta {C:poke_hazard}trampa{} es sacada",
 					"{C:inactive}(Evoluciona cuando tiene",
 					"{C:chips}+#4#{C:inactive} / +#5# fichas)",
                 }
@@ -5393,10 +5393,10 @@ return {
             j_poke_overqwil = {
                 name = "Overqwil",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas",
+                    "{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:inactive}(1 por cada #2# cartas en tu baraja)"
 					,"Obtiene {C:chips}+#3#{} fichas cuando una",
-					"carta {C:hazard}trampa{} es sacada",
+					"carta {C:poke_hazard}trampa{} es sacada",
 					"{br:3}ERROR - CONTACT STEAK",
 					"{C:attention}Divide a la mitad{} las fichas tras jugar una mano",
 					"{C:inactive}(Actual {C:chips}+#4#{C:inactive} fichas)",
@@ -5429,7 +5429,7 @@ return {
             j_poke_ursaluna = {
               name = "Ursaluna",
               text = {
-				"Obtiene {C:mult}+#2#{} multi y crea un {C:item}objeto",
+				"Obtiene {C:mult}+#2#{} multi y crea un {C:poke_item}objeto",
 				"con {C:dark_edition}laminado{}, {C:dark_edition}holográfico{}, o {C:dark_edition}policromía{}",
 				"cuando cualquier {C:attention}paquete potenciador{}",
 				"es omitido",
@@ -5440,7 +5440,7 @@ return {
             j_poke_tarountula = {
                 name = "Tarountula",
                 text = {
-                    "{C:hazard}+#1# Nivel de trampas{}",
+                    "{C:poke_hazard}+#1# Nivel de trampas{}",
 					"{C:attention}+#3#{} tamaño de mano",
                     "{C:inactive}(Evoluciona tras {C:attention}#2#{C:inactive} rondas)",
 				}
@@ -5448,7 +5448,7 @@ return {
             j_poke_spidops = {
                 name = "Spidops",
                 text = {
-					"{C:hazard}+#1# Nivel de trampas",
+					"{C:poke_hazard}+#1# Nivel de trampas",
 					"{C:attention}+#2#{} tamaño de mano",
                     "Agrega un {C:attention}sello{} al azar a cada",
                     "{C:attention}octava{} {C:attention}carta de juego {C:inactive}[#4#]{}",
@@ -5465,7 +5465,7 @@ return {
 				  "{C:inactive,s:0.8}(Cuando es la más alta, se vuelve la menor)",
 				  "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
 				  "{C:inactive}(Evoluciona cuando tienes un",
-				  "{C:inactive}comodín tipo {X:fire,C:white}Fuego{C:inactive})",
+				  "{C:inactive}comodín tipo {X:poke_fire,C:white}Fuego{C:inactive})",
                 }
             },
             j_poke_dachsbun = {
@@ -5478,7 +5478,7 @@ return {
 				  "{C:inactive,s:0.9}(Cuando es la más alta, se vuelve la menor)",
 				  "{br:4}ERROR - CONTACT STEAK",
 				  "Aumenta las fichas ganadas en {C:chips}+2{} por",
-				  "cada comodín tipo {X:fire,C:white}Fuego{} que tengas",
+				  "cada comodín tipo {X:poke_fire,C:white}Fuego{} que tengas",
 				  "{C:inactive}(Actual {C:chips}+#1#{C:inactive} fichas)",
                 }
             },
@@ -5509,7 +5509,7 @@ return {
                 "al final de la ronda",
                 "{br:2.5}ERROR - CONTACT STEAK",
                 "Agrega el {C:attention}doble{} a comodines",
-				"tipo {X:grass,C:white}Planta{} y {C:pink}Energías {X:grass,C:white}Planta{}"
+				"tipo {X:poke_grass,C:white}Planta{} y {C:poke_pink}Energías {X:poke_grass,C:white}Planta{}"
               }
             },
             j_poke_charcadet = {
@@ -5569,7 +5569,7 @@ return {
             j_poke_rellor = {
                 name = 'Rellor',      
                 text = {
-                    "{C:mult}+#1#{} multi por cada {C:item}objeto{}",
+                    "{C:mult}+#1#{} multi por cada {C:poke_item}objeto{}",
                     "usado en esta partida",
                     "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                     "{C:inactive}(Evoluciona tras usar","{C:attention}#3#{C:inactive} objetos)",
@@ -5580,10 +5580,10 @@ return {
                 text = {
                     "{C:green}#3# en #4#{} probabilidades de crear",
                     "una carta de {C:tarot}tarot{} cuando",
-                    "usas un {C:item}objeto{}",
+                    "usas un {C:poke_item}objeto{}",
                     "{C:inactive}(Debe haber espacio){}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "{C:mult}+#1#{} multi por cada {C:item}objeto{}",
+                    "{C:mult}+#1#{} multi por cada {C:poke_item}objeto{}",
                     "usado en esta partida",
                     "{C:inactive}(Actual {C:mult}+#2#{C:inactive} multi)",
                 } 
@@ -5734,7 +5734,7 @@ return {
                 text = {
                     "Los {C:attention}paquetes potenciadores{}",
 					"cuestan {C:money}1 ${} menos",
-                    "por cada {C:pink}tipo{} diferente",
+                    "por cada {C:poke_pink}tipo{} diferente",
                     "de tus comodines",
                     "{C:inactive}(Actual {C:money}#1# ${C:inactive} menos)"
                 } 
@@ -5761,7 +5761,7 @@ return {
             j_poke_jelly_donut = {
                 name = "Rosquilla rellena",
                 text = {
-                  "Crea una {C:pink}energía{} {X:colorless,C:white}Incolora",
+                  "Crea una {C:poke_pink}energía{} {X:poke_colorless,C:white}Incolora",
 				  "cuando se selecciona la {C:attention}ciega",
 				  "{C:inactive}({C:attention}#1#{C:inactive} rondas restantes){}"
                 }
@@ -5793,8 +5793,8 @@ return {
                 text = {
                   "{C:attention}Cambia Tipo{}",
 				  "{br:2}ERROR - CONTACT STEAK",
-				  "Cambia el {C:pink}tipo{} del comodín más a la izquierda",
-				  "por el {C:pink}tipo{} del comodín más a la derecha",
+				  "Cambia el {C:poke_pink}tipo{} del comodín más a la izquierda",
+				  "por el {C:poke_pink}tipo{} del comodín más a la derecha",
 				  "cuando seleccionas la {C:attention}ciega",
 				  "{C:inactive}({C:attention}#1#{C:inactive} rondas restantes){}"
                 }
@@ -5862,7 +5862,7 @@ return {
             j_poke_mystery_egg = {
                 name = "Huevo misterioso",
                 text = {
-                  "Eclosiona en un Pokémon {C:attention}Básico{} o","{C:attention}Bebé{} tras {C:attention}#1#{} rondas y","{C:pink}energizado{} una vez si se puede"
+                  "Eclosiona en un Pokémon {C:attention}Básico{} o","{C:attention}Bebé{} tras {C:attention}#1#{} rondas y","{C:poke_pink}energizado{} una vez si se puede"
                 }
             },
             j_poke_daycare = {
@@ -5885,13 +5885,13 @@ return {
             j_poke_billion_lions = {
                 name = 'Un billón de leones',
                 text = {
-                    "Cuando la ciega es seleccionada, destruye","todos los comodines con un {C:pink}tipo{} que tengas","y obtiene {X:mult,C:white}X#2#{} multi por cada uno","{S:1.1,C:red,E:2}Se autodestruye{} cuando se quedá sin leones","{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi, {C:attention}#3#{C:inactive} leones)"
+                    "Cuando la ciega es seleccionada, destruye","todos los comodines con un {C:poke_pink}tipo{} que tengas","y obtiene {X:mult,C:white}X#2#{} multi por cada uno","{S:1.1,C:red,E:2}Se autodestruye{} cuando se quedá sin leones","{C:inactive}(Actual {X:mult,C:white}X#1#{C:inactive} multi, {C:attention}#3#{C:inactive} leones)"
                 } 
             },
             j_poke_spiclops = {
                 name = "Spiclops",
                 text = {
-                    "{C:hazard}+#1#{} Nivel de trampas, {C:attention}+#2#{} tamaño de mano",
+                    "{C:poke_hazard}+#1#{} Nivel de trampas, {C:attention}+#2#{} tamaño de mano",
                     "Apply a random {C:attention}seal{} to",
                     "every {C:attention}#3#th{} {C:attention}playing card {C:inactive}[#4#]{}",
                     "added to your deck",
@@ -5964,9 +5964,9 @@ return {
             sleeve_poke_obituarysleeve_alt = {
                 name = "Funda Obituaria",
                 text = {
-                    "Los {C:pink}sellos rosados{} tienen {C:green}#1# en #2#{} probabilidades",
+                    "Los {C:poke_pink}sellos rosados{} tienen {C:green}#1# en #2#{} probabilidades",
                     "de ser removidos tras activarse",
-                    "Los comodines crean una {C:pink}energía {C:dark_edition}negativa{} de",
+                    "Los comodines crean una {C:poke_pink}energía {C:dark_edition}negativa{} de",
                     "su tipo cuando son vendidos o destruidos",
                 },
             },
@@ -5980,7 +5980,7 @@ return {
               name = "Funda Renacida",
               text = {
                   "{C:blue}+#1#{} ranuras de consumible",
-                  "Los {C:pink}paquetes pokémon{} no",
+                  "Los {C:poke_pink}paquetes pokémon{} no",
                   "aparecerán en la tienda",
               },
             },
@@ -5988,27 +5988,27 @@ return {
                 name = "Funda Luminosa",
                 text = {
                     "Todos los comodines son",
-					"creados con {C:pink}1 energía{} y",
-					"con un sticker de un {C:pink}tipo{} al azar"
+					"creados con {C:poke_pink}1 energía{} y",
+					"con un sticker de un {C:poke_pink}tipo{} al azar"
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "Funda Luminosa",
                 text = {
                     "Los cambios tienen una {C:green}#1# en #2#{} probabilidades",
-                    "de crear un {C:item}Orbe Teracristal",
+                    "de crear un {C:poke_item}Orbe Teracristal",
                 },
             },
             sleeve_poke_telekineticsleeve = {
                 name = "Funda Telequinética",
                 text = {
-                    "Comienza la partida con","el vale {C:tarot,T:v_crystal_ball}#1#{}","y {C:attention}2{} copias","de la {C:item,T:c_poke_twisted_spoon}#2#"
+                    "Comienza la partida con","el vale {C:tarot,T:v_crystal_ball}#1#{}","y {C:attention}2{} copias","de la {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
 			sleeve_poke_telekineticsleeve_alt = {
                 name = "Funda Telequinética",
                 text = {
-                    "Las {C:item,T:c_poke_twisted_spoon}#2#s{}",
+                    "Las {C:poke_item,T:c_poke_twisted_spoon}#2#s{}",
                     "que tengas otorgan",
                     "{C:blue}+1{} ranura de consumible",
                 }
@@ -6016,15 +6016,15 @@ return {
             sleeve_poke_ampedsleeve = {
                 name = "Funda Energizada",
                 text = {
-                    "Comienza la partida con","el vale {C:tarot,T:v_poke_energysearch}#1#{}","y una copia de","{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "Comienza la partida con","el vale {C:tarot,T:v_poke_energysearch}#1#{}","y una copia de","{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "Funda Energizada",
                 text = {
                     "Comienza la partida con una {C:attention,T:j_poke_jelly_donut}#1#{} {C:dark_edition}negativa",
-                    "en vez de una {C:pink,T:c_poke_double_rainbow_energy}#2#",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{} ya no es la mitad de",
+                    "en vez de una {C:poke_pink,T:c_poke_double_rainbow_energy}#2#",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{} ya no es la mitad de",
                     "efectiva en comodines que no son tipo Normal",
                 } 
             },
@@ -6094,17 +6094,17 @@ return {
             sleeve_poke_diceysleeve = {
                 name = "Funda tramposa",
                 text = {
-                    "{C:hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
+                    "{C:poke_hazard}+#1# nivel y límite de trampas{}","{C:attention}+#1#{} tamaño de mano",
                     "Al final de cada ronda:",
                     "Gana {C:money}#4# ${} por cada carta",
-                    "{C:hazard}trampa{} en tu {C:attention}baraja completa",
+                    "{C:poke_hazard}trampa{} en tu {C:attention}baraja completa",
                     "No ganas {C:attention}intereses"
                 } 
             },
             sleeve_poke_diceysleeve_alt = {
                 name = "Funda tramposa",
                 text = {
-                    "Todas las {C:hazard}trampas{} otorgan {C:attention}+1{} tamaño de mano",
+                    "Todas las {C:poke_hazard}trampas{} otorgan {C:attention}+1{} tamaño de mano",
                 } 
             },
         },
@@ -6127,7 +6127,7 @@ return {
                     "Evoluciona al Pokémon más",
 					"a la izquierda o seleccionado a su",
                     "{C:attention}etapa{} más alta {C:inactive}(si puede){} y",
-                    "lo {C:pink}energiza{}", 
+                    "lo {C:poke_pink}energiza{}", 
                 },
             },
             c_poke_megastone = {
@@ -6144,30 +6144,30 @@ return {
             c_poke_obituary = {
                 name = "Obituario",
                 text = {
-                    "Agrega un {C:pink}sello rosado{}",
+                    "Agrega un {C:poke_pink}sello rosado{}",
 					"a {C:attention}1{} carta seleccionada",
                 }
             },
             c_poke_nightmare = {
                 name = "Pesadilla",
                 text = {
-                    "Destruye al comodín más a la izquierda","o seleccionado con {C:pink}tipo{}",
-					"y crea {C:attention}2{} {C:pink}energías{} {C:dark_edition}negativas{}","del {C:pink}tipo{} de ese comodín"
+                    "Destruye al comodín más a la izquierda","o seleccionado con {C:poke_pink}tipo{}",
+					"y crea {C:attention}2{} {C:poke_pink}energías{} {C:dark_edition}negativas{}","del {C:poke_pink}tipo{} de ese comodín"
                 },
             },
             c_poke_revenant = {
                 name = "Renacido",
                 text = {
-                    "Agrega un {C:item}sello plateado{}",
+                    "Agrega un {C:poke_item}sello plateado{}",
 					"a {C:attention}1{} carta seleccionada",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "Doble Energía Arcoíris",
                 text = {
-                    "{C:pink}Energiza{} al comodín más a la",
+                    "{C:poke_pink}Energiza{} al comodín más a la",
 					"izquierda o seleccionado de",
-					"cualquier {C:pink}tipo{} {C:red}d{C:attention}o{C:green}s{} {C:red}v{C:attention}e{C:green}c{C:blue}e{C:purple}s{}",
+					"cualquier {C:poke_pink}tipo{} {C:red}d{C:attention}o{C:green}s{} {C:red}v{C:attention}e{C:green}c{C:blue}e{C:purple}s{}",
 					"No ganas intereses esta ronda","{C:inactive}(Máximo de {C:attention}#1#","{C:inactive}aumentos por comodín)",
                 },
             },
@@ -6232,7 +6232,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Etiqueta Pokémon",
                 text = {
-                    "Otorga gratis un {C:pink}megapaquete Pokémon",
+                    "Otorga gratis un {C:poke_pink}megapaquete Pokémon",
 					"{C:green}#1#%{} de probabilidad de que contenga",
 					"una {C:attention}Megapiedra{} en una {C:attention}apuesta mayor a 5{}",
 					"{C:inactive,s:0.8}(La probabilidad no puede ser aumentada){}",
@@ -6242,7 +6242,7 @@ return {
                 name = "Etiqueta variocolor",
                 text = {
                     "El próximo comodín de la",
-					"tienda de la edición base es gratis y","se vuelve {C:colorless}variocolor{}",
+					"tienda de la edición base es gratis y","se vuelve {C:poke_colorless}variocolor{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -6254,7 +6254,7 @@ return {
             tag_poke_safari_tag = {
                 name = "Etiqueta de safari",
                 text = {
-                    "La tienda tiene un","Pokémon de {C:safari}Safari{} gratis",
+                    "La tienda tiene un","Pokémon de {C:poke_safari}Safari{} gratis",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -6288,13 +6288,13 @@ return {
             v_poke_energysearch = {
                 name = "Búsqueda de Energía",
                 text = {
-                    "{C:pink}+2{} límite de energía"
+                    "{C:poke_pink}+2{} límite de energía"
                 },
             },
             v_poke_energyresearch = {
                 name = "Investigación de Energía",
                 text = {
-                    "{C:pink}+3{} límite de energía"
+                    "{C:poke_pink}+3{} límite de energía"
                 },
             },
             v_poke_goodrod = {
@@ -6306,7 +6306,7 @@ return {
             v_poke_superrod = {
                 name = "Supercaña",
                 text = {
-                    "Puedes {C:pink}guardar{} cartas","de cualquier paquete de {C:attention}consumibles{}",
+                    "Puedes {C:poke_pink}guardar{} cartas","de cualquier paquete de {C:attention}consumibles{}",
                 },
             },
         },
@@ -6315,80 +6315,80 @@ return {
             Grass = {
                 name = "Tipo",
                 text = {
-                  "{X:grass,C:white}Planta{}",
+                  "{X:poke_grass,C:white}Planta{}",
                 }
             },
             Fire = {
                 name = "Tipo",
                 text = {
-                  "{X:fire,C:white}Fuego{}",
+                  "{X:poke_fire,C:white}Fuego{}",
                 }
             },
             Water = {
                 name = "Tipo",
                 text = {
-                  "{X:water,C:white}Agua{}",
+                  "{X:poke_water,C:white}Agua{}",
                 }
             },
             Lightning = {
                 name = "Tipo",
                 text = {
-                  "{X:lightning,C:black}Rayo{}",
+                  "{X:poke_lightning,C:black}Rayo{}",
                 }
             },
             Psychic = {
                 name = "Tipo",
                 text = {
-                  "{X:psychic,C:white}Psíquico{}",
+                  "{X:poke_psychic,C:white}Psíquico{}",
                 }
             },
             Fighting = {
                 name = "Tipo",
                 text = {
-                  "{X:fighting,C:white}Lucha{}",
+                  "{X:poke_fighting,C:white}Lucha{}",
                 }
             },
             Colorless = {
                 name = "Tipo",
                 text = {
-                  "{X:colorless,C:white}Incoloro{}",
+                  "{X:poke_colorless,C:white}Incoloro{}",
                 }
             },
             Dark = {
                 name = "Tipo",
                 text = {
-                  "{X:dark,C:white}Oscuro{}",
+                  "{X:poke_dark,C:white}Oscuro{}",
                 }
             },
             Metal = {
                 name = "Tipo",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Tipo",
                 text = {
-                  "{X:fairy,C:white}Hada{}",
+                  "{X:poke_fairy,C:white}Hada{}",
                 }
             },
             Dragon = {
                 name = "Tipo",
                 text = {
-                  "{X:dragon,C:white}Dragón{}",
+                  "{X:poke_dragon,C:white}Dragón{}",
                 }
             },
             Earth = {
                 name = "Tipo",
                 text = {
-                  "{X:earth,C:white}Tierra{}",
+                  "{X:poke_earth,C:white}Tierra{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "Tipo",
                 text = {
-                  "{X:bird,C:white}¿Pájaro?{}",
+                  "{X:poke_bird,C:white}¿Pájaro?{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -6537,8 +6537,8 @@ return {
               name = "Nivel de trampas",
               text = {
                   "Cuando sacas la {C:attention}primera{} mano, agrega",
-                  "tantas cartas {C:hazard}trampa{} a tu mano",
-                  "como tu {C:hazard}nivel de trampas",
+                  "tantas cartas {C:poke_hazard}trampa{} a tu mano",
+                  "como tu {C:poke_hazard}nivel de trampas",
                   "{C:inactive}(Nivel de trampas actual {C:attention}#1#{C:inactive}/#2#){}"
               }
             },
@@ -6546,8 +6546,8 @@ return {
               name = "Nivel de trampas",
               text = {
                   "Cuando sacas la {C:attention}primera{} mano, agrega",
-                  "tantas cartas {C:hazard}trampa{} a tu mano",
-                  "igual a tu {C:hazard}nivel de trampas",
+                  "tantas cartas {C:poke_hazard}trampa{} a tu mano",
+                  "igual a tu {C:poke_hazard}nivel de trampas",
                   "{C:inactive}(Nivel de trampas actual {C:attention}#1#{C:inactive}/#2#){}",
                   "{C:inactive}(Nivel de trampas extra aumentan el límite){}"
               }
@@ -6610,7 +6610,7 @@ return {
                 name = "Regalos",
                 text = {
                     "{C:green}35%{} - {C:money}8 ${}",
-					"{C:green}30%{} - {C:attention}Carta de {C:item}objeto{}",
+					"{C:green}30%{} - {C:attention}Carta de {C:poke_item}objeto{}",
 					"{C:green}20%{} - {C:attention}Etiqueta de cupón",
 					"{C:green}15%{} - {C:attention}Carta de regalo{}",
 					"con {C:dark_edition}policromía{}",
@@ -6628,9 +6628,9 @@ return {
             dril_treasure = {
                 name = "Tesoros",
                 text = {
-                    "{C:green}30%{} - {C:item}Piedra {C:attention}evolutiva   ",
+                    "{C:green}30%{} - {C:poke_item}Piedra {C:attention}evolutiva   ",
                     "{C:green}30%{} - {C:money}5 ${}               ",
-                    "{C:green}20%{} - {C:attention}2 {C:item}Piedras {C:attention}evolutivas",
+                    "{C:green}20%{} - {C:attention}2 {C:poke_item}Piedras {C:attention}evolutivas",
                     "{C:green}15%{} - {C:money}10 ${}              ",
                     "{C:green}5%{} - {C:money}20 ${}             ",
                 }
@@ -6638,9 +6638,9 @@ return {
             exdril_treasure = {
                 name = "Tesoros",
                 text = {
-                    "{C:green}30%{} - {C:item}Piedra {C:attention}evolutiva   ",
+                    "{C:green}30%{} - {C:poke_item}Piedra {C:attention}evolutiva   ",
                     "{C:green}30%{} - {C:money}5 ${}               ",
-                    "{C:green}20%{} - {C:attention}2 {C:item}Piedras {C:attention}evolutivas",
+                    "{C:green}20%{} - {C:attention}2 {C:poke_item}Piedras {C:attention}evolutivas",
                     "{C:green}15%{} - {C:money}10 ${}              ",
                     "{C:green}4%{} - {C:money}20 ${}             ",
                     "{C:green}1%{} - {C:attention}Megapiedra       ",
@@ -6649,10 +6649,10 @@ return {
             pickup = {
               name = "Recogida",
               text = {
-                "{C:green}34%{} - {C:item}Carta de objeto{}",
-				"{C:green}25%{} - {C:item}Carta evolutiva",
-				"{C:green}20%{} - {C:item}Restos",
-				"{C:green}20%{} - {C:item}Cuchara Torcida",
+                "{C:green}34%{} - {C:poke_item}Carta de objeto{}",
+				"{C:green}25%{} - {C:poke_item}Carta evolutiva",
+				"{C:green}20%{} - {C:poke_item}Restos",
+				"{C:green}20%{} - {C:poke_item}Cuchara Torcida",
 				"{C:green}1%{} - {C:spectral}Transformación",
               }
             },
@@ -6712,7 +6712,7 @@ return {
             eeveelution = {
                 name = "Evoluciones",
                 text = {
-                    "{C:attention}Piedra Agua{} - {X:water,C:white}Vaporeon{}","{C:attention}Piedra Trueno{} - {X:lightning,C:black}Jolteon{}","{C:attention}Piedra Fuego{} - {X:fire,C:white}Flareon{}","{C:attention}Piedra Solar{} - {X:psychic,C:white}Espeon{}","{C:attention}Piedra Lunar{} - {X:dark,C:white}Umbreon{}","{C:attention}Piedra Hoja{} - {X:grass,C:white}Leafeon{}","{C:attention}Piedra Hielo{} - {X:water,C:white}Glaceon{}","{C:attention}Piedra Día{} - {X:fairy,C:white}Sylveon{}"
+                    "{C:attention}Piedra Agua{} - {X:poke_water,C:white}Vaporeon{}","{C:attention}Piedra Trueno{} - {X:poke_lightning,C:black}Jolteon{}","{C:attention}Piedra Fuego{} - {X:poke_fire,C:white}Flareon{}","{C:attention}Piedra Solar{} - {X:poke_psychic,C:white}Espeon{}","{C:attention}Piedra Lunar{} - {X:poke_dark,C:white}Umbreon{}","{C:attention}Piedra Hoja{} - {X:poke_grass,C:white}Leafeon{}","{C:attention}Piedra Hielo{} - {X:poke_water,C:white}Glaceon{}","{C:attention}Piedra Día{} - {X:poke_fairy,C:white}Sylveon{}"
                 }
             },
             poke_egg_tip = {
@@ -6770,14 +6770,14 @@ return {
             unlimited_energy_tooltip = {
               name = "Energía ilimitada",
               text = {
-                "Puedes usar {C:pink}energías{} en comodines",
+                "Puedes usar {C:poke_pink}energías{} en comodines",
 				"cuantas veces quieras"
               }
             },
             precise_energy_tooltip = {
                 name = "Escalado preciso de energía",
                 text = {
-                    "{s:0.8}Usa {C:attention,s:0.8}decimales{} para todos los valores cuando se aplican los {s:0.8}aumentos{} por {C:pink,s:0.8}energías{}",
+                    "{s:0.8}Usa {C:attention,s:0.8}decimales{} para todos los valores cuando se aplican los {s:0.8}aumentos{} por {C:poke_pink,s:0.8}energías{}",
 					"{s:0.8}Con esta opción {C:attention,s:0.8}apagada{}{s:0.8} lo siguiente ocurrirá para el aumento:{}",
 					"{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}multi - Usa decimales",
 					"{C:attenion}2. {s:0.8}+ {C:mult,s:0.8}multi{}{s:0.8} y {C:chips,s:0.8}fichas{}{s:0.8} - Se aproxima al número entero más cercano",
@@ -6860,7 +6860,7 @@ return {
             hazards_on_tooltip = {
               name = "Cartas trampa permitidas",
               text = {
-                "Aparecerán comodines {C:attention}Pokémon{}","que agreguen cartas {C:hazard}trampa{}"
+                "Aparecerán comodines {C:attention}Pokémon{}","que agreguen cartas {C:poke_hazard}trampa{}"
               }
             },
             shinyplayingcard_tooltip = {
@@ -6949,7 +6949,7 @@ return {
             allowpokeballs_tooltip = {
               name = "Permitir Poké Balls",
               text = {
-                "Permite que los {C:item}objetos{} de Poké Balls aparezcan",
+                "Permite que los {C:poke_item}objetos{} de Poké Balls aparezcan",
               }
             },
             pokemaster_tooltip = {
@@ -6993,7 +6993,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Sello rosado",
                 text = {
-                    "Crea una carta de {C:pink}energía{}",
+                    "Crea una carta de {C:poke_pink}energía{}",
 					"del {C:attention}tipo{} de un comodín",
 					"que tienes si anota en la",
 					"{C:attention}primera mano{} de la ronda",
@@ -7005,7 +7005,7 @@ return {
             poke_silver_seal = {
                 name = "Sello plateado",
                 text = {
-                  "Crea una carta de {C:item}objeto{}",
+                  "Crea una carta de {C:poke_item}objeto{}",
 				  "y es {C:attention}descartada{} si está en",
 				  "{C:attention}en tu mano{} cuando anotas fichas"
                 }
@@ -7023,73 +7023,73 @@ return {
             grass_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:grass,C:white}Planta{}"
+                    "{X:poke_grass,C:white}Planta{}"
                 } 
             },
             fire_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fire,C:white}Fuego{}"
+                    "{X:poke_fire,C:white}Fuego{}"
                 } 
             },
             water_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:water,C:white}Agua{}"
+                    "{X:poke_water,C:white}Agua{}"
                 } 
             },
             lightning_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:lightning,C:white}Rayo{}"
+                    "{X:poke_lightning,C:white}Rayo{}"
                 } 
             },
             psychic_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:psychic,C:white}Psíquico{}"
+                    "{X:poke_psychic,C:white}Psíquico{}"
                 } 
             },
             fighting_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fighting,C:white}Lucha{}"
+                    "{X:poke_fighting,C:white}Lucha{}"
                 } 
             },
             colorless_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:colorless,C:white}Incoloro{}"
+                    "{X:poke_colorless,C:white}Incoloro{}"
                 } 
             },
             dark_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dark,C:white}Oscuro{}"
+                    "{X:poke_dark,C:white}Oscuro{}"
                 } 
             },
             metal_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fairy,C:white}Hada{}"
+                    "{X:poke_fairy,C:white}Hada{}"
                 } 
             },
             dragon_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dragon,C:white}Dragón{}"
+                    "{X:poke_dragon,C:white}Dragón{}"
                 } 
             },
             earth_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:earth,C:white}Tierra{}"
+                    "{X:poke_earth,C:white}Tierra{}"
                 } 
             },
             --]]
@@ -7110,49 +7110,49 @@ return {
             p_poke_pokepack_normal_1 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "Paquete Pokémon jumbo",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "Paquete Pokémon mega",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "Paquete Pokémon",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "Paquete Pokémon jumbo",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "Paquete Pokémon mega",
                 text = {
-                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:item}objeto{}"," y {C:attention}#3#{} cartas de {C:pink}energía{}",
+                    "Elige {C:attention}#1#{} de hasta","{C:attention}#2#{} cartas de {C:poke_item}objeto{}"," y {C:attention}#3#{} cartas de {C:poke_pink}energía{}",
                 },
             },
             p_poke_pokepack_wish_pack = {
@@ -7180,7 +7180,7 @@ return {
                 text = {
                     "Cuando se selecciona la {C:attention}ciega{},",
 					"{C:attention}#1#{} cartas sin mejora en tu baraja",
-                    "se vuelven cartas {C:hazard}trampa{}",
+                    "se vuelven cartas {C:poke_hazard}trampa{}",
                 },
             },
             poke_elite_sticker = {

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -45,7 +45,7 @@ return {
                     "Commencez la partie avec",
                     "le coupon {C:tarot,T:v_crystal_ball}#1#{}",
                     "et {C:attention}2{} copies",
-                    "de {C:item,T:c_poke_twisted_spoon}#2#"
+                    "de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             b_poke_obituarydeck = {
@@ -58,8 +58,8 @@ return {
                 name = "Jeu lumineux",
                 text = {
                     "Tous les Jokers sont créés",
-                    "avec un autocollant {C:pink}Type{} aléatoire",
-                    "et ont {C:attention}+1{} {C:pink}Énergie{}"
+                    "avec un autocollant {C:poke_pink}Type{} aléatoire",
+                    "et ont {C:attention}+1{} {C:poke_pink}Énergie{}"
                 }
             },
         },
@@ -187,7 +187,7 @@ return {
             c_poke_teraorb = {
                 name = "Orbe Téracristal",
                 text = {
-                    "Donne {C:attention}+1{} {C:pink}Énergie{} au Joker",
+                    "Donne {C:attention}+1{} {C:poke_pink}Énergie{} au Joker",
                     "le plus à gauche ou sélectionné{}",
                     "{C:attention}Change-Type{}"
                 },
@@ -204,7 +204,7 @@ return {
                 name = "Écaille Draco",
                 text = {
                     "Crée jusqu'à {C:attention}3{} cartes",
-                    "{C:item}Objet{} ou {C:pink}Énergie{} aléatoires",
+                    "{C:poke_item}Objet{} ou {C:poke_pink}Énergie{} aléatoires",
                     "{C:attention}Change-Type{}",
                     "{C:inactive}(Selon la place disponible){}"
                 },
@@ -258,9 +258,9 @@ return {
                 name = "Cuillière Tordue",
                 text = {
                     "Crée la dernière",
-                    "carte {C:item}Objet{} ou {C:pink}Énergie{} utilisée",
+                    "carte {C:poke_item}Objet{} ou {C:poke_pink}Énergie{} utilisée",
                     "pendant cette partie",
-                    "{s:0.8}Sauf {s:0.8,C:item}Cuillière Tordue et Réutilisables"
+                    "{s:0.8}Sauf {s:0.8,C:poke_item}Cuillière Tordue et Réutilisables"
                 }
             },
             c_poke_prismscale = {
@@ -297,7 +297,7 @@ return {
                 text = {
                     "Améliore {C:attention}1{} carte sélectionnée en",
                     "{C:attention}Carte Pierre{} avec {C:chips}+#2#{} Jetons supplémentaires",
-                    "pour chaque Joker {X:earth,C:white}Terre{} que vous avez"
+                    "pour chaque Joker {X:poke_earth,C:white}Terre{} que vous avez"
                 }
             },
         },
@@ -305,7 +305,7 @@ return {
             c_poke_grass_energy = {
                 name = "Énergie Plante",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:grass,C:white}Plante{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_grass,C:white}Plante{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -313,7 +313,7 @@ return {
             c_poke_fire_energy = {
                 name = "Énergie Feu",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:fire,C:white}Feu{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_fire,C:white}Feu{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -321,7 +321,7 @@ return {
             c_poke_water_energy = {
                 name = "Énergie Eau",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:water,C:white}Eau{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_water,C:white}Eau{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -329,7 +329,7 @@ return {
             c_poke_lightning_energy = {
                 name = "Énergie Électrique",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:lightning,C:white}Électrique{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_lightning,C:white}Électrique{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -337,7 +337,7 @@ return {
             c_poke_psychic_energy = {
                 name = "Énergie Psy",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:psychic,C:white}Psy{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_psychic,C:white}Psy{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -345,7 +345,7 @@ return {
             c_poke_fighting_energy = {
                 name = "Énergie Combat",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:fighting,C:white}Combat{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_fighting,C:white}Combat{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -353,17 +353,17 @@ return {
             c_poke_colorless_energy = {
                 name = "Énergie Incolore",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:colorless,C:white}Incolore{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_colorless,C:white}Incolore{}",
                     "le plus à gauche ou sélectionné si possible",
                     "Moitié moins efficace sur",
-                    "les Jokers non-{X:colorless,C:white}Incolores{}",
+                    "les Jokers non-{X:poke_colorless,C:white}Incolores{}",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)"
                 },
             },
             c_poke_darkness_energy = {
                 name = "Énergie Obscurité",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:dark,C:white}Obscurité{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_dark,C:white}Obscurité{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -371,7 +371,7 @@ return {
             c_poke_metal_energy = {
                 name = "Énergie Métal",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:metal,C:white}Métal{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_metal,C:white}Métal{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -379,7 +379,7 @@ return {
             c_poke_fairy_energy = {
                 name = "Énergie Fée",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:fairy,C:white}Fée{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_fairy,C:white}Fée{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -388,7 +388,7 @@ return {
             c_poke_dragon_energy = {
                 name = "Énergie Dragon",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:dragon,C:white}Dragon{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_dragon,C:white}Dragon{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -396,7 +396,7 @@ return {
             c_poke_earth_energy = {
                 name = "Énergie Terre",
                 text = {
-                    "{C:pink}Énergise{} le Joker {X:earth,C:white}Terre{}",
+                    "{C:poke_pink}Énergise{} le Joker {X:poke_earth,C:white}Terre{}",
                     "le plus à gauche ou sélectionné si possible",
                     "{C:inactive}(Maximum de {C:attention}#1#{C:inactive} augmentations par Joker)",
                 },
@@ -1032,7 +1032,7 @@ return {
             j_poke_abra = {
                 name = "Abra",
                 text = {
-                    "{C:green}#1# in #2#{} chance to create an {C:item}Item",
+                    "{C:green}#1# in #2#{} chance to create an {C:poke_item}Item",
                     "or {C:tarot}Tarot{} card if played {C:attention}poker hand{}",
                     "has already been played this round",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#3#{C:inactive,s:0.8} rounds)",
@@ -1042,7 +1042,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# in #2#{} chance to create a {C:tarot}Tarot{} or",
-                    "{C:item}Twisted Spoon{} card if played {C:attention}poker hand{}",
+                    "{C:poke_item}Twisted Spoon{} card if played {C:attention}poker hand{}",
                     "has already been played this round",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Linking Cord{C:inactive,s:0.8})"
                 } 
@@ -1052,7 +1052,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} consumable slot",
                     "{C:green}#1# in #2#{} chance to create a {C:attention}Fool{} or",
-                    "{C:item}Twisted Spoon{} card if played {C:attention}poker hand{}",
+                    "{C:poke_item}Twisted Spoon{} card if played {C:attention}poker hand{}",
                     "has already been played this round",
                 } 
             },
@@ -1061,7 +1061,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} consumable slot",
                     "Every held {C:attention}Consumable{} gives {X:mult,C:white}X#1#{} Mult",
-                    "{C:item}Twisted Spoons{} give {X:mult,C:white}X#2#{} Mult",
+                    "{C:poke_item}Twisted Spoons{} give {X:mult,C:white}X#2#{} Mult",
                 } 
             },
             j_poke_machop = {
@@ -1220,7 +1220,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards give {X:red,C:white}X#1#{} Mult",
                     "plus {X:red,C:white}X#2#{} Mult for each",
-                    "adjacent {X:metal,C:white}Metal{} Joker",
+                    "adjacent {X:poke_metal,C:white}Metal{} Joker",
                     "{C:inactive}(Currently {X:red,C:white}X#3#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Thunder Stone{C:inactive,s:0.8})"
                 } 
@@ -1352,7 +1352,7 @@ return {
                     "The leftmost scoring card of",
                     "{C:attention}first hand{} of round",
                     "becomes a {C:attention}Stone{} card",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Metal{C:inactive,s:0.8} sticker)"
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Metal{C:inactive,s:0.8} sticker)"
                 } 
             },
             j_poke_drowzee = {
@@ -1553,7 +1553,7 @@ return {
                     "Gains {C:mult}+#2#{} Mult for each scored {C:attention}6{}",
                     "Doubled if a {C:attention}King{} is held in hand",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolves with a {C:dragon,s:0.8}Dragon{C:inactive,s:0.8} sticker)"
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_dragon,s:0.8}Dragon{C:inactive,s:0.8} sticker)"
                 } 
             },
             j_poke_goldeen = {
@@ -1601,7 +1601,7 @@ return {
                     "Gain {C:dark_edition}Foil{}, {C:dark_edition}Holographic{}, or {C:dark_edition}Polychrome{}",
                     "if it was {C:red}Rare{} or higher",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Metal{C:inactive,s:0.8} sticker or a {C:attention,s:0.8}Hard Stone{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Metal{C:inactive,s:0.8} sticker or a {C:attention,s:0.8}Hard Stone{C:inactive,s:0.8})",
                 } 
             },
             j_poke_jynx = {
@@ -1612,7 +1612,7 @@ return {
                     "{br:4}ERROR - CONTACT STEAK",
                     "{C:attention}Playing cards{} added to your",
                     "deck from the {C:attention}Shop{}, {C:attention}Standard{} packs,",
-                    "{C:spectral}Cryptid{}, {C:item}Items{} and certain Jokers",
+                    "{C:spectral}Cryptid{}, {C:poke_item}Items{} and certain Jokers",
                     "are {C:attention}duplicated{}"
                 } 
             },
@@ -1704,7 +1704,7 @@ return {
                 text = {
                     "Sell this to duplicate the leftmost",
                     "Joker with {C:attention}Perishable{} and",
-                    "a {C:colorless}Colorless{} sticker",
+                    "a {C:poke_colorless}Colorless{} sticker",
                     "{C:inactive,s:0.8}(removes Eternal, excludes Dittos)",
                 } 
             },
@@ -1743,10 +1743,10 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} Energy Limit",
-                    "Create an {C:pink}Energy{} card when",
+                    "{C:poke_pink}+1{} Energy Limit",
+                    "Create an {C:poke_pink}Energy{} card when",
                     "any {C:attention}Booster Pack{} is opened",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Upgrade{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Upgrade{C:inactive,s:0.8})",
                 } 
             },
             j_poke_omanyte = {
@@ -1755,7 +1755,7 @@ return {
                     "{C:attention}Ancient #1#s{}",
                     "{X:attention,C:white}1+{} : Create a {C:tarot}Tarot{} card",
                     "{X:attention,C:white}2+{} : Earn {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Create a {C:item}Item{} card",
+                    "{X:attention,C:white}3+{} : Create a {C:poke_item}Item{} card",
                     "{C:inactive,s:0.8}(Must have room)",
                     "{C:inactive,s:0.8}(Evolves after triggering third level {C:attention,s:0.8}#3#{C:inactive,s:0.8} times)"
                 } 
@@ -1766,7 +1766,7 @@ return {
                     "{C:attention}Ancient #1#s{}",
                     "{X:attention,C:white}1+{} : Create a {C:tarot}Tarot{} card",
                     "{X:attention,C:white}2+{} : Earn {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Create a {C:item}Item{} card",
+                    "{X:attention,C:white}3+{} : Create a {C:poke_item}Item{} card",
                     "{C:inactive,s:0.8}(Must have room)",
                     "{X:attention,C:white}4+{} : Create a {C:attention}tag{} once per round{C:inactive}#3#{}",
                 } 
@@ -1880,7 +1880,7 @@ return {
                 text = {
                     "At end of shop, create a",
                     "{C:dark_edition}Polychrome{} {C:attention}duplicate{} of leftmost",
-                    "{C:attention}Joker{} and {C:pink}Energize{} the {C:attention}duplicate{}",
+                    "{C:attention}Joker{} and {C:poke_pink}Energize{} the {C:attention}duplicate{}",
                     "then destroy leftmost {C:attention}Joker{}",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:dark_edition}Polychrome{} Jokers give {X:mult,C:white} X#1# {} Mult",
@@ -1896,10 +1896,10 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "{C:pink}Energize{} leftmost joker {C:attention}twice{}",
+                    "{C:poke_pink}Energize{} leftmost joker {C:attention}twice{}",
                     "at end of shop",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "{C:pink}+1{} Energy Limit when",
+                    "{C:poke_pink}+1{} Energy Limit when",
                     "{C:attention}Boss Blind{} is defeated"
                 } 
             },
@@ -1908,7 +1908,7 @@ return {
                 text = {
                     "At the end of the {C:attention}shop{},",
                     "create a {C:dark_edition}Negative{} {C:tarot}Tarot{},",
-                    "{C:spectral}Spectral{} or {C:item}Item{} card",
+                    "{C:spectral}Spectral{} or {C:poke_item}Item{} card",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:green}#1#%{} chance to create a",
                     "{C:dark_edition}Negative{} Joker {C:attention}instead{}",
@@ -2168,8 +2168,8 @@ return {
                   "Played {C:attention}face{} cards give {C:mult}+#1#{} Mult when scored",
                   "{br:3.5}ERROR - CONTACT STEAK",
                   "Retrigger all played {C:attention}face{} cards if",
-                  "this Joker isn't {X:grass,C:white}Grass{} or",
-                  "you have a {X:water,C:white}Water{} Joker"
+                  "this Joker isn't {X:poke_grass,C:white}Grass{} or",
+                  "you have a {X:poke_water,C:white}Water{} Joker"
                 }
             },
             j_poke_bellossom = {
@@ -2188,7 +2188,7 @@ return {
                     "Played {V:1}#2#{} cards give {C:mult}+#1#{} Mult when scored",
                     "{br:5}ERROR - CONTACT STEAK",
                     "Retrigger {V:1}#2#{} cards based on",
-                    "how many {X:water,C:white}Water{} Jokers you have",
+                    "how many {X:poke_water,C:white}Water{} Jokers you have",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{C:inactive,s:0.8} Retrigger(s) divided evenly between scoring cards){}",
                     "{s:0.8}Suit cycles after scoring {C:inactive,s:0.8}(#3#, #4#, #5#, #6#)",
                 } 
@@ -2279,7 +2279,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:red,C:white} X#1# {} Mult for each",
-                "{X:dark,C:white}Dark{} Joker you have",
+                "{X:poke_dark,C:white}Dark{} Joker you have",
                 "{C:inactive}(Currently {X:red,C:white} X#2#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Dusk Stone{C:inactive,s:0.8})"
               }
@@ -2428,7 +2428,7 @@ return {
               name = "Ursaring",
               text = {
                 "Gains {C:mult}+#2#{} Mult and",
-                "creates an {C:item}Item{} when any",
+                "creates an {C:poke_item}Item{} when any",
                 "{C:attention}Booster Pack{} is skipped {C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Moon Stone{C:inactive,s:0.8})",
@@ -2470,7 +2470,7 @@ return {
                 "{C:mult}+#1#{} Mult for each {C:attention}Enhanced{}",
                 "card in your full deck",
                 "{br:2}ERROR - CONTACT STEAK",
-                "Create a {C:attention}Basic{} {X:water,C:white}Water{} Joker if scoring",
+                "Create a {C:attention}Basic{} {X:poke_water,C:white}Water{} Joker if scoring",
                 "hand contains {C:attention}5 Enhanced{} cards",
                 "{C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
@@ -2547,11 +2547,11 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} Energy Limit",
+                    "{C:poke_pink}+2{} Energy Limit",
                     "When any {C:attention}Booster Pack{} is opened",
-                    "create an {C:pink}Energy{} card of",
-                    "the same {C:pink}Type{} of leftmost Joker",
-                    "{C:inactive,s:0.8}(Evolves with a {C:metal,s:0.8}Dubious Disc{C:inactive,s:0.8})",
+                    "create an {C:poke_pink}Energy{} card of",
+                    "the same {C:poke_pink}Type{} of leftmost Joker",
+                    "{C:inactive,s:0.8}(Evolves with a {C:poke_metal,s:0.8}Dubious Disc{C:inactive,s:0.8})",
                 } 
             },
             j_poke_stantler = {
@@ -2642,7 +2642,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Earn {C:money}$#1#{} for each", 
-                  "{C:colorless}Colorless{} Joker you have",
+                  "{C:poke_colorless}Colorless{} Joker you have",
                   "at end of round",
                   "{C:inactive}(Currently {C:money}$#2#{C:inactive}){}"
                 }
@@ -2668,7 +2668,7 @@ return {
                     "{C:attention}+#3#{} hand size, {C:attention}Nature: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards have a",
                     "a {C:green}#4# in #5#{} chance to earn {C:money}$#1#{} when scored",
-                    "Guaranteed if you have other {X:grass,C:white}Grass{} cards",
+                    "Guaranteed if you have other {X:poke_grass,C:white}Grass{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive,s:0.8}(Evolves after earning {C:money,s:0.8}$#2#{C:inactive,s:0.8})",
                 } 
@@ -2679,7 +2679,7 @@ return {
                     "{C:attention}+#3#{} hand size, {C:attention}Nature: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards have a",
                     "{C:green}#4# in #5#{} chance to earn {C:money}$#1#{} when scored",
-                    "Guaranteed if you have other {X:grass,C:white}Grass{} cards",
+                    "Guaranteed if you have other {X:poke_grass,C:white}Grass{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive,s:0.8}(Evolves after earning {C:money,s:0.8}$#2#{C:inactive,s:0.8})",
                 } 
@@ -2691,7 +2691,7 @@ return {
                     "Played {C:attention}Nature{} cards earn {C:money}$#1#{} when scored",
                     "{br:5}ERROR - CONTACT STEAK",
                     "Earn {C:money}$#1#{} at end of round for",
-                    "each other {X:grass,C:white}Grass{} card you have",
+                    "each other {X:poke_grass,C:white}Grass{} card you have",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive}(Currently {C:money}$#4#{C:inactive}, Max of {C:money}$14{C:inactive}){}"
                 } 
@@ -2701,7 +2701,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} discards, {C:attention}Nature: {C:inactive}({C:attention}#5#, #6#, #7#{C:inactive}){}",
                     "{C:mult}+#1#{} Mult for each {C:attention}Nature{} card discarded this round",
-                    "Doubled with other {X:fire,C:white}Fire{} or {X:earth,C:white}Fighting{} cards",
+                    "Doubled with other {X:poke_fire,C:white}Fire{} or {X:poke_earth,C:white}Fighting{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive}(Currently {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves after scoring {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult)",
@@ -2712,7 +2712,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} discards, {C:attention}Nature: {C:inactive}({C:attention}#5#, #6#, #7#{C:inactive}){}",
                     "{C:mult}+#1#{} Mult for each {C:attention}Nature{} card discarded this round",
-                    "Doubled with other {X:fire,C:white}Fire{} or {X:earth,C:white}Fighting{} cards",
+                    "Doubled with other {X:poke_fire,C:white}Fire{} or {X:poke_earth,C:white}Fighting{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive}(Currently {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves after scoring {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult)",
@@ -2724,7 +2724,7 @@ return {
                     "{C:mult}+#2#{} discards, {C:attention}Nature: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "For each {C:attention}Nature{} card discarded this round",
                     "gain {C:mult}+#4#{} Mult and {X:red,C:white}X#1#{} Mult for",
-                    "each {X:fire,C:white}Fire{} or {X:earth,C:white}Fighting{} card you have",
+                    "each {X:poke_fire,C:white}Fire{} or {X:poke_earth,C:white}Fighting{} card you have",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive}(Currently {C:mult}+#5#{C:inactive} Mult, {X:red,C:white}X#3#{C:inactive} Mult){}",
                 } 
@@ -2734,7 +2734,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} hands, {C:attention}Nature: {C:inactive}({C:attention}#4#, #5#, #6#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards give {C:chips}+#1#{} Chips",
-                    "Doubled with other {X:water,C:white}Water{} or {X:earth,C:white}Earth{} cards",
+                    "Doubled with other {X:poke_water,C:white}Water{} or {X:poke_earth,C:white}Earth{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive,s:0.8}(Evolves after gaining {C:chips,s:0.8}#2#{C:inactive,s:0.8} Chips)"
                 } 
@@ -2744,7 +2744,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} hands, {C:attention}Nature: {C:inactive}({C:attention}#4#, #5#, #6#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards give {C:chips}+#1#{} Chips",
-                    "Doubled with other {X:water,C:white}Water{} or {X:earth,C:white}Earth{} cards",
+                    "Doubled with other {X:poke_water,C:white}Water{} or {X:poke_earth,C:white}Earth{} cards",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive,s:0.8}(Evolves after gaining {C:chips,s:0.8}#2#{C:inactive,s:0.8} Chips)"
                 } 
@@ -2754,7 +2754,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} hands, {C:attention}Nature: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Played {C:attention}Nature{} cards give {C:chips}+#1#{} Chips",
-                    "and {C:chips}+#5#{} Chips per other {X:water,C:white}Water{} or {X:earth,C:white}Earth{} card",
+                    "and {C:chips}+#5#{} Chips per other {X:poke_water,C:white}Water{} or {X:poke_earth,C:white}Earth{} card",
                     "{C:inactive,s:0.8}(includes Jokers and Energy cards){}",
                     "{C:inactive}(Currently {C:chips}+#4#{C:inactive} total)"
                 } 
@@ -2762,9 +2762,9 @@ return {
             j_poke_zigzagoon = {
               name = "Zigzagoon",
               text = {
-                "{C:attention}Holding Pickup{} {C:item}Item{}",
+                "{C:attention}Holding Pickup{} {C:poke_item}Item{}",
                 "{C:green}#1# in #2#{} chance to create an",
-                "{C:item}Item{} when hand is played",
+                "{C:poke_item}Item{} when hand is played",
                 "{C:inactive}(Must have room)",
                 "{C:inactive,s:0.8}(Evolves after {C:attention}#3#{C:inactive,s:0.8} rounds)",
               }
@@ -2773,7 +2773,7 @@ return {
               name = "Linoone",
               text = {
                 "{C:green}#1# in #2#{} chance to create an",
-                "{C:item}Item{} when hand is played",
+                "{C:poke_item}Item{} when hand is played",
                 "Guaranteed if hand",
                 "contains a {C:attention}Straight{}",
                 "{C:inactive}(Must have room)"
@@ -2938,7 +2938,7 @@ return {
                 name = 'Jirachi',
                 text = {
                     "Copies ability of {C:attention}Joker{} to the right",
-                    "as if it was {C:pink}Energized{} an extra time",
+                    "as if it was {C:poke_pink}Energized{} an extra time",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -2990,7 +2990,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Each {X:dark,C:white}Dark{} Joker gives {X:red,C:white}X#1#{} Mult",
+                  "Each {X:poke_dark,C:white}Dark{} Joker gives {X:red,C:white}X#1#{} Mult",
                 }
             },
             j_poke_bonsly = {
@@ -3026,7 +3026,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}, {X:red,C:white} X#1# {} Mult",
-                    "Create a random {C:item}Item{} card with",
+                    "Create a random {C:poke_item}Item{} card with",
                     "{C:dark_edition}Negative{} at end of round",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }
@@ -3058,7 +3058,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards give {X:red,C:white}X#1#{} Mult",
                     "plus {X:red,C:white}X#2#{} Mult for each",
-                    "{X:metal,C:white}Metal{} Joker you have",
+                    "{X:poke_metal,C:white}Metal{} Joker you have",
                     "{C:inactive}(Currently {X:red,C:white}X#3#{C:inactive} Mult){}",
                 } 
             },
@@ -3079,7 +3079,7 @@ return {
                     "gains {C:chips}+#1#{} Chips when scored",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:attention}Stone{} cards retrigger for each",
-                    "{X:earth,C:white}Earth{} Joker you have",
+                    "{X:poke_earth,C:white}Earth{} Joker you have",
                     "{C:inactive}(Currently #2# retriggers)"
                 } 
             },
@@ -3175,8 +3175,8 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energy Limit",
-                    "{X:red,C:white} X#2# {} Mult per {C:pink}Energy{}",
+                    "{C:poke_pink}+3{} Energy Limit",
+                    "{X:red,C:white} X#2# {} Mult per {C:poke_pink}Energy{}",
                     "card used this {C:attention}run{}",
                     "{C:inactive}(Currently {X:red,C:white} X#1# {C:inactive} Mult)"
                 } 
@@ -3195,7 +3195,7 @@ return {
                 text = {
                   "Go up to {C:mult}-$#1#{} in debt",
                   "{br:2.5}ERROR - CONTACT STEAK",
-                  "Create an {C:item}Item{} card if",
+                  "Create an {C:poke_item}Item{} card if",
                   "hand is played while in debt",
                   "{C:inactive,s:0.8}(Must have room)",
                 }
@@ -3451,7 +3451,7 @@ return {
                 text = {
                     "{C:chips}+#1#{} Chips if played hand contains a {C:attention}Flush{}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Create an {C:pink}Energy{} card if it",
+                    "Create an {C:poke_pink}Energy{} card if it",
                     "also contains a {C:attention}King{} or {C:attention}Queen{}"
                 } 
             },
@@ -3470,7 +3470,7 @@ return {
                 text = {
                     "{C:mult}+#1#{} Mult",
                     "{C:attention}Tripled{} if you have",
-                    "a {X:lightning, C:black}Lightning{} Joker",
+                    "a {X:poke_lightning, C:black}Lightning{} Joker",
                     "{C:inactive,s:0.8}(Evolves after {C:attention,s:0.8}#2#{C:inactive,s:0.8} rounds)",
                 }  
             },
@@ -3478,7 +3478,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult for each",
-                    "{X:lightning, C:black}Lightning{} Joker you have",
+                    "{X:poke_lightning, C:black}Lightning{} Joker you have",
                     "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolves with a {C:attention,s:0.8}Thunder Stone{C:inactive,s:0.8})"
                 }  
@@ -3488,7 +3488,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult for each other",
-                    "{X:lightning, C:black}Lightning{} Joker you have",
+                    "{X:poke_lightning, C:black}Lightning{} Joker you have",
                     "{C:inactive}(Currently {X:red,C:white} X#2# {C:inactive} Mult)",
                 }
             },
@@ -3596,7 +3596,7 @@ return {
               name = "Ursaluna",
               text = {
                 "Gains {C:mult}+#2#{} Mult and creates",
-                "an {C:item}Item{} with {C:dark_edition}Polychrome{} when any",
+                "an {C:poke_item}Item{} with {C:dark_edition}Polychrome{} when any",
                 "{C:attention}Booster Pack{} is skipped {C:inactive,s:0.8}(Must have room)",
                 "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
               }
@@ -3628,7 +3628,7 @@ return {
                   "Required {C:attention}rank{} rises with each trigger",
                   "{C:inactive,s:0.8}(If rank is highest, it becomes lowest)",
                   "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
-                  "{C:inactive,s:0.8}(Evolves when you have a {X:fire,C:white,s:0.8}Fire{C:inactive,s:0.8} Joker)",
+                  "{C:inactive,s:0.8}(Evolves when you have a {X:poke_fire,C:white,s:0.8}Fire{C:inactive,s:0.8} Joker)",
                 }
             },
             j_poke_dachsbun = {
@@ -3638,7 +3638,7 @@ return {
                   "Required {C:attention}rank{} rises with each trigger",
                   "{br:4}ERROR - CONTACT STEAK",
                   "Increase Chip gain by {C:chips}+2{} for each",
-                  "{X:fire,C:white}Fire{} Joker you have",
+                  "{X:poke_fire,C:white}Fire{} Joker you have",
                   "{C:inactive,s:0.8}(If rank is highest, it becomes lowest)",
                   "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
                 }
@@ -3770,7 +3770,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult for each Joker",
-                    "you have that has a {C:pink}Type{}",
+                    "you have that has a {C:poke_pink}Type{}",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:attention}Pokemon{} from the same", 
                     "evolutionary line may appear",
@@ -3797,7 +3797,7 @@ return {
             j_poke_jelly_donut = {
                 name = "Jelly Donut",
                 text = {
-                  "Create a {C:colorless}Colorless {C:pink}Energy{}",
+                  "Create a {C:poke_colorless}Colorless {C:poke_pink}Energy{}",
                   "when blind is selected",
                   "{C:inactive}({C:attention}#1#{C:inactive} rounds remaining){}"
                 }
@@ -3805,8 +3805,8 @@ return {
             j_poke_treasure_eatery = {
                 name = "Treasure Eatery",
                 text = {
-                  "Convert the leftmost Joker's {C:pink}type{}",
-                  "into the rightmost Joker's {C:pink}type{}",
+                  "Convert the leftmost Joker's {C:poke_pink}type{}",
+                  "into the rightmost Joker's {C:poke_pink}type{}",
                   "when blind is selected",
                   "{C:attention}Type Changer{}",
                   "{C:inactive}({C:attention}#1#{C:inactive} rounds remaining){}"
@@ -3841,14 +3841,14 @@ return {
                 text = {
                   "Hatches into a {C:attention}Basic{} or",
                   "{C:attention}Baby{} Joker after {C:attention}#1#{} rounds",
-                  "that is {C:pink}Energized{} if applicable"
+                  "that is {C:poke_pink}Energized{} if applicable"
                 }
             },
             j_poke_billion_lions = {
                 name = 'A Billion Lions',
                 text = {
                     "When blind is selected",
-                    "destroy each {C:pink}typed{} Joker you have",
+                    "destroy each {C:poke_pink}typed{} Joker you have",
                     "then gain {X:mult,C:white}X#2#{} Mult for each",
                     "{S:1.1,C:red,E:2}self destructs{} when out of lions",
                     "{C:inactive}(Currently {X:mult,C:white}X#1#{C:inactive} Mult, {C:attention}#3#{C:inactive} lions)"
@@ -3892,7 +3892,7 @@ return {
                 name = "Pochette lumineuse",
                 text = {
                     "Tous les Jokers sont créés avec",
-                    "un autocollant de {C:pink}Type{} aléatoire",
+                    "un autocollant de {C:poke_pink}Type{} aléatoire",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -3901,7 +3901,7 @@ return {
                     "Commencez la partie avec",
                     "le coupon {C:tarot,T:v_crystal_ball}#1#{}",
                     "et {C:attention}2{} copies",
-                    "de {C:item,T:c_poke_twisted_spoon}#2#"
+                    "de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
         },
@@ -3926,7 +3926,7 @@ return {
                 name = "Transformation",
                 text = {
                     "Évolue le Pokémon sélectionné ou le plus à gauche",
-                    "au {C:attention}niveau{} le plus haut et octroie {}+1{} {C:pink}Énergie{}", 
+                    "au {C:attention}niveau{} le plus haut et octroie {}+1{} {C:poke_pink}Énergie{}", 
                 },
             },
             c_poke_megastone = {
@@ -3942,7 +3942,7 @@ return {
             c_poke_obituary = {
                 name = "Nécrotique",
                 text = {
-                    "Ajoute un {C:pink}Sceau rose{}",
+                    "Ajoute un {C:poke_pink}Sceau rose{}",
                     "à {C:attention}1{} carte sélectionnée",
                     "dans votre main",
                 }
@@ -3950,15 +3950,15 @@ return {
             c_poke_nightmare = {
                 name = "Cauchemar",
                 text = {
-                    "Détruit le Joker sélectionné avec un {C:pink}Type{}",
-                    "et crée {C:attention}2{} {C:pink}Énergies{} {C:dark_edition}Négatives{}",
-                    "du {C:pink}type{} de ce Joker"
+                    "Détruit le Joker sélectionné avec un {C:poke_pink}Type{}",
+                    "et crée {C:attention}2{} {C:poke_pink}Énergies{} {C:dark_edition}Négatives{}",
+                    "du {C:poke_pink}type{} de ce Joker"
                 },
             },
             c_poke_revenant = {
                 name = "Revenant",
                 text = {
-                    "Ajoute un {C:item}Sceau argent{}",
+                    "Ajoute un {C:poke_item}Sceau argent{}",
                     "à {C:attention}1{} carte sélectionnée",
                     "dans votre main",
                 }
@@ -4010,7 +4010,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Badge de poche",
                 text = {
-                    "Octroie un {C:pink}Paquet Méga-Pocket",
+                    "Octroie un {C:poke_pink}Paquet Méga-Pocket",
                     "{C:green}25%{} de chance que le paquet contienne",
                     "une {C:attention}Gemme Sésame{} sur les {C:attention}Mises 5+{}"
                 }, 
@@ -4020,7 +4020,7 @@ return {
                 text = {
                     "Le prochain joker en édition de base",
                     "du magasin sera gratuit et",
-                    "obtiendra le statut {C:colorless}Chromatique{}",
+                    "obtiendra le statut {C:poke_colorless}Chromatique{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -4034,7 +4034,7 @@ return {
                 name = "Safari Tag",
                 text = {
                     "Le magasin possède un",
-                    "{C:safari}Joker Safari{}",
+                    "{C:poke_safari}Joker Safari{}",
                 }, 
             },
         },
@@ -4060,13 +4060,13 @@ return {
             v_poke_energysearch = {
                 name = "Recherche d'Énergie",
                 text = {
-                    "{C:pink}+2{} limite d'Énergie"
+                    "{C:poke_pink}+2{} limite d'Énergie"
                 },
             },
             v_poke_energyresearch = {
                 name = "Développement d'Énergie",
                 text = {
-                    "{C:pink}+3{} limite d'Énergie"
+                    "{C:poke_pink}+3{} limite d'Énergie"
                 },
             },
             v_poke_goodrod = {
@@ -4079,7 +4079,7 @@ return {
             v_poke_superrod = {
                 name = "Méga Canne",
                 text = {
-                    "Vous pouver {C:pink}Garder{} des cartes",
+                    "Vous pouver {C:poke_pink}Garder{} des cartes",
                     "de tous les paquets de {C:attention}consommables{}",
                 },
             },
@@ -4089,80 +4089,80 @@ return {
             Grass = {
                 name = "Type",
                 text = {
-                  "{X:grass,C:white}Plante{}",
+                  "{X:poke_grass,C:white}Plante{}",
                 }
             },
             Fire = {
                 name = "Type",
                 text = {
-                  "{X:fire,C:white}Feu{}",
+                  "{X:poke_fire,C:white}Feu{}",
                 }
             },
             Water = {
                 name = "Type",
                 text = {
-                  "{X:water,C:white}Eau{}",
+                  "{X:poke_water,C:white}Eau{}",
                 }
             },
             Lightning = {
                 name = "Type",
                 text = {
-                  "{X:lightning,C:black}Électrique{}",
+                  "{X:poke_lightning,C:black}Électrique{}",
                 }
             },
             Psychic = {
                 name = "Type",
                 text = {
-                  "{X:psychic,C:white}Psy{}",
+                  "{X:poke_psychic,C:white}Psy{}",
                 }
             },
             Fighting = {
                 name = "Type",
                 text = {
-                  "{X:fighting,C:white}Combat{}",
+                  "{X:poke_fighting,C:white}Combat{}",
                 }
             },
             Colorless = {
                 name = "Type",
                 text = {
-                  "{X:colorless,C:white}Incolore{}",
+                  "{X:poke_colorless,C:white}Incolore{}",
                 }
             },
             Dark = {
                 name = "Type",
                 text = {
-                  "{X:dark,C:white}Obscurité{}",
+                  "{X:poke_dark,C:white}Obscurité{}",
                 }
             },
             Metal = {
                 name = "Type",
                 text = {
-                  "{X:metal,C:white}Métal{}",
+                  "{X:poke_metal,C:white}Métal{}",
                 }
             },
             Fairy = {
                 name = "Type",
                 text = {
-                  "{X:fairy,C:white}Fée{}",
+                  "{X:poke_fairy,C:white}Fée{}",
                 }
             },
             Dragon = {
                 name = "Type",
                 text = {
-                  "{X:dragon,C:white}Dragon{}",
+                  "{X:poke_dragon,C:white}Dragon{}",
                 }
             },
             Earth = {
                 name = "Type",
                 text = {
-                  "{X:earth,C:white}Terre{}",
+                  "{X:poke_earth,C:white}Terre{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "Type",
                 text = {
-                  "{X:bird,C:white}Bird{}",
+                  "{X:poke_bird,C:white}Bird{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -4350,7 +4350,7 @@ return {
                 name = "Cadeaux",
                 text = {
                     "{C:green}35%{} - {C:money}8 ${}",
-                    "{C:green}30%{} - {C:attention}Carte{} {C:item}Objet{}",
+                    "{C:green}30%{} - {C:attention}Carte{} {C:poke_item}Objet{}",
                     "{C:green}20%{} - {C:attention}Badge de coupon",
                     "{C:green}15%{} - {C:attention}Carte cadeau{} {C:dark_edition}Polychrome",
                 }
@@ -4358,7 +4358,7 @@ return {
             pickup = {
               name = "Ramassage",
               text = {
-                "{C:green}34%{} - {C:item}Objet{} {C:attention}Card",
+                "{C:green}34%{} - {C:poke_item}Objet{} {C:attention}Card",
                 "{C:green}25%{} - {C:attention}Leftovers",
                 "{C:green}25%{} - {C:attention}Poke Ball",
                 "{C:green}15%{} - {C:attention}Great Ball",
@@ -4391,14 +4391,14 @@ return {
             eeveelution = {
                 name = "Évolutions",
                 text = {
-                    "{C:attention}Pierre Eau{} - {X:water,C:white}Aquali{}",
-                    "{C:attention}Pierre Foudre{} - {X:lightning,C:black}Voltali{}",
-                    "{C:attention}Pierre Feu{} - {X:fire,C:white}Pyroli{}",
-                    "{C:attention}Pierre Soleil{} - {X:psychic,C:white}Mentali{}",
-                    "{C:attention}Pierre Lune{} - {X:dark,C:white}Noctali{}",
-                    "{C:attention}Pierre Plante{} - {X:grass,C:white}Phyllali{}",
-                    "{C:attention}Pierre Glace{} - {X:water,C:white}Givrali{}",
-                    "{C:attention}Pierre Éclat{} - {X:fairy,C:white}Nymphali{}"
+                    "{C:attention}Pierre Eau{} - {X:poke_water,C:white}Aquali{}",
+                    "{C:attention}Pierre Foudre{} - {X:poke_lightning,C:black}Voltali{}",
+                    "{C:attention}Pierre Feu{} - {X:poke_fire,C:white}Pyroli{}",
+                    "{C:attention}Pierre Soleil{} - {X:poke_psychic,C:white}Mentali{}",
+                    "{C:attention}Pierre Lune{} - {X:poke_dark,C:white}Noctali{}",
+                    "{C:attention}Pierre Plante{} - {X:poke_grass,C:white}Phyllali{}",
+                    "{C:attention}Pierre Glace{} - {X:poke_water,C:white}Givrali{}",
+                    "{C:attention}Pierre Éclat{} - {X:poke_fairy,C:white}Nymphali{}"
                 }
             },
             poke_egg_tip = {
@@ -4460,7 +4460,7 @@ return {
             precise_energy_tooltip = {
                 name = "Mise à l'échelle précise des énergies",
                 text = {
-                    "{s:0.8}Use {C:attention,s:0.8}decimals{} for all values when applying {C:pink,s:0.8}Énergie{}{s:0.8} bonus{}",
+                    "{s:0.8}Use {C:attention,s:0.8}decimals{} for all values when applying {C:poke_pink,s:0.8}Énergie{}{s:0.8} bonus{}",
                     "{s:0.8}With this option {C:attention,s:0.8}off{}{s:0.8} the following will occur for the bonus:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Multi. - Uses Decimals",
                     "{C:attenion}2. {s:0.8}Flat {C:mult,s:0.8}Multi.{}{s:0.8} and {C:chips,s:0.8}Jetons{}{s:0.8} - Rounds up to nearest whole number",
@@ -4531,7 +4531,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Sceau rose",
                 text = {
-                    "Crée une carte {C:pink}Énergie{}",
+                    "Crée une carte {C:poke_pink}Énergie{}",
                     "dont le {C:attention}type{} correspond à",
                     "l'un de vos Jokers si cette carte marque",
                     "durant la {C:attention}première main{} de la manche",
@@ -4543,7 +4543,7 @@ return {
             poke_silver_seal = {
                 name = "Sceau argent",
                 text = {
-                  "Crée une carte {C:item}Objet{}",
+                  "Crée une carte {C:poke_item}Objet{}",
                   "et est {C:attention}défaussée{} si {C:attention}tenue{}",
                   "en main quand les cartes",
                   "marquent des points"
@@ -4553,73 +4553,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Plante{}"
+                    "{X:poke_grass,C:white}Plante{}"
                 } 
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Feu{}"
+                    "{X:poke_fire,C:white}Feu{}"
                 } 
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Eau{}"
+                    "{X:poke_water,C:white}Eau{}"
                 } 
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Électrique{}"
+                    "{X:poke_lightning,C:white}Électrique{}"
                 } 
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psy{}"
+                    "{X:poke_psychic,C:white}Psy{}"
                 } 
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Combat{}"
+                    "{X:poke_fighting,C:white}Combat{}"
                 } 
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Incolore{}"
+                    "{X:poke_colorless,C:white}Incolore{}"
                 } 
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Obscurité{}"
+                    "{X:poke_dark,C:white}Obscurité{}"
                 } 
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Métal{}"
+                    "{X:poke_metal,C:white}Métal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fée{}"
+                    "{X:poke_fairy,C:white}Fée{}"
                 } 
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 } 
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Terre{}"
+                    "{X:poke_earth,C:white}Terre{}"
                 } 
             },
             --]]
@@ -4647,64 +4647,64 @@ return {
                 name = "Paquet Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "Paquet Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "Paquet Jumbo Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "Paquet Méga-Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "Paquet Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "Paquet Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "Paquet Jumbo Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "Paquet Méga-Pocket",
                 text = {
                     "Choisissez {C:attention}#1#{} parmi",
-                    "{C:attention}#2#{} {C:item}cartes Objet{} et",
-                    "{C:attention}#3#{} {C:pink}carte Énergie{}",
+                    "{C:attention}#2#{} {C:poke_item}cartes Objet{} et",
+                    "{C:attention}#3#{} {C:poke_pink}carte Énergie{}",
                 },
             },
             p_poke_pokepack_wish_pack = {

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -50,8 +50,8 @@ return {
                 name = "Luminous Deck",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
-                    "and have {C:attention}+1{} {C:pink}Energy{}"
+                    "with random {C:poke_pink}Type{} stickers",
+                    "and have {C:attention}+1{} {C:poke_pink}Energy{}"
                 }
             },
         },
@@ -165,15 +165,15 @@ return {
                 name = "Tera Orb",
                 text = {
                     "Applies a random",
-                    "{C:pink}Type{} sticker",
+                    "{C:poke_pink}Type{} sticker",
                     "to leftmost Joker{}", 
-                    "and gives {C:attention}+1{} {C:pink}Energy{}"
+                    "and gives {C:attention}+1{} {C:poke_pink}Energy{}"
                 },
             },
             c_poke_metalcoat = {
                 name = "Metal Coat",
                 text = {
-                    "Applies a {C:metal}Metal{} sticker",
+                    "Applies a {C:poke_metal}Metal{} sticker",
                     "to leftmost Joker.",
                     "Creates a {C:attention}Chariot{} card",
                     "{C:inactive}(Must have room){}"
@@ -182,7 +182,7 @@ return {
             c_poke_dragonscale = {
                 name = "Dragon Scale",
                 text = {
-                    "Applies a {C:dragon}Dragon{} sticker",
+                    "Applies a {C:poke_dragon}Dragon{} sticker",
                     "to leftmost Joker.",
                     "Creates an {C:attention}Emperor{} card",
                     "{C:inactive}(Must have room){}"
@@ -1211,7 +1211,7 @@ return {
                     "The leftmost scoring card of",
                     "your {C:attention}first hand{} of round",
                     "becomes a {C:attention}Stone{} card",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1416,7 +1416,7 @@ return {
                     "for each scoring {C:attention}6{}",
                     "in your first {C:attention}2{} hands",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive}(Evolves with a {C:dragon}Dragon{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_dragon}Dragon{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1466,7 +1466,7 @@ return {
                     "Joker to the right and gain {C:mult}+#2#{} Mult or {C:chips}+#4#{} Chips",
                     "Gain {C:attention}Foil{}, {C:attention}Holographic{}, or {C:attention}Polychrome{}",
                     "if Joker was {C:red}Rare{} or higher",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}",
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult, {C:chips}+#3#{C:inactive} Chips)"
                 } 
             },
@@ -1590,7 +1590,7 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "Create an {C:pink}Energy{} card",
+                    "Create an {C:poke_pink}Energy{} card",
                     "when any {C:attention}Booster Pack{}",
                     "is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -1712,7 +1712,7 @@ return {
                 text = {
                     "At end of shop, create a",
                     "{C:dark_edition}Polychrome{} {C:attention}duplicate{} of",
-                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:pink}Energy{}",
+                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:poke_pink}Energy{}",
                     "then destroy leftmost {C:attention}Joker{}",
                     "{C:dark_edition}Polychrome{} Jokers each give {X:mult,C:white} X#1# {} Mult",
                     "{C:inactive}(Can't destroy self)",
@@ -1723,7 +1723,7 @@ return {
                 text = {
                     "At end of shop, create",
                     "a random {C:dark_edition}Negative{} {C:attention}Tarot{}",
-                    "{C:spectral}Spectral{} or {C:item}Item{} card",
+                    "{C:spectral}Spectral{} or {C:poke_item}Item{} card",
                     "{C:green}#1# in {C:green}#2#{} chance to create",
                     "a random {C:dark_edition}Negative{} Joker {C:attention}instead{}",
                     "{C:inactive,s:0.8}(Odds can't be increased){}"
@@ -1804,7 +1804,7 @@ return {
                     "Played cards with {V:1}#2#{} suit give",
                     "{C:mult}+#1#{} Mult when scored",
                     "Those cards retrigger based on",
-                    "how many {X:water,C:white}Water{} Jokers you have",
+                    "how many {X:poke_water,C:white}Water{} Jokers you have",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} Retrigger(s) divided evenly between scoring cards){}",
                     "Suit changes in order {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -1875,9 +1875,9 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+1{} Energy Limit",
-                    "Create an {C:pink}Energy{} card",
-                    "of the same {C:pink}Type{} of",
+                    "{C:poke_pink}+1{} Energy Limit",
+                    "Create an {C:poke_pink}Energy{} card",
+                    "of the same {C:poke_pink}Type{} of",
                     "leftmost Joker when any",
                     "{C:attention}Booster Pack{} is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -2027,7 +2027,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}",
-                    "Create a random {C:item}Item{} card with",
+                    "Create a random {C:poke_item}Item{} card with",
                     "{C:dark_edition}Negative{} at end of round",
                     "{X:red,C:white} X#1# {} Mult",
                     "{C:inactive}(Yes, this will {C:attention}reduce{C:inactive} your Mult)",
@@ -2039,7 +2039,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards",
                     "give {X:red,C:white}X#1#{} Mult",
-                    "{X:metal,C:white}Metal{} Jokers next to",
+                    "{X:poke_metal,C:white}Metal{} Jokers next to",
                     "this Joker each give {X:red,C:white}X#2#{} Mult"
                 } 
             },
@@ -2059,7 +2059,7 @@ return {
                     "permanently gains",
                     "{C:chips}+#1#{} Chips when scored",
                     "{C:attention}Stone{} cards retrigger for each",
-                    "{C:attention}other{} {X:earth,C:white}Earth{} Joker you have",
+                    "{C:attention}other{} {X:poke_earth,C:white}Earth{} Joker you have",
                     "{C:inactive}(Currently #2# retriggers)"
                 } 
             },
@@ -2118,10 +2118,10 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energy Limit",
+                    "{C:poke_pink}+3{} Energy Limit",
                     "This Joker gains",
                     "{X:red,C:white} X#2# {} Mult every time",
-                    "an {C:pink}Energy{} card is used",
+                    "an {C:poke_pink}Energy{} card is used",
                     "{C:inactive}(Currently {X:red,C:white} X#1# {}{C:inactive} Mult)"
                 } 
             },
@@ -2142,7 +2142,7 @@ return {
                     "{C:mult}+#1#{} Mult",
                     "This card scores {C:attention}triple{}",
                     "its Mult if you have",
-                    "a {X:lightning, C:black}Lightning{} Joker",
+                    "a {X:poke_lightning, C:black}Lightning{} Joker",
                     "{C:inactive}(Evolves after {C:attention}#2#{}{C:inactive} rounds)"
                 }  
             },
@@ -2150,7 +2150,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult",
-                    "for each {X:lightning, C:black}Lightning{} Joker",
+                    "for each {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have {C:inactive}(includes self){}",
                      "{C:inactive}(Currently {C:mult}#2#{C:inactive} Mult)",
                     "{C:inactive}(Evolves with a{} {C:attention}Thunder Stone{}{C:inactive} card)"
@@ -2161,7 +2161,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult for each",
-                    "other {X:lightning, C:black}Lightning{} Joker",
+                    "other {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have{}",
                      "{C:inactive}(Currently {X:red,C:white} X#2# {}{C:inactive} Mult)",
                 }  
@@ -2204,7 +2204,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult for each",
-                    "Joker with a {C:pink}Type{} you have",
+                    "Joker with a {C:poke_pink}Type{} you have",
                     "{C:attention}Pokemon{} may appear",
                     "multiple times",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)"
@@ -2240,7 +2240,7 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
+                    "with random {C:poke_pink}Type{} stickers",
                 },
             },
         },
@@ -2274,7 +2274,7 @@ return {
             c_poke_obituary = {
                 name = "Obituary",
                 text = {
-                    "Adds a {C:pink}Pink{} seal",
+                    "Adds a {C:poke_pink}Pink{} seal",
                     "to {C:attention}1{} selected card",
                 }
             },
@@ -2283,7 +2283,7 @@ return {
                 text = {
                     "Destroys a random Pokemon",
                     "Joker and creates {C:attention}3{}",
-                    "random {C:pink}Energy{} with {C:dark_edition}Negative{}"
+                    "random {C:poke_pink}Energy{} with {C:dark_edition}Negative{}"
                 },
             },
         },
@@ -2292,7 +2292,7 @@ return {
                 name = "Pocket Tag",
                 text = {
                     "Gives a free",
-                    "{C:pink}Mega Pocket Pack",
+                    "{C:poke_pink}Mega Pocket Pack",
                 }, 
             },
             tag_poke_shiny_tag = {
@@ -2300,7 +2300,7 @@ return {
                 text = {
                     "Next base edition shop",
                     "Joker is free and",
-                    "becomes {C:colorless}Shiny{}",
+                    "becomes {C:poke_colorless}Shiny{}",
                 }, 
             },
         },
@@ -2311,13 +2311,13 @@ return {
             v_poke_energysearch = {
                 name = "Energy Search",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_energyresearch = {
                 name = "Energy Research",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_goodrod = {
@@ -2340,79 +2340,79 @@ return {
             Grass = {
                 name = "Type",
                 text = {
-                  "{X:grass,C:white}Grass{}",
+                  "{X:poke_grass,C:white}Grass{}",
                 }
             },
             Fire = {
                 name = "Type",
                 text = {
-                  "{X:fire,C:white}Fire{}",
+                  "{X:poke_fire,C:white}Fire{}",
                 }
             },
             Water = {
                 name = "Type",
                 text = {
-                  "{X:water,C:white}Water{}",
+                  "{X:poke_water,C:white}Water{}",
                 }
             },
             Lightning = {
                 name = "Type",
                 text = {
-                  "{X:lightning,C:black}Lightning{}",
+                  "{X:poke_lightning,C:black}Lightning{}",
                 }
             },
             Psychic = {
                 name = "Type",
                 text = {
-                  "{X:psychic,C:white}Psychic{}",
+                  "{X:poke_psychic,C:white}Psychic{}",
                 }
             },
             Fighting = {
                 name = "Type",
                 text = {
-                  "{X:fighting,C:white}Fighting{}",
+                  "{X:poke_fighting,C:white}Fighting{}",
                 }
             },
             Colorless = {
                 name = "Type",
                 text = {
-                  "{X:colorless,C:white}Colorless{}",
+                  "{X:poke_colorless,C:white}Colorless{}",
                 }
             },
             Dark = {
                 name = "Type",
                 text = {
-                  "{X:dark,C:white}Dark{}",
+                  "{X:poke_dark,C:white}Dark{}",
                 }
             },
             Metal = {
                 name = "Type",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Type",
                 text = {
-                  "{X:fairy,C:white}Fairy{}",
+                  "{X:poke_fairy,C:white}Fairy{}",
                 }
             },
             Dragon = {
                 name = "Type",
                 text = {
-                  "{X:dragon,C:white}Dragon{}",
+                  "{X:poke_dragon,C:white}Dragon{}",
                 }
             },
             Earth = {
                 name = "Type",
                 text = {
-                  "{X:earth,C:white}Earth{}",
+                  "{X:poke_earth,C:white}Earth{}",
                 }
             },
             Bird = {
                 name = "Type",
                 text = {
-                  "{X:bird,C:white}Bird{}",
+                  "{X:poke_bird,C:white}Bird{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -2487,7 +2487,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Pink Seal",
                 text = {
-                    "Creates an {C:pink}Energy{} card",
+                    "Creates an {C:poke_pink}Energy{} card",
                     "if it scores in the",
                     "{C:attention}first hand{} of round"
                 },
@@ -2496,73 +2496,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Grass{}"
+                    "{X:poke_grass,C:white}Grass{}"
                 } 
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Fire{}"
+                    "{X:poke_fire,C:white}Fire{}"
                 } 
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Water{}"
+                    "{X:poke_water,C:white}Water{}"
                 } 
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Lightning{}"
+                    "{X:poke_lightning,C:white}Lightning{}"
                 } 
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psychic{}"
+                    "{X:poke_psychic,C:white}Psychic{}"
                 } 
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Fighting{}"
+                    "{X:poke_fighting,C:white}Fighting{}"
                 } 
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Colorless{}"
+                    "{X:poke_colorless,C:white}Colorless{}"
                 } 
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Dark{}"
+                    "{X:poke_dark,C:white}Dark{}"
                 } 
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fairy{}"
+                    "{X:poke_fairy,C:white}Fairy{}"
                 } 
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 } 
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Earth{}"
+                    "{X:poke_earth,C:white}Earth{}"
                 } 
             },
             --Since these are normally discovered by default these will probably not matter
@@ -2590,7 +2590,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
@@ -2598,7 +2598,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
@@ -2606,7 +2606,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
@@ -2614,7 +2614,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
@@ -2622,7 +2622,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
@@ -2630,7 +2630,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
@@ -2638,7 +2638,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
@@ -2646,7 +2646,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
         },

--- a/localization/it.lua
+++ b/localization/it.lua
@@ -42,7 +42,7 @@ return {
                     "Inizia la partita con il",
                     "buono {C:tarot,T:v_crystal_ball}#1#{}",
                     "e {C:attention}2{} copie",
-                    "di {C:item,T:c_poke_twisted_spoon}#2#"
+                    "di {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             -- Curiosità: questo e il mazzo luminoso avevano le descrizioni scambiate
@@ -62,8 +62,8 @@ return {
                 name = "Mazzo Luminoso",
                 text = {
                     "Tutti i Jolly sono creati",
-                    "con adesivi {C:pink}Tipo{} casuali",
-                    "e hanno {C:attention}+1{} {C:pink}Energia{}"
+                    "con adesivi {C:poke_pink}Tipo{} casuali",
+                    "e hanno {C:attention}+1{} {C:poke_pink}Energia{}"
                 }
             },
             b_poke_ampeddeck = {
@@ -72,7 +72,7 @@ return {
                     "Inizia la partita con un buono",
                     "{C:tarot,T:v_poke_energysearch}#1#{}",
                     "e una copia di",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             b_poke_futuredeck = {
@@ -230,7 +230,7 @@ return {
             c_poke_teraorb = {
                 name = "Tera Sfera",
                 text = {
-                    "Dà {C:attention}+1{} {C:pink}Energia{}",
+                    "Dà {C:attention}+1{} {C:poke_pink}Energia{}",
                     "al Jolly selezionato o più a sinistra{}",
                     "{C:attention}Cambiatore di Tipo{}"
                 },
@@ -247,7 +247,7 @@ return {
                 name = "Squama di Drago",
                 text = {
                     "Crea fino a {C:attention}3{} carte",
-                    "{C:item}Oggetto{} o {C:pink}Energia{} casuali",
+                    "{C:poke_item}Oggetto{} o {C:poke_pink}Energia{} casuali",
                     "{C:attention}Cambiatore di Tipo{}",
                     "{C:inactive}(Devi avere spazio){}"
                 },
@@ -300,9 +300,9 @@ return {
             c_poke_twisted_spoon = {
                 name = "Cucchiaio Torto",
                 text = {
-                    "Crea l'ultima {C:item}Carta Oggetto{}",
-                    "o {C:pink}Energia{} usata durante questa partita",
-                    "esclusi {s:0.8,C:item}Cucchiaio Torto e Riutilizzabili{s:0.8}"
+                    "Crea l'ultima {C:poke_item}Carta Oggetto{}",
+                    "o {C:poke_pink}Energia{} usata durante questa partita",
+                    "esclusi {s:0.8,C:poke_item}Cucchiaio Torto e Riutilizzabili{s:0.8}"
                 }
             },
             c_poke_prismscale = {
@@ -340,7 +340,7 @@ return {
                     "{br:2}ERROR - CONTACT STEAK",
                     "Trasforma {C:attention}1{} carta selezionata in una",
                     "{C:attention}Carta di Pietra{} con {C:chips}+#2#{} fiche extra ",
-                    "per ogni Jolly di tipo {X:earth,C:white}Terra{} in possesso"
+                    "per ogni Jolly di tipo {X:poke_earth,C:white}Terra{} in possesso"
                 }
             },
             c_poke_berry_juice = {
@@ -353,7 +353,7 @@ return {
             c_poke_berry_juice_energy = {
                 name = "Succo di Bacca Energetico",
                 text = {
-                    "{C:pink}Energia{} al Jolly più",
+                    "{C:poke_pink}Energia{} al Jolly più",
                     "a sinistra o selezionato",
                     "{C:inactive}(Massimo di {C:attention}#1#{C:inactive} utilizzo per ogni Jolly)",
                 },
@@ -376,7 +376,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "Succo di Bacca oggettizzato",
                 text = {
-                    "Crea un {C:item}Cucchiaio Torto{}",
+                    "Crea un {C:poke_item}Cucchiaio Torto{}",
                     "{C:green}#1# possibilità su #2#{} di",
                     "crearne {C:attention}2{}",
                     "{C:inactive}(Devi avere spazio){}"
@@ -393,7 +393,7 @@ return {
                 name = "Succo di Bacca misterioso",
                 text = {
                     "Crea una carta",
-                    "{C:item}Succo di Bacca{} casuale"
+                    "{C:poke_item}Succo di Bacca{} casuale"
                 }
             },
             c_poke_oven = {
@@ -1220,7 +1220,7 @@ return {
                 name = "Abra",
                 text = {
                     "{C:green}#1# possibilità su #2#{} di creare",
-                    "un {C:attention}Tarocco{} o un {C:item}Oggetto",
+                    "un {C:attention}Tarocco{} o un {C:poke_item}Oggetto",
                     "se la {C:attention}mano di poker{} giocata è",
                     "già stata giocata questo round",
                     "{C:inactive,s:0.8}(Si evolve dopo {C:attention,s:0.8}#3#{C:inactive,s:0.8} round)",
@@ -1230,7 +1230,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# possibilità su #2#{} di creare ",
-                    "un {C:attention}Tarocco{} o {C:item}Cucchiaio Torto{}",
+                    "un {C:attention}Tarocco{} o {C:poke_item}Cucchiaio Torto{}",
                     "se la {C:attention}mano di poker{} giocata è",
                     "già stata giocata questo round",
                     "{C:inactive,s:0.8}(Si evolve tramite {C:attention,s:0.8}Cavo di Collegamento{C:inactive,s:0.8})"
@@ -1241,7 +1241,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} slot consumabili",
                     "{C:green}#1# possibilità su #2#{} di creare",
-                    " una carta {C:attention}Matto{} o {C:item}Cucchiaio Torto{}",
+                    " una carta {C:attention}Matto{} o {C:poke_item}Cucchiaio Torto{}",
                     "se la {C:attention}mano di poker{} giocata è",
                     "già stata giocata questo round",
                 } 
@@ -1251,7 +1251,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} slot consumabili",
                     "Ogni {C:attention}Consumabile{} posseduto dà {X:mult,C:white}X#1#{} mult",
-                    "le carte {C:item}Cucchiao Torto{} danno {X:mult,C:white}X#2#{} mult",
+                    "le carte {C:poke_item}Cucchiao Torto{} danno {X:mult,C:white}X#2#{} mult",
                 } 
             },
             j_poke_machop = {
@@ -1418,7 +1418,7 @@ return {
                 text = {
                     "Le carte {C:attention}Acciaio{} giocate danno {X:red,C:white}X#1#{} mult",
                     "più {X:red,C:white}X#2#{} mult per ogni",
-                    "Jolly {X:metal,C:white}Acciaio{} adiacente",
+                    "Jolly {X:poke_metal,C:white}Acciaio{} adiacente",
                     "{C:inactive}(Attualmente {X:red,C:white}X#3#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Si evolve tramite {C:attention,s:0.8}Pietratuono{C:inactive,s:0.8})"
                 } 
@@ -1551,7 +1551,7 @@ return {
                     "La carta più a sinistra della",
                     "tua {C:attention}prima mano giocata{} del round",
                     "diventa una carta {C:attention}di Pietra{}",
-                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:metal,s:0.8}Metallo{C:inactive,s:0.8})"
+                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:poke_metal,s:0.8}Metallo{C:inactive,s:0.8})"
                 } 
             },
             j_poke_drowzee = {
@@ -1759,7 +1759,7 @@ return {
                     "Raddoppia i guadagni se un {C:attention}Re{}",
                     "è tenuto in mano",
                     "{C:inactive}(Attualmente {C:mult}+#1#{C:inactive} mult)",
-                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:dragon,s:0.8}Drago{C:inactive,s:0.8})"
+                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:poke_dragon,s:0.8}Drago{C:inactive,s:0.8})"
                 } 
             },
             j_poke_goldeen = {
@@ -1810,7 +1810,7 @@ return {
                     "Ottiene un'edizione {C:attention}Foil{}, {C:attention}Olografico{}, o {C:attention}Policromo{}",
                     "se il Jolly era {C:red}Raro{} o superiore",
                     "{C:inactive}(Attualmente {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:metal,s:0.8}Metallo{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Si evolve con un adesivo {C:poke_metal,s:0.8}Metallo{C:inactive,s:0.8})",
                 } 
             },
             j_poke_jynx = {
@@ -1821,7 +1821,7 @@ return {
                     "{br:4}text needs to be here to work",
                     "{C:attention}Le carte aggiunte al mazzo{} tramite",
                     "{C:attention}Negozio{}, {C:attention}Standard{} pack,",
-                    "{C:spectral}Criptide{}, {C:item}Oggetti{} e alcuni Jolly",
+                    "{C:spectral}Criptide{}, {C:poke_item}Oggetti{} e alcuni Jolly",
                     "quando vengono giocate vengono {C:attention}duplicate{}"
                 } 
             },
@@ -1918,7 +1918,7 @@ return {
                     "Vendi questo Jolly per creare",
                     "un'edizione base {C:attention}Deperibile{}",
                     "del Jolly più a sinistra",
-                    "e di {C:colorless}Tipo Incolore{}",
+                    "e di {C:poke_colorless}Tipo Incolore{}",
                     "{C:inactive,s:0.8}(rimuove eventuali adesivi Eterni, esclude Ditto)",
                 } 
             },
@@ -1956,8 +1956,8 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} Limite di Energia",
-                    "Crea una carta {C:pink}Energia{}",
+                    "{C:poke_pink}+1{} Limite di Energia",
+                    "Crea una carta {C:poke_pink}Energia{}",
                     "quando un {C:attention}Booster Pack{}",
                     "viene aperto",
                     "{C:inactive, s:0.8}(Si evolve con una carta{} {C:attention}Potenziamento{}{C:inactive})"
@@ -1969,7 +1969,7 @@ return {
                     "{C:attention}#1#Antico{}",
                     "{X:attention,C:white}1+{} : Crea un {C:tarot}Tarocco{}",
                     "{X:attention,C:white}2+{} : Guadagna {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Crea un {C:item}Oggetto{}",
+                    "{X:attention,C:white}3+{} : Crea un {C:poke_item}Oggetto{}",
                     "{C:inactive,s:0.8}(Devi avere spazio)",
                     "{C:inactive,s:0.8}(Si evolve dopo aver attivato il terzo effetto {C:attention,s:0.8}#3#{C:inactive,s:0.8} volte)"
                 } 
@@ -1980,7 +1980,7 @@ return {
                     "{C:attention}#1# Antico{}",
                     "{X:attention,C:white}1+{} : Crea un {C:tarot}Tarocco{}",
                     "{X:attention,C:white}2+{} : Guadagni {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Crea un {C:item}Oggetto{}",
+                    "{X:attention,C:white}3+{} : Crea un {C:poke_item}Oggetto{}",
                     "{C:inactive,s:0.8}(Devi avere spazio)",
                     "{X:attention,C:white}4+{} : Crea un {C:attention}Patto{} una volte per round{C:inactive}#3#{}",
                 } 
@@ -2093,7 +2093,7 @@ return {
                 text = {
                     "Alla fine del negozio, distrugge il Jolly più a sinistra",
                     "e ne crea una copia {C:dark_edition}Policroma{}",
-                    "con {C:attention}+1{} {C:pink}Energia{}",
+                    "con {C:attention}+1{} {C:poke_pink}Energia{}",
                     "I Jolly {C:dark_edition}policromi{} danno {X:mult,C:white} X#1# {} mult",
                     "{C:inactive}(Non può distruggere sé stesso)",
                 } 
@@ -2107,9 +2107,9 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "Dà {C:attention}+2{} {C:pink}Energia{} al",
+                    "Dà {C:attention}+2{} {C:poke_pink}Energia{} al",
                     "Jolly più a sinistra alla fine del negozio",
-                    "{C:pink}+1{} Limite di Energia quando",
+                    "{C:poke_pink}+1{} Limite di Energia quando",
                     "un {C:attention}Buio Boss{} viene sconfitto"
                 } 
             },
@@ -2118,7 +2118,7 @@ return {
                 text = {
                     "Alla fine del negozio, crea",
                     "una carta {C:attention}Tarocco{} ,{C:spectral}Spettrale{}",
-                    " o {C:item}Oggetto{} {C:dark_edition}Negativo{}  casuale",
+                    " o {C:poke_item}Oggetto{} {C:dark_edition}Negativo{}  casuale",
                     "A volte crea un Jolly {C:dark_edition}Negativo{} casuale",
                 } 
             },
@@ -2306,8 +2306,8 @@ return {
                   "Da {C:chips}+#1#{} Fiche e guadagni {C:money}$#2#{}",
                   "se la mano giocata include una {C:attention}Coppia",
                   "{br:3}ERROR - CONTACT STEAK",
-                  "{C:chips}+#3#{} Fiche extra per ogni Jolly di Tipo {X:water,C:white}Acqua{}",
-                  "{C:money}$#4#{} extra per ogni Jolly di Tipo {X:lightning,C:black}Elettro{}",
+                  "{C:chips}+#3#{} Fiche extra per ogni Jolly di Tipo {X:poke_water,C:white}Acqua{}",
+                  "{C:money}$#4#{} extra per ogni Jolly di Tipo {X:poke_lightning,C:black}Elettro{}",
                   "{C:inactive}(Attualmente {C:chips}+#6#{C:inactive} Fiche e {C:money}$#5#{C:inactive})"
                 }
             },
@@ -2442,8 +2442,8 @@ return {
                   "Le {C:attention}Figure{} giocate danno {C:mult}+#1#{} Mult quando assegnano punti",
                   "{br:2}text needs to be here to work",
                   "Riattiva tutte le {C:attention}Figure{} giocate se",
-                  "questo Jolly non è {X:grass,C:white}Erba{} o",
-                  "Se hai un Jolly {X:water,C:white}Acqua{}"
+                  "questo Jolly non è {X:poke_grass,C:white}Erba{} o",
+                  "Se hai un Jolly {X:poke_water,C:white}Acqua{}"
                 }
             },
             j_poke_bellossom = {
@@ -2462,7 +2462,7 @@ return {
                     "Le carte {V:1}#2#{} giocate danno",
                     "{C:mult}+#1#{} mult quando assegnano punti",
                     "Le carte si riattivano in base a",
-                    "quanti Jolly {X:water,C:white}Acqua{} possiedi",
+                    "quanti Jolly {X:poke_water,C:white}Acqua{} possiedi",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} Il numero delle riattivazione si divide equamente tra le carte di punteggio){}",
                     "Il seme cambia in ordine {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -2572,7 +2572,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:red,C:white} X#1# {} Mult per ogni",
-                "Joker di tipo {X:dark,C:white}Buio{} in possesso",
+                "Joker di tipo {X:poke_dark,C:white}Buio{} in possesso",
                 "{C:inactive}(Attualmente {X:red,C:white} X#2#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Si evolve tramite {C:attention,s:0.8}Neropietra{C:inactive,s:0.8})"
               }
@@ -2726,8 +2726,8 @@ return {
                 text = {
                   "Quando un {C:attention}Buio{} viene selezionato, distruggi",
                   "il {C:attention}Consumabile{} più a sinistra e",
-                  "crea una carta {C:item}Succo di Bacca{} ",
-                  "{C:inactive}(Il {C:item}Succo di Bacca{C:inactive} non può essere distrutto)"
+                  "crea una carta {C:poke_item}Succo di Bacca{} ",
+                  "{C:inactive}(Il {C:poke_item}Succo di Bacca{C:inactive} non può essere distrutto)"
                 }
             },
             j_poke_sneasel = {
@@ -2751,7 +2751,7 @@ return {
               name = "Ursaring",
               text = {
                 "Ottiene {C:mult}+#2#{} Mult e",
-                "crea un {C:item}Oggetto{} quando un",
+                "crea un {C:poke_item}Oggetto{} quando un",
                 "{C:attention}Pcchetto{} viene saltato {C:inactive,s:0.8}(Devi avere spazio)",
                 "{C:inactive}(Attualmente {C:mult}+#1#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Si evolve tramite{C:attention,s:0.8}Pietralunare{C:inactive,s:0.8})",
@@ -2811,7 +2811,7 @@ return {
                 "{C:mult}+#1#{} Mult per ogni carta ",
                 "{C:attention}Potenziata{} nel tuo mazzo completo",
                 "{br:2}text needs to be here to work",
-                "Crea un Jolly {C:attention}Comune{} {X:water,C:white}Acqua{} se",
+                "Crea un Jolly {C:attention}Comune{} {X:poke_water,C:white}Acqua{} se",
                 "la mano giocata include {C:attention}5 carte potenziate{}",
                 "{C:inactive,s:0.8}(Devi avere spazio)",
                 "{C:inactive}(Attualmente {C:mult}+#2#{C:inactive} Mult)",
@@ -2892,12 +2892,12 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} Limite di Energia",
-                    "Crea una carta {C:pink}Energia{}",
-                    "dello stesso {C:pink}Tipo{} del",
+                    "{C:poke_pink}+2{} Limite di Energia",
+                    "Crea una carta {C:poke_pink}Energia{}",
+                    "dello stesso {C:poke_pink}Tipo{} del",
                     "Jolly più a sinistra quando un",
                     "{C:attention}Booster Pack{} è aperto",
-                    "{C:inactive,s:0.8}(Si evolve tramite {C:metal,s:0.8}Dubbiodisco{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Si evolve tramite {C:poke_metal,s:0.8}Dubbiodisco{C:inactive,s:0.8})",
                 } 
             },
             j_poke_stantler = {
@@ -2990,7 +2990,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Ottieni {C:money}$#1#{} per ogni Jolly", 
-                  "{C:colorless}Incolore{} Joker in possesso",
+                  "{C:poke_colorless}Incolore{} Joker in possesso",
                   "alla fine del round",
                   "{C:inactive}(Attualmente {C:money}$#2#{C:inactive}){}"
                 }
@@ -3096,7 +3096,7 @@ return {
                     "{C:attention}+#3#{} Carte della mano, {C:attention}Natura{}",
                     "Ogni {C:attention}#6#, #7# o #8#{} giocato ha {C:green}#4# possibilità su #5#{}",
                     "di guadagnare {C:money}$#1#{} quando assegna punti",
-                    "Garantito se hai altre carte {X:grass,C:white}Erba{}",
+                    "Garantito se hai altre carte {X:poke_grass,C:white}Erba{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive,s:0.8}(Si evolve dopo aver guadagnato {C:money, s:0.8}$#2#/16{})"
                 } 
@@ -3107,7 +3107,7 @@ return {
                     "{C:attention}+#3#{} Carte della mano, {C:attention}Natura{}",
                     "Ogni {C:attention}#6#, #7# o #8#{} giocato ha {C:green}#4# possibilità su #5#{}",
                     "di guadagnare {C:money}$#1#{} quando assegna punti",
-                    "Garantito se hai altre carte {X:grass,C:white}Erba{}",
+                    "Garantito se hai altre carte {X:poke_grass,C:white}Erba{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive,s:0.8}(Si evolve dopo aver guadagnato {C:money,s:0.8}$#2#/32{})"
                 } 
@@ -3119,7 +3119,7 @@ return {
                     "Per ogni {C:attention}#5#, #6# o #7#{} giocati guadagni {C:money}$#1#{}",
                     "{br:5}ERROR - CONTACT STEAK",
                     "quando assegnano punti. Guadagna {C:money}$#1#{} alla fine del round per",
-                    "ogni altre carte {X:grass,C:white}Erba{} in tuo possesso",
+                    "ogni altre carte {X:poke_grass,C:white}Erba{} in tuo possesso",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive,s:0.8}(Attualmente {C:money}$#4#{}, Massimo di {C:money}$14{}{C:inactive}){}"
                 } 
@@ -3129,7 +3129,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} scarti, {C:attention}Natura{}",
                     "{C:mult}+#1#{} mult per ogni {C:attention}#5#, #6# o #7#{} scartato questo round",
-                    "Raddoppia i guadagni se hai altre carte {X:fire,C:white}Fuoco{} o {X:earth,C:white}Lotta{}",
+                    "Raddoppia i guadagni se hai altre carte {X:poke_fire,C:white}Fuoco{} o {X:poke_earth,C:white}Lotta{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive}(Attualmente {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Si evolve dopo {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult )",
@@ -3140,7 +3140,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} scarti, {C:attention}Natura{}",
                     "{C:mult}+#1#{} mult per ogni {C:attention}#5#, #6# o #7#{} scartato questo round",
-                    "Raddoppia i guadagni se hai altre carte {X:fire,C:white}Fuoco{} o {X:earth,C:white}Lotta{}",
+                    "Raddoppia i guadagni se hai altre carte {X:poke_fire,C:white}Fuoco{} o {X:poke_earth,C:white}Lotta{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive}(Attualmente {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Si evolve dopo {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult)",
@@ -3152,7 +3152,7 @@ return {
                     "{C:mult}+#2#{} scarti, {C:attention}Natura{}",
                     "Per ogni {C:attention}#6#, #7# o #8#{} scartati questo round",
                     "guadagna {C:mult}+#4#{} mult e {X:red,C:white} X#1# {} mult per",
-                    "ogni carta {X:fire,C:white}Fuoco{} o {X:earth,C:white}Lotta{} che hai",
+                    "ogni carta {X:poke_fire,C:white}Fuoco{} o {X:poke_earth,C:white}Lotta{} che hai",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive}(Attualmente {C:mult}+#5#{C:inactive} Mult, {X:red,C:white}X#3#{C:inactive} Mult){}",
                 } 
@@ -3162,7 +3162,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} Mani, {C:attention}Natura{}",
                     "Per ogni {C:attention}#4#, #5# o #6#{} giocato ottieni {C:chips}+#1#{} Fiche",
-                    "Raddoppia le fiche guadagnate se hai carte {X:water,C:white}Acqua{} o {X:earth,C:white}Terra{}",
+                    "Raddoppia le fiche guadagnate se hai carte {X:poke_water,C:white}Acqua{} o {X:poke_earth,C:white}Terra{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive,s:0.8}(Si evolve dopo aver guadagnato {C:chips,s:0.8}#2#{C:inactive,s:0.8} fiche)"
                 } 
@@ -3172,7 +3172,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} Mani, {C:attention}Natura{}",
                     "Per ogni {C:attention}#4#, #5# o #6#{} giocato ottieni {C:chips}+#1#{} Fiche",
-                    "Raddoppia le fiche guadagnate se hai carte {X:water,C:white}Acqua{} o {X:earth,C:white}Terra{}",
+                    "Raddoppia le fiche guadagnate se hai carte {X:poke_water,C:white}Acqua{} o {X:poke_earth,C:white}Terra{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive,s:0.8}(Si evolve dopo aver guadagnato {C:chips,s:0.8}#2#{C:inactive,s:0.8} fiche)"
                 } 
@@ -3183,7 +3183,7 @@ return {
                     "{C:chips}+#3#{} mani, {C:attention}Natura{}",
                     "Per ogni {C:attention}#6#, #7# o #8#{} giocato ottieni {C:chips}+#1#{} fiche",
                     "Ottieni ulteriori {C:chips}+#5#{} fiche per",
-                    "ogni altra carta {X:water,C:white}Acqua{} o {X:earth,C:white}Terra{}",
+                    "ogni altra carta {X:poke_water,C:white}Acqua{} o {X:poke_earth,C:white}Terra{}",
                     "{C:inactive,s:0.8}(include Jolly e carte Energia){}",
                     "{C:inactive}(Attualmente {C:chips}+#4#{}{C:inactive} totale)"
                 } 
@@ -3204,16 +3204,16 @@ return {
                 "{C:attention}una carta giocata{} viene distrutta",
                 "{br:2}ERROR - CONTACT STEAK",
                 "Bonus aumento di {C:mult}+#3#{} Mult",
-                "per ogni Jolly {X:dark,C:white}Buio{} in possesso",
+                "per ogni Jolly {X:poke_dark,C:white}Buio{} in possesso",
                 "{C:inactive}(Attualmente {C:mult}+#1#{C:inactive} Mult)",
               }
             },
             j_poke_zigzagoon = {
               name = "Zigzagoon",
               text = {
-                "{C:attention}Raccolta{} {C:item}Ottieni un Oggetto{}",
+                "{C:attention}Raccolta{} {C:poke_item}Ottieni un Oggetto{}",
                 "{C:green}#1# possibilità su #2#{} di creare un ",
-                "{C:item}Oggetto{} quando una mano viene giocata",
+                "{C:poke_item}Oggetto{} quando una mano viene giocata",
                 "{C:inactive}(Devi avere spazio)",
                 "{C:inactive,s:0.8}(Si evolve dopo {C:attention}#3#{C:inactive,s:0.8} round)",
               }
@@ -3222,7 +3222,7 @@ return {
               name = "Linoone",
               text = {
                 "{C:green}#1# possibilità su #2#{} di creare un",
-                "{C:item}Oggetto{} quando una mano viene giocata",
+                "{C:poke_item}Oggetto{} quando una mano viene giocata",
                 "Garantito se la mano giocata",
                 "include una {C:attention}scala{}",
                 "{C:inactive}(Devi avere spazio)"
@@ -3451,7 +3451,7 @@ return {
                 name = 'Jirachi',
                 text = {
                     "Copia l'abilità del {C:attention}Jolly{} a destra",
-                    "con {C:attention}#1#{} extra {C:pink}Energy",
+                    "con {C:attention}#1#{} extra {C:poke_pink}Energy",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -3554,7 +3554,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Ogni Jolly di tipo {X:dark,C:white}Buio{} da {X:red,C:white}X#1#{} Mult",
+                  "Ogni Jolly di tipo {X:poke_dark,C:white}Buio{} da {X:red,C:white}X#1#{} Mult",
                 }
             },
             j_poke_bonsly = {
@@ -3589,7 +3589,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}, {X:red,C:white} X#1# {} mult",
-                    "Crea una carta {C:item}Oggetto{} {C:dark_edition}Negativo{} casuale ",
+                    "Crea una carta {C:poke_item}Oggetto{} {C:dark_edition}Negativo{} casuale ",
                     "alla fine del round",
                     "{C:inactive}(Sì, questo {C:attention}ridurrà{C:inactive} il tuo mult)",
                     "{C:inactive,s:0.8}(Si evolve dopo {C:attention,s:0.8}#2#{C:inactive,s:0.8} round)",
@@ -3622,7 +3622,7 @@ return {
                 text = {
                     "Le carte {C:attention}d'acciaio{} giocate danno {X:red,C:white}X#1#{} mult",
                     "più {X:red,C:white}X#2#{} mult per ogni",
-                    "Jolly {X:metal,C:white}Acciaio{} in possesso",
+                    "Jolly {X:poke_metal,C:white}Acciaio{} in possesso",
                     "{C:inactive}(Attualmente {X:red,C:white}X#3#{}{C:inactive} mult){}",
                 } 
             },
@@ -3643,7 +3643,7 @@ return {
                     "{C:chips}+#1#{} fiche quando assegna punti",
                     "{br:3}ERROR - CONTACT STEAK",
                     "Le carte {C:attention}di pietra{} si riattivano per ogni",
-                    "Jolly {X:earth,C:white}Terra{} che hai",
+                    "Jolly {X:poke_earth,C:white}Terra{} che hai",
                     "{C:inactive}(Attualmente #2# riattivazioni)"
                 } 
             },
@@ -3743,8 +3743,8 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Limite di Energia",
-                    "{X:red,C:white} X#2# {} mult per ogni carta {C:pink}Energia{}",
+                    "{C:poke_pink}+3{} Limite di Energia",
+                    "{X:red,C:white} X#2# {} mult per ogni carta {C:poke_pink}Energia{}",
                     "usata in questa {C:attention}partita{}",
                     "{C:inactive}(Attualmente {X:red,C:white} X#1# {}{C:inactive} mult)"
                 } 
@@ -3774,7 +3774,7 @@ return {
                 text = {
                   "Il debito arriva fino a {C:mult}-$#1#{}",
                   "{br:2.5}ERROR - CONTACT STEAK",
-                  "Crea una carta {C:item}Oggetto{} se",
+                  "Crea una carta {C:poke_item}Oggetto{} se",
                   "la mano viene giocata mentre si è in debito",
                   "{C:inactive,s:0.8}(Devi avere spazio)",
                 }
@@ -3783,7 +3783,7 @@ return {
                 name = "Rotom",
                 text = {
                   "{C:green}#1# possibilità su #2#{} di creare",
-                  "un {C:item}oggetto{} quando apri una qualsiasi",
+                  "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                   "{C:attention}Busta d'espansione{}",
                   "{C:inactive}(Devi avere spazio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -3795,7 +3795,7 @@ return {
                 name = "Rotom (Calore)",
                 text = {
                   "{C:green}#1# possibilità su #2#{} di creare",
-                  "un {C:item}oggetto{} quando apri una qualsiasi",
+                  "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                   "{C:attention}Busta d'espansione{}",
                   "{C:inactive}(Devi avere spazio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -3809,7 +3809,7 @@ return {
                 name = "Rotom (Lavaggio)",
                 text = {
                   "{C:green}#1# possibilità su #2#{} di creare",
-                  "un {C:item}oggetto{} quando apri una qualsiasi",
+                  "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                   "{C:attention}Busta d'espansione{}",
                   "{C:inactive}(Devi avere spazio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -3823,7 +3823,7 @@ return {
               name = "Rotom (Gelo)",
               text = {
                 "{C:green}#1# possibilità su #2#{} di creare",
-                "un {C:item}oggetto{} quando apri una qualsiasi",
+                "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                 "{C:attention}Busta d'espansione{}",
                 "{C:inactive}(Devi avere spazio){}",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -3837,7 +3837,7 @@ return {
                 name = "Rotom (Vortice)",
                 text = {
                   "{C:green}#1# possibilità su #2#{} di creare",
-                  "un {C:item}oggetto{} quando apri una qualsiasi",
+                  "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                   "{C:attention}Busta d'espansione{}",
                   "{C:inactive}(Devi avere spazio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -3851,7 +3851,7 @@ return {
                 name = "Rotom (Taglio)",
                 text = {
                   "{C:green}#1# possibilità su #2#{} di creare",
-                  "un {C:item}oggetto{} quando apri una qualsiasi",
+                  "un {C:poke_item}oggetto{} quando apri una qualsiasi",
                   "{C:attention}Busta d'espansione{}",
                   "{C:inactive}(Devi avere spazio){}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4236,7 +4236,7 @@ return {
                 text = {
                     "{C:chips}+#1#{} Fiche se la mano giocata include un {C:attention}Colore{}",
                     "{br:2}ERROR - CONTACT STEAK",
-                    "Crea una carta {C:pink}Energia{} se la giocata",
+                    "Crea una carta {C:poke_pink}Energia{} se la giocata",
                     "include un {C:attention}Re{} o una {C:attention}Regina{}"
                 } 
             },
@@ -4293,7 +4293,7 @@ return {
                   "{C:inactive}(Devi avere spazio)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Guadagni {C:money}$#3#{} quando una carta{C:spectral}Spettrale{}",
-                  "viene usata e applica un adesivo{X:psychic,C:white}Psico{}",
+                  "viene usata e applica un adesivo{X:poke_psychic,C:white}Psico{}",
                   "al Jolly {C:attention}più a sinistra{}"
                 }
             },
@@ -4305,7 +4305,7 @@ return {
                   "{C:inactive}(Devi avere spazio)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Guadagni {C:money}$#3#{} quando una carta{C:spectral}Spettrale{}",
-                  "viene usata e applica un adesivo{X:psychic,C:white}Psico{}",
+                  "viene usata e applica un adesivo{X:poke_psychic,C:white}Psico{}",
                   "al Jolly {C:attention}più a sinistra{}"
                 }
             },
@@ -4317,7 +4317,7 @@ return {
                   "{C:inactive}(Devi avere spazio)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Guadagni {C:money}$#3#{} quando una carta{C:spectral}Spettrale{}",
-                  "viene usata e applica un adesivo{X:psychic,C:white}Psico{}",
+                  "viene usata e applica un adesivo{X:poke_psychic,C:white}Psico{}",
                   "al Jolly {C:attention}più a sinistra{}"
                 }
             },
@@ -4329,7 +4329,7 @@ return {
                   "{C:inactive}(Devi avere spazio)",
                   "{br:2}ERROR - CONTACT STEAK",
                   "Guadagni {C:money}$#3#{} quando una carta{C:spectral}Spettrale{}",
-                  "viene usata e applica un adesivo{X:psychic,C:white}Psico{}",
+                  "viene usata e applica un adesivo{X:poke_psychic,C:white}Psico{}",
                   "al Jolly {C:attention}più a sinistra{}"
                 }
             },
@@ -4338,7 +4338,7 @@ return {
                 text = {
                     "{C:mult}+#1#{} Mult",
                     "{C:attention}Triplica{} se hai",
-                    "un Jolly di tipo {X:lightning, C:black}Elettro{} ",
+                    "un Jolly di tipo {X:poke_lightning, C:black}Elettro{} ",
                     "{C:inactive,s:0.8}(Evolve dopo {C:attention,s:0.8}#2#{C:inactive,s:0.8} round)",
                 }  
             },
@@ -4346,7 +4346,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult per ogni",
-                    "Jolly {X:lightning, C:black}Elettro{} in possesso",
+                    "Jolly {X:poke_lightning, C:black}Elettro{} in possesso",
                     "{C:inactive}(Attualmente {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolve tramite carta {C:attention,s:0.8}Pietratuono{C:inactive,s:0.8})"
                 }  
@@ -4356,7 +4356,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult per ogni",
-                    "Jolly {X:lightning, C:black}Elettro{} in possesso",
+                    "Jolly {X:poke_lightning, C:black}Elettro{} in possesso",
                     "{C:inactive}(Attualmente {X:red,C:white} X#2# {C:inactive} Mult)",
                 }
             },
@@ -4538,7 +4538,7 @@ return {
               name = "Ursaluna",
               text = {
                 "Ottiene {C:mult}+#2#{} Mult e crea",
-                "un {C:item}Oggetto{} con edizione {C:dark_edition}Policroma{} quando un",
+                "un {C:poke_item}Oggetto{} con edizione {C:dark_edition}Policroma{} quando un",
                 "{C:attention}Pacchetto{} viene saltato {C:inactive,s:0.8}(Devi avere spazio)",
                 "{C:inactive}(Attualmente {C:mult}+#1#{C:inactive} Mult)",
               }
@@ -4567,7 +4567,7 @@ return {
                   "Il {C:attention}valore{} richiesto aumenta ad ogni attivazione",
                   "{C:inactive,s:0.8}(Se il valore raggiunge il massimo, torna il minimo)",
                   "{C:inactive}(Attualmente {C:chips}+#1#{C:inactive} fiche)",
-                  "{C:inactive,s:0.8}(Si evolve quando hai un Jolly {X:fire,C:white,s:0.8}di tipo Fuoco{C:inactive,s:0.8})",
+                  "{C:inactive,s:0.8}(Si evolve quando hai un Jolly {X:poke_fire,C:white,s:0.8}di tipo Fuoco{C:inactive,s:0.8})",
                 }
             },
             j_poke_dachsbun = {
@@ -4577,7 +4577,7 @@ return {
                   "Il {C:attention}valore{} aumenta ad ogni attivazione",
                   "{br:4}ERROR - CONTACT STEAK",
                   "Le fiche aumentano di {C:chips}+2{} per ogni",
-                  "Jolly di tipo {X:fire,C:white}Fuoco{} in possesso",
+                  "Jolly di tipo {X:poke_fire,C:white}Fuoco{} in possesso",
                   "{C:inactive,s:0.8}(Se il valore raggiunge il massimo, ritorna al minimo)",
                   "{C:inactive}(Currently {C:chips}+#1#{C:inactive} chips)",
                 }
@@ -4752,7 +4752,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult per ogni jolly",
-                    "di {C:pink}Tipo{} diverso",
+                    "di {C:poke_pink}Tipo{} diverso",
                     "{br:3}ERROR - CONTACT STEAK",
                     "Possono apparire {C:attention}Pokemon{}", 
                     "della stessa linea evolutiva",
@@ -4782,7 +4782,7 @@ return {
                 name = "Onigiri",
                 text = {
                   "Quando selezioni un Buio",
-                  "crea una carta {C:pink}Energia{} {C:colorless}Incolore ",
+                  "crea una carta {C:poke_pink}Energia{} {C:poke_colorless}Incolore ",
                   "{C:inactive}({C:attention}#1#{C:inactive} round rimanenti){}"
                 }
             },
@@ -4812,8 +4812,8 @@ return {
                 name = "Oro in Bocca",
                 text = {
                   "Quando un Buio viene selezionato",
-                  "cambia il {C:pink}tipo{} del jolly più a sinistra",
-                  "nel {C:pink}tipo{} del Jolly più a destra",
+                  "cambia il {C:poke_pink}tipo{} del jolly più a sinistra",
+                  "nel {C:poke_pink}tipo{} del Jolly più a destra",
                   "{C:attention}Cambiatore di Tipo{}",
                   "{C:inactive}({C:attention}#1#{C:inactive} round rimasti){}"
                 }
@@ -4855,14 +4855,14 @@ return {
                 text = {
                   "Quando si schiude diventa un Jolly {C:attention}Base{} o",
                   "{C:attention}Baby{} dopo {C:attention}#1#{} round",
-                  "con {C:pink}+1{} Energy se apllicabile"
+                  "con {C:poke_pink}+1{} Energy se apllicabile"
                 }
             },
             j_poke_billion_lions = {
                 name = 'Un miliardo di leoni',
                 text = {
                     "Quando un buio viene selezionato",
-                    "distruggi i Jolly di ogni {C:pink}tipo{} in tuo possesso",
+                    "distruggi i Jolly di ogni {C:poke_pink}tipo{} in tuo possesso",
                     "e guadagna {X:mult,C:white}X#2#{} Mult per ognuno",
                     "Questo Jolly si {S:1.1,C:red,E:2}autodistrugge{} quando non ha più leoni",
                     "{C:inactive}(Attualmente {X:mult,C:white}X#1#{C:inactive} Mult, {C:attention}#3#{C:inactive} Leoni)"
@@ -4906,7 +4906,7 @@ return {
                 name = "Mazzo Luminoso",
                 text = {
                     "Tutti i Jolly sono creati",
-                    "con adesivi {C:pink}Tipo{} casuali",
+                    "con adesivi {C:poke_pink}Tipo{} casuali",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -4915,7 +4915,7 @@ return {
                     "Inizia la partita con il buono",
                     "{C:tarot,T:v_crystal_ball}#1#{}",
                     "e {C:attention}2{} copie",
-                    "di {C:item,T:c_poke_twisted_spoon}#2#"
+                    "di {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
             sleeve_poke_ampedsleeve = {
@@ -4924,7 +4924,7 @@ return {
                     "Inizia la partita con il buono",
                     "{C:tarot,T:v_poke_energysearch}#1#{}",
                     "e una copia di",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             sleeve_poke_futuresleeve = {
@@ -4980,7 +4980,7 @@ return {
                 text = {
                     "Evolve il Pokémon più a sinistra o selezionato al",
                     "massimo {C:attention}stage{}",
-                    "e dà {}+1{} {C:pink}Energia{}", 
+                    "e dà {}+1{} {C:poke_pink}Energia{}", 
                 },
             },
             c_poke_megastone = {
@@ -4997,7 +4997,7 @@ return {
             c_poke_obituary = {
                 name = "Necrologio",
                 text = {
-                    "Aggiunge un sigillo {C:pink}Rosa{}",
+                    "Aggiunge un sigillo {C:poke_pink}Rosa{}",
                     "a {C:attention}1{} carta selezionata",
                 }
             },
@@ -5005,22 +5005,22 @@ return {
                 name = "Incubo",
                 text = {
                     "Distrugge il Jolly selezionato con",
-                    "un {C:pink}tipo{} e crea {C:attention}2{}",
-                    "{C:pink}Energia{} di quel Jolly", 
-                    "{C:pink}tipo{} con {C:dark_edition}Negativo{}"
+                    "un {C:poke_pink}tipo{} e crea {C:attention}2{}",
+                    "{C:poke_pink}Energia{} di quel Jolly", 
+                    "{C:poke_pink}tipo{} con {C:dark_edition}Negativo{}"
                 },
             },
             c_poke_revenant = {
                 name = "Revenant",
                 text = {
-                    "Aggiunge un sigillo {C:item}Argento{}",
+                    "Aggiunge un sigillo {C:poke_item}Argento{}",
                     "a {C:attention}1{} carta selezionata",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "Doppia energia arcobaleno",
                 text = {
-                    "{C:pink}Energia{} al Jolly più a sinistra",
+                    "{C:poke_pink}Energia{} al Jolly più a sinistra",
                     "o selezionato {C:red}t{C:attention}w{C:green}i{C:blue}c{C:purple}e{}",
                     "non ottieni interessi round",
                     "{C:inactive}(Massimo {C:attention}#1#{C:inactive} utilizzi per Jolly)",
@@ -5073,7 +5073,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Patto Pocket",
                 text = {
-                    "Ottieni un {C:pink}Mega Pocket Pack",
+                    "Ottieni un {C:poke_pink}Mega Pocket Pack",
                     "{C:green}25%{} possibilità che contenga",
                     "una {C:attention}Mega Pietra{} o {C:attention}Ante 5+{}"
                 }, 
@@ -5083,7 +5083,7 @@ return {
                 text = {
                     "Il prossimo jolly base",
                     "nek negozio è gratuito",
-                    "e diventa {C:colorless}Shiny{}",
+                    "e diventa {C:poke_colorless}Shiny{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -5097,7 +5097,7 @@ return {
                 name = "Patto Safari",
                 text = {
                     "Il negozio ha un Jolly",
-                    "{C:safari}Safari{} gratuito",
+                    "{C:poke_safari}Safari{} gratuito",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -5127,13 +5127,13 @@ return {
             v_poke_energysearch = {
                 name = "Ricerca di Energia",
                 text = {
-                    "{C:pink}+2{} Limite di Energia"
+                    "{C:poke_pink}+2{} Limite di Energia"
                 },
             },
             v_poke_energyresearch = {
                 name = "Ricerca di Energia Avanzata",
                 text = {
-                    "{C:pink}+3{} Limite di Energia"
+                    "{C:poke_pink}+3{} Limite di Energia"
                 },
             },
             v_poke_goodrod = {
@@ -5146,7 +5146,7 @@ return {
             v_poke_superrod = {
                 name = "Super Amo",
                 text = {
-                    "Puoi {C:pink}Salvare{} carte",
+                    "Puoi {C:poke_pink}Salvare{} carte",
                     "da tutti i pacchetti {C:attention}consumabili{}",
                 },
             },
@@ -5156,80 +5156,80 @@ return {
             Grass = {
                 name = "Tipo",
                 text = {
-                  "{X:grass,C:white}Erba{}",
+                  "{X:poke_grass,C:white}Erba{}",
                 }
             },
             Fire = {
                 name = "Tipo",
                 text = {
-                  "{X:fire,C:white}Fuoco{}",
+                  "{X:poke_fire,C:white}Fuoco{}",
                 }
             },
             Water = {
                 name = "Tipo",
                 text = {
-                  "{X:water,C:white}Acqua{}",
+                  "{X:poke_water,C:white}Acqua{}",
                 }
             },
             Lightning = {
                 name = "Tipo",
                 text = {
-                  "{X:lightning,C:black}Elettro{}",
+                  "{X:poke_lightning,C:black}Elettro{}",
                 }
             },
             Psychic = {
                 name = "Tipo",
                 text = {
-                  "{X:psychic,C:white}Psico{}",
+                  "{X:poke_psychic,C:white}Psico{}",
                 }
             },
             Fighting = {
                 name = "Tipo",
                 text = {
-                  "{X:fighting,C:white}Lotta{}",
+                  "{X:poke_fighting,C:white}Lotta{}",
                 }
             },
             Colorless = {
                 name = "Tipo",
                 text = {
-                  "{X:colorless,C:white}Incolore{}",
+                  "{X:poke_colorless,C:white}Incolore{}",
                 }
             },
             Dark = {
                 name = "Tipo",
                 text = {
-                  "{X:dark,C:white}Oscurità{}",
+                  "{X:poke_dark,C:white}Oscurità{}",
                 }
             },
             Metal = {
                 name = "Tipo",
                 text = {
-                  "{X:metal,C:white}Acciaio{}",
+                  "{X:poke_metal,C:white}Acciaio{}",
                 }
             },
             Fairy = {
                 name = "Tipo",
                 text = {
-                  "{X:fairy,C:white}Folletto{}",
+                  "{X:poke_fairy,C:white}Folletto{}",
                 }
             },
             Dragon = {
                 name = "Tipo",
                 text = {
-                  "{X:dragon,C:white}Drago{}",
+                  "{X:poke_dragon,C:white}Drago{}",
                 }
             },
             Earth = {
                 name = "Tipo",
                 text = {
-                  "{X:earth,C:white}Terra{}",
+                  "{X:poke_earth,C:white}Terra{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "Tipo",
                 text = {
-                  "{X:bird,C:white}Uccello{}",
+                  "{X:poke_bird,C:white}Uccello{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -5434,7 +5434,7 @@ return {
                 name = "Regali",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}Oggetto{} {C:attention}Carta",
+                    "{C:green}30%{} - {C:poke_item}Oggetto{} {C:attention}Carta",
                     "{C:green}20%{} - {C:attention}Tag Coupon",
                     "{C:green}15%{} - {C:dark_edition}Policromo{} {C:attention}Carta Regalo",
                 }
@@ -5442,9 +5442,9 @@ return {
             dril_treasure = {
                 name = "Tesoro",
                 text = {
-                    "{C:green}30%{} - {C:item}Pietra {C:attention}Evoluzione  ",
+                    "{C:green}30%{} - {C:poke_item}Pietra {C:attention}Evoluzione  ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}2 Evolution {C:item}Stones",
+                    "{C:green}20%{} - {C:attention}2 Evolution {C:poke_item}Stones",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}5%{} - {C:money}$20{}             ",
                 }
@@ -5452,9 +5452,9 @@ return {
             exdril_treasure = {
                 name = "Tesoro",
                 text = {
-                    "{C:green}30%{} - {C:item}Pietra {C:attention}Evoluzione  ",
+                    "{C:green}30%{} - {C:poke_item}Pietra {C:attention}Evoluzione  ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:item}2 Pietre {C:attention}Evoluzione",
+                    "{C:green}20%{} - {C:poke_item}2 Pietre {C:attention}Evoluzione",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}4%{} - {C:money}$20{}             ",
                     "{C:green}1%{} - {C:attention}Mega Pietra    ",
@@ -5463,7 +5463,7 @@ return {
             pickup = {
               name = "Raccogli",
               text = {
-                "{C:green}34%{} - {C:attention}Carta {C:item}Oggetto{}",
+                "{C:green}34%{} - {C:attention}Carta {C:poke_item}Oggetto{}",
                 "{C:green}25%{} - {C:attention}Avanzi",
                 "{C:green}25%{} - {C:attention}Poke Ball",
                 "{C:green}15%{} - {C:attention}Mega Ball",
@@ -5518,14 +5518,14 @@ return {
             eeveelution = {
                 name = "Eevoluzioni",
                 text = {
-                    "{C:attention}Pietraidrica{} - {X:water,C:white}Vaporeon{}",
-                    "{C:attention}Pietratuono{} - {X:lightning,C:black}Jolteon{}",
-                    "{C:attention}Pietrafocaia{} - {X:fire,C:white}Flareon{}",
-                    "{C:attention}Pietrasolare{} - {X:psychic,C:white}Espeon{}",
-                    "{C:attention}Pietralunare{} - {X:dark,C:white}Umbreon{}",
-                    "{C:attention}Pietrafoglia{} - {X:grass,C:white}Leafeon{}",
-                    "{C:attention}Pietragelo{} - {X:water,C:white}Glaceon{}",
-                    "{C:attention}Pietralbore{} - {X:fairy,C:white}Sylveon{}"
+                    "{C:attention}Pietraidrica{} - {X:poke_water,C:white}Vaporeon{}",
+                    "{C:attention}Pietratuono{} - {X:poke_lightning,C:black}Jolteon{}",
+                    "{C:attention}Pietrafocaia{} - {X:poke_fire,C:white}Flareon{}",
+                    "{C:attention}Pietrasolare{} - {X:poke_psychic,C:white}Espeon{}",
+                    "{C:attention}Pietralunare{} - {X:poke_dark,C:white}Umbreon{}",
+                    "{C:attention}Pietrafoglia{} - {X:poke_grass,C:white}Leafeon{}",
+                    "{C:attention}Pietragelo{} - {X:poke_water,C:white}Glaceon{}",
+                    "{C:attention}Pietralbore{} - {X:poke_fairy,C:white}Sylveon{}"
                 }
             },
             poke_egg_tip = {
@@ -5587,7 +5587,7 @@ return {
             precise_energy_tooltip = {
                 name = "Scala Energia Precisa",
                 text = {
-                    "{s:0.8}Usa {C:attention,s:0.8}decimali{} per tutti i valori quando applichi il bonus {C:pink,s:0.8}Energia{}{s:0.8}",
+                    "{s:0.8}Usa {C:attention,s:0.8}decimali{} per tutti i valori quando applichi il bonus {C:poke_pink,s:0.8}Energia{}{s:0.8}",
                     "{s:0.8}Con questa opzione {C:attention,s:0.8}disattivata{}{s:0.8} si verificherà quanto segue per il bonus:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Mult - Usa Decimali",
                     "{C:attenion}2. {s:0.8}Flat {C:mult,s:0.8}Mult{}{s:0.8} e {C:chips,s:0.8}Chip{}{s:0.8} - Arrotonda al numero intero più vicino",
@@ -5751,7 +5751,7 @@ return {
             allowpokeballs_tooltip = {
               name = "Allow Pokeballs",
               text = {
-                "Allow Pokeball {C:item}items{} to appear",
+                "Allow Pokeball {C:poke_item}items{} to appear",
               }
             },
             pokemaster_tooltip = {
@@ -5805,7 +5805,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Pink Seal",
                 text = {
-                    "Crea una carta {C:pink}Energia{}",
+                    "Crea una carta {C:poke_pink}Energia{}",
                     "dello stesso {C:attention}tipo di un Jolly in tuo",
                     "possesso se assegna punti",
                     "{C:attention}durante la prima mano{} del round",
@@ -5817,7 +5817,7 @@ return {
             poke_silver_seal = {
                 name = "Sigillo argento",
                 text = {
-                  "Crea una carta {C:item}Oggetto{}",
+                  "Crea una carta {C:poke_item}Oggetto{}",
                   "e viene {C:attention}scartata{} se {C:attention}tenuta in mano{}",
                   "mentre i punti vengono assegnati"
                 }
@@ -5826,73 +5826,73 @@ return {
             grass_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:grass,C:white}Erba{}"
+                    "{X:poke_grass,C:white}Erba{}"
                 } 
             },
             fire_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fire,C:white}Fuoco{}"
+                    "{X:poke_fire,C:white}Fuoco{}"
                 } 
             },
             water_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:water,C:white}Acqua{}"
+                    "{X:poke_water,C:white}Acqua{}"
                 } 
             },
             lightning_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:lightning,C:white}Elettro{}"
+                    "{X:poke_lightning,C:white}Elettro{}"
                 } 
             },
             psychic_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:psychic,C:white}Psico{}"
+                    "{X:poke_psychic,C:white}Psico{}"
                 } 
             },
             fighting_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fighting,C:white}Lotta{}"
+                    "{X:poke_fighting,C:white}Lotta{}"
                 } 
             },
             colorless_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:colorless,C:white}Incolore{}"
+                    "{X:poke_colorless,C:white}Incolore{}"
                 } 
             },
             dark_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dark,C:white}Oscurità{}"
+                    "{X:poke_dark,C:white}Oscurità{}"
                 } 
             },
             metal_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:metal,C:white}Acciaio{}"
+                    "{X:poke_metal,C:white}Acciaio{}"
                 } 
             },
             fairy_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:fairy,C:white}Folletto{}"
+                    "{X:poke_fairy,C:white}Folletto{}"
                 } 
             },
             dragon_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:dragon,C:white}Drago{}"
+                    "{X:poke_dragon,C:white}Drago{}"
                 } 
             },
             earth_sticker = {
                 name = "Tipo",
                 text = {
-                    "{X:earth,C:white}Terra{}"
+                    "{X:poke_earth,C:white}Terra{}"
                 } 
             },
             --]]
@@ -5920,64 +5920,64 @@ return {
                 name = "Poké Pacchetto",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "Poké Pacchetto",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "Poké Pacchetto Jumbo",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "Poké Pacchetto Mega",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "Poké Pacchetto",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "Poké Pacchetto",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "Poké Pacchetto Jumbo",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "Poké Pacchetto Mega",
                 text = {
                     "Scegli {C:attention}#1#{} tra",
-                    "{C:attention}#2#{} Carte {C:item}Oggetto{} e",
-                    "{C:attention}#3#{} Carta {C:pink}Energia{}",
+                    "{C:attention}#2#{} Carte {C:poke_item}Oggetto{} e",
+                    "{C:attention}#3#{} Carta {C:poke_pink}Energia{}",
                 },
 			},
             p_poke_pokepack_wish_pack = {

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -42,7 +42,7 @@ return {
                 name = "テレキネシスデッキ",
                 text = {
 					"{C:tarot,T:v_crystal_ball}#1#{} のバウチャーと",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{} の",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{} の",
                     "{C:attention}2{} つのコピーで",
                     "ランをスタートする",
                 } 
@@ -57,8 +57,8 @@ return {
                 name = "ステラデッキ",
                 text = {
                     "すべてのジョーカーは",
-                    "ランダムな {C:pink}タイプ{} のステッカーや",
-                    "{C:pink}エナジャイズ{} {C:attention}された{} 作成される"
+                    "ランダムな {C:poke_pink}タイプ{} のステッカーや",
+                    "{C:poke_pink}エナジャイズ{} {C:attention}された{} 作成される"
                 }
             },
         },
@@ -193,16 +193,16 @@ return {
             c_poke_teraorb = {
                 name = "テラスタルオーブ",
                 text = {
-					"{C:attention}タイプチェンジャー{} {X:pink,C:white}ランダム{}",
+					"{C:attention}タイプチェンジャー{} {X:poke_pink,C:white}ランダム{}",
 					"{br:2}ERROR - CONTACT STEAK",
                     "選択したか一番左ジョーカーを",
-                    "{C:pink}エナジャイズ{} する",
+                    "{C:poke_pink}エナジャイズ{} する",
                 },
             },
             c_poke_metalcoat = {
                 name = "メタルコート",
                 text = {
-					"{C:attention}タイプチェンジャー{} {X:metal,C:white}鋼{}",
+					"{C:attention}タイプチェンジャー{} {X:poke_metal,C:white}鋼{}",
 					"{br:2}ERROR - CONTACT STEAK",
                     "選択したカードの{C:attention}スチール{}コピーを",
 					"1枚作る",
@@ -211,9 +211,9 @@ return {
             c_poke_dragonscale = {
                 name = "竜のウロコ",
                 text = {
-					"{C:attention}タイプチェンジャー{} {X:dragon,C:white}ドラゴン{}",
+					"{C:attention}タイプチェンジャー{} {X:poke_dragon,C:white}ドラゴン{}",
 					"{br:2}ERROR - CONTACT STEAK",
-                    "ランダムな {C:item}アイテム{}か {C:pink}エネルギー{} カードを",
+                    "ランダムな {C:poke_item}アイテム{}か {C:poke_pink}エネルギー{} カードを",
 					"最大 {C:attention}3{}枚まで作る",
 					"{C:attention}タイプチェンジャー{}",
                     "{C:inactive}（空きが必要）{}"
@@ -272,9 +272,9 @@ return {
                 name = "曲がったスプーン",
                 text = {
                     "このランで使用された",
-                    "最後の {C:item}アイテム{} または {C:energy}エネルギー{} カードを",
+                    "最後の {C:poke_item}アイテム{} または {C:energy}エネルギー{} カードを",
                     "作る",
-                    "{s:0.8}ただし {s:0.8,C:item}曲がったスプーンと再使用可能なもの{s:0.8} は除く"
+                    "{s:0.8}ただし {s:0.8,C:poke_item}曲がったスプーンと再使用可能なもの{s:0.8} は除く"
                 }
             },
 			c_poke_prismscale = {
@@ -314,7 +314,7 @@ return {
 					"選択した {C:attention}#1#{} 枚のカードを",
                     "{C:attention}ストーンカード{} に",
                     "強化する",
-					"{X:earth,C:white}地面{} ジョーカーにつき",
+					"{X:poke_earth,C:white}地面{} ジョーカーにつき",
 					"そのストーンカードはチップ {C:chips}+#2#{} を得る",
                 }
             },
@@ -324,7 +324,7 @@ return {
                 name = "草エネルギー",
                 text = {
 					"可能であれば選択したか一番左",
-					"{C:attention}草{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}草{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -332,7 +332,7 @@ return {
                 name = "炎エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}炎{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}炎{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -340,7 +340,7 @@ return {
                 name = "水エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}水{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}水{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -348,7 +348,7 @@ return {
                 name = "雷エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}雷{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}雷{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -356,7 +356,7 @@ return {
                 name = "超エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}超{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}超{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -364,7 +364,7 @@ return {
                 name = "闘エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}闘{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}闘{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -372,7 +372,7 @@ return {
                 name = "無色エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"ジョーカーを {C:pink}エナジャイズ{} する",
+					"ジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:attention}無色{} ジョーカー以外では増加半減",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
@@ -381,7 +381,7 @@ return {
                 name = "悪エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}悪{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}悪{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -389,7 +389,7 @@ return {
                 name = "鋼エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}鋼{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}鋼{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -397,7 +397,7 @@ return {
                 name = "フェアリーエネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}フェアリー{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}フェアリー{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -406,7 +406,7 @@ return {
                 name = "ドラゴンエネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}ドラゴン{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}ドラゴン{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -414,7 +414,7 @@ return {
                 name = "地面エネルギー",
                 text = {
                     "可能であれば選択したか一番左",
-					"{C:attention}地面{} タイプのジョーカーを {C:pink}エナジャイズ{} する",
+					"{C:attention}地面{} タイプのジョーカーを {C:poke_pink}エナジャイズ{} する",
                     "{C:inactive}(ジョーカー1枚につき最大 {C:attention}#1#{}{C:inactive} 回まで増加)",
                 },
             },
@@ -1097,7 +1097,7 @@ return {
 					"プレイした {C:attention}ポーカーハンド{} が",
                     "すでにこのラウンドでプレイされていた場合",
                     "{C:green}#2#分の#1#{} の確率で",
-                    "{C:tarot}タロット{} か {C:item}アイテム{} カードを1枚作る",
+                    "{C:tarot}タロット{} か {C:poke_item}アイテム{} カードを1枚作る",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#3#{}{C:inactive,s:0.8} ラウンド後に進化)"
                 } 
             },
@@ -1107,7 +1107,7 @@ return {
                     "プレイした {C:attention}ポーカーハンド{} が",
                     "すでにこのラウンドでプレイされていた場合",
                     "{C:green}#2#分の#1#{} の確率で",
-                    "{C:tarot}タロット{} か {C:item}曲がったスプーン{} カードを1枚作る",
+                    "{C:tarot}タロット{} か {C:poke_item}曲がったスプーン{} カードを1枚作る",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}つながりのヒモ{}{C:inactive,s:0.8} で進化)"
                 } 
             },
@@ -1118,7 +1118,7 @@ return {
                     "プレイした {C:attention}ポーカーハンド{} が",
                     "すでにこのラウンドでプレイされていた場合",
                     "{C:green}#2#分の#1#{} の確率で",
-                    "{C:attention}愚者{} か {C:item}曲がったスプーン{} カードを1枚作る",
+                    "{C:attention}愚者{} か {C:poke_item}曲がったスプーン{} カードを1枚作る",
                 } 
             },
 			j_poke_mega_alakazam = {
@@ -1126,7 +1126,7 @@ return {
                 text = {
                     "消耗スロット {C:attention}+#3#{}",
                     "持っている {C:attention}消耗カード{} が倍率 {X:mult,C:white}X#1#{}",
-                    "{C:item}曲がったスプーン{} は倍率 {X:mult,C:white}X#2#{}",
+                    "{C:poke_item}曲がったスプーン{} は倍率 {X:mult,C:white}X#2#{}",
                 } 
             },
             j_poke_machop = {
@@ -1292,7 +1292,7 @@ return {
                 text = {
 					"プレイされた {C:attention}スチール{} カードは",
                     "倍率 {X:red,C:white}X#1#{}",
-					"隣接する {X:metal,C:white}鋼{} タイプジョーカーごとに",
+					"隣接する {X:poke_metal,C:white}鋼{} タイプジョーカーごとに",
                     "この倍率は {X:red,C:white}X#2# {}ずつ増加する",
 					"{C:inactive,s:0.8}({C:attention,s:0.8}雷の石{}{C:inactive,s:0.8} で進化)"
                 } 
@@ -1431,7 +1431,7 @@ return {
 					"{C:attention}ファーストハンド{}の",
 					"最初にスコアされたカードを",
 					"{C:attention}ストーン{} に強化する",
-                    "{C:inactive,s:0.8}({C:metal,s:0.8}鋼{}{C:inactive,s:0.8}タイプ ステッカで進化){}"
+                    "{C:inactive,s:0.8}({C:poke_metal,s:0.8}鋼{}{C:inactive,s:0.8}タイプ ステッカで進化){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1644,7 +1644,7 @@ return {
 					"倍率 {C:mult}+#2#{} を得る",
 					"手札にある {C:attention}キング{} 場合, 倍率の増加は2倍される",
                     "{C:inactive}(現在 倍率 {C:mult}+#1#{C:inactive})",
-                    "{C:inactive,s:0.8}({C:dragon,s:0.8}ドラゴン{C:inactive,s:0.8} タイプ ステッカで進化){}"
+                    "{C:inactive,s:0.8}({C:poke_dragon,s:0.8}ドラゴン{C:inactive,s:0.8} タイプ ステッカで進化){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1700,7 +1700,7 @@ return {
 					"{C:dark_edition}フォイル{}、 {C:dark_edition}ホログラム{}",
                     "{C:dark_edition}ポリクローム{} エディションのいずれかを得る",
                     "{C:inactive}(現在 倍率 {C:mult}+#1#{C:inactive}",
-                    "{C:inactive,s:0.8}({C:metal,s:0.8}鋼 {C:inactive,s:0.8}タイプ ステッカか {C:attention,s:0.8}固い石{C:inactive,s:0.8}で進化)",
+                    "{C:inactive,s:0.8}({C:poke_metal,s:0.8}鋼 {C:inactive,s:0.8}タイプ ステッカか {C:attention,s:0.8}固い石{C:inactive,s:0.8}で進化)",
                 } 
             },
             j_poke_jynx = {
@@ -1711,7 +1711,7 @@ return {
 					"ハンドサイズ {C:attention}+#1#{}",
 					"{br:4}ERROR - CONTACT STEAK",
                     "{C:attention}カード{}がデッキに {C:attention}ショップ{}, {C:attention}スタンダードパック{}, ",
-					"{C:spectral}クリプティッド{}, {C:item}アイテム{}, 特定ジョーカーから",
+					"{C:spectral}クリプティッド{}, {C:poke_item}アイテム{}, 特定ジョーカーから",
 					"追加されるたびには {C:attention}複製{}する",
                 } 
             },
@@ -1808,7 +1808,7 @@ return {
                 text = {
                     "このカードを売ると",
 					"一番左のジョーカーを",
-					"{C:colorless}無色{} ステッカー と {C:attention}摩耗{} で",
+					"{C:poke_colorless}無色{} ステッカー と {C:attention}摩耗{} で",
                     "複製する",
                     "{C:inactive,s:0.8}(エターナル解除, メタモン除き){}",
                 } 
@@ -1848,9 +1848,9 @@ return {
             j_poke_porygon = {
                 name = 'ポリゴン',
                 text = {
-					"{C:pink}+1{} エネルギーMAXレベル",
+					"{C:poke_pink}+1{} エネルギーMAXレベル",
 					"{C:attention}ブースターパック{} を開封するたびに",
-					"{C:pink}エネルギー{} カードを作る",
+					"{C:poke_pink}エネルギー{} カードを作る",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}アップグレード{}{C:inactive,s:0.8} で進化する)"
                 } 
             },
@@ -1860,7 +1860,7 @@ return {
                     "{C:attention}原始 #1#{}",
                     "{X:attention,C:white}1+{} : {C:tarot}タロット{} カードを作る",
                     "{X:attention,C:white}2+{} : {C:money}$#2#{} を得る",
-                    "{X:attention,C:white}3+{} : {C:item}アイテム{} カードを作る",
+                    "{X:attention,C:white}3+{} : {C:poke_item}アイテム{} カードを作る",
 					"{C:inactive,s:0.8}(空きが必要)",
                     "{C:inactive,s:0.8}(3+のレベルを {C:attention,s:0.8}#3#{}{C:inactive,s:0.8} 回発動した後に進化)"
                 } 
@@ -1871,7 +1871,7 @@ return {
                     "{C:attention}原始 #1#{}",
 					"{X:attention,C:white}1+{} : {C:tarot}タロット{} カードを作る",
                     "{X:attention,C:white}2+{} : {C:money}$#2#{} を得る",
-                    "{X:attention,C:white}3+{} : {C:item}アイテム{} カードを作る",
+                    "{X:attention,C:white}3+{} : {C:poke_item}アイテム{} カードを作る",
 					"{C:inactive,s:0.8}(空きバサギリが必要)",
                     "{X:attention,C:white}4+{} : ラウンドごとに1回 {C:attention}タグ{} を作る {C:inactive}#3#{}",
                 } 
@@ -1981,7 +1981,7 @@ return {
                 name = 'ミュウツー',
                 text = {
 					"ショップ終了時に",
-					"一番左ジョーカーの{C:dark_edition}ポリクローム{}と {C:pink}エナジャイズ{} {C:attention}された{}",
+					"一番左ジョーカーの{C:dark_edition}ポリクローム{}と {C:poke_pink}エナジャイズ{} {C:attention}された{}",
 					"{C:attention}コピー{} を作成する",
 					"次に一番左ジョーカーを{C:attention}破壊{}する",
 					"{br:3}ERROR - CONTACT STEAK",
@@ -1999,10 +1999,10 @@ return {
 			j_poke_mega_mewtwo_y = {
                 name = "メガミュウツーY",
                 text = {
-					"ショップ終了時に一番左ジョーカーを {C:attention}2回{} {C:pink}エナジャイズ{} する",
+					"ショップ終了時に一番左ジョーカーを {C:attention}2回{} {C:poke_pink}エナジャイズ{} する",
                     "{br:2}ERROR - CONTACT STEAK",
 					"{C:attention}ボスブラインド{} を倒した時",
-					"{C:pink}+1{} エネルギーMAXレベル",
+					"{C:poke_pink}+1{} エネルギーMAXレベル",
                 } 
             },
             j_poke_mew = {
@@ -2010,7 +2010,7 @@ return {
                 text = {
 					"ショップ終了時に",
 					"ランダムな {C:dark_edition}ネガティブ{} {C:tarot}タロット{},",
-					"{C:spectral}スペクトル{} か {C:item}アイテム{} カードを作る",
+					"{C:spectral}スペクトル{} か {C:poke_item}アイテム{} カードを作る",
 					"{C:green}#1#%{}の確率で {C:attention}代わり{} に",
 					"ラ{C:dark_edition}ネガティブ{} ジョーカーを作る",
 					"{C:inactive,s:0.8}(確率は変更できない)",
@@ -2277,8 +2277,8 @@ return {
 				    "プレイされた {C:attention}フェイス{} カードがスコアされた時",
 				    "倍率 {C:mult}+#1#{} を与える",
                     "{br:3.5}ERROR - CONTACT STEAK",
-				    "このジョーカーは {X:grass,C:white}草{} タイプじゃない場合か",
-				    "{X:water,C:white}水{} タイプのジョーカーがある場合",
+				    "このジョーカーは {X:poke_grass,C:white}草{} タイプじゃない場合か",
+				    "{X:poke_water,C:white}水{} タイプのジョーカーがある場合",
 				    "すべてのプレイされた {C:attention}フェイス{} カードが再発動する",
                 }
             },
@@ -2300,7 +2300,7 @@ return {
                     "カードがスコアされた時, 倍率 {C:mult}+#1#{}",
 					"{br:5}ERROR - CONTACT STEAK",
 					"{V:1}#2#{} スーツのカードを",
-					"{X:water,C:white}水タイプ{} ジョーカー1枚につき再発動",
+					"{X:poke_water,C:white}水タイプ{} ジョーカー1枚につき再発動",
 					"{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} 再発動はスコアしたカードに均等に分散する){}",
 					"ハンドがプレイ後にスーツの変わってが順番に行われる",
                     "{C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
@@ -2396,7 +2396,7 @@ return {
 			j_poke_murkrow = {
               name = "ヤミカラス",
               text = {
-				"{X:dark,C:white}悪{} タイプのジョーカーにつき",
+				"{X:poke_dark,C:white}悪{} タイプのジョーカーにつき",
                 "倍率 {X:red,C:white} X#1# {}",
                 "{C:inactive}(現在 倍率 {X:red,C:white} X#2#{C:inactive} )",
                 "{C:inactive,s:0.8}({C:attention,s:0.8}闇の石{C:inactive,s:0.8} で進化)"
@@ -2562,7 +2562,7 @@ return {
 					"{C:attention}ブースターパック{}が",
                     "スキップされた時、",
                     "倍率{C:red}+#2#{}",
-					"{C:item}アイテム{} を作る",
+					"{C:poke_item}アイテム{} を作る",
 					"{C:inactive,s:0.8}(空きが必要)",
 					"{C:inactive}(現在 倍率 {C:mult}+#1#{C:inactive})",
 					"{C:inactive,s:0.8}({C:attention,s:0.8}月の石{C:inactive,s:0.8} で進化)",
@@ -2608,7 +2608,7 @@ return {
                 "{br:2}ERROR - CONTACT STEAK",
 				"スコアされたハンドが",
 				"{C:attention}5枚の強化されているカード{} 場合",
-				"{C:attention}たね{} の {X:water,C:white}水{} タイプのジョーカーを作る",
+				"{C:attention}たね{} の {X:poke_water,C:white}水{} タイプのジョーカーを作る",
                 "{C:inactive,s:0.8}(空きが必要)",
                 "{C:inactive}(現在 倍率 {C:mult}+#2#{C:inactive})",
               }
@@ -2688,10 +2688,10 @@ return {
             j_poke_porygon2 = {
                 name = 'ポリゴン2',
                 text = {
-                    "{C:pink}+2{} エネルギーMAXレベル",
+                    "{C:poke_pink}+2{} エネルギーMAXレベル",
 					"{C:attention}ブースターパック{} を開封するたびに",
-					"一番左ジョーカーと同じ {C:pink}タイプ{} の",
-					"{C:pink}エネルギーカード{} を作る",
+					"一番左ジョーカーと同じ {C:poke_pink}タイプ{} の",
+					"{C:poke_pink}エネルギーカード{} を作る",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}怪しいパッチ{}{C:inactive,s:0.8} で進化する)"
                 } 
             },
@@ -2792,7 +2792,7 @@ return {
                 name = "Miltank",
                 text = {
 					"ラウンド終了時に",
-					"{C:colorless}無色{} タイプのジョーカー1枚につき",
+					"{C:poke_colorless}無色{} タイプのジョーカー1枚につき",
                     "{C:money}$#1#{} を得る", 
                     "{C:inactive}(現在 {C:money}$#2#{C:inactive}){}"
                 }
@@ -2820,7 +2820,7 @@ return {
                     "ハンドサイズ {C:attention}+#3#{}, {C:attention}性格{}",
                     "プレイされた {C:attention}#6#, #7#, #8#{} カードがスコアされた時",
                     "{C:green}#5#分の#4#{} の確率で {C:money}$#1#{} を与える",
-					"他の {X:grass,C:white}草{} カードを有する場合",
+					"他の {X:poke_grass,C:white}草{} カードを有する場合",
 					"確率保証",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive,s:0.8}({C:money}$#2# {C:inactive,s:0.8}を与えた後に進化)"
@@ -2832,7 +2832,7 @@ return {
                     "ハンドサイズ {C:attention}+#3#{}, {C:attention}性格{}",
                     "プレイされた {C:attention}#6#, #7#, #8#{} カードがスコアされた時",
                     "{C:green}#5#分の#4#{} の確率で {C:money}$#1#{} を与える",
-					"他の {X:grass,C:white}草{} カードを有する場合",
+					"他の {X:poke_grass,C:white}草{} カードを有する場合",
 					"確率保証",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive,s:0.8}({C:money}$#2# {C:inactive,s:0.8}を与えた後に進化)"
@@ -2846,7 +2846,7 @@ return {
                     "{C:money}$#1#{} を与える",
                     "{br:5}ERROR - CONTACT STEAK",
 					"ラウンド終了時に",
-					"{X:grass,C:white}草{} カード1枚につき {C:money}$#1#{} を得る",
+					"{X:poke_grass,C:white}草{} カード1枚につき {C:money}$#1#{} を得る",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive}(現在 {C:money}$#4#{}, 最高 {C:money}$14{}{C:inactive}){}"
                 } 
@@ -2857,7 +2857,7 @@ return {
                     "ディスカード {C:mult}+#3#{}, {C:attention}性格{}",
 					"このラウンドで {C:attention}#5#, #6#, #7#{} カードが",
 					"ディスカードされるたびに倍率 {C:mult}+#1#{} を得る",
-					"他の {X:fire,C:white}炎{} か {X:earth,C:white}闘{} カードを有する場合",
+					"他の {X:poke_fire,C:white}炎{} か {X:poke_earth,C:white}闘{} カードを有する場合",
 					"倍率は2倍になる",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive}(現在 倍率 {C:mult}#4#{}{C:inactive}){}",
@@ -2870,7 +2870,7 @@ return {
                     "ディスカード {C:mult}+#3#{}, {C:attention}性格{}",
 					"このラウンドで {C:attention}#5#, #6#, #7#{} カードが",
 					"ディスカードされるたびに倍率 {C:mult}+#1#{} を得る",
-					"他の {X:fire,C:white}炎{} か {X:earth,C:white}闘{} カードを有する場合",
+					"他の {X:poke_fire,C:white}炎{} か {X:poke_earth,C:white}闘{} カードを有する場合",
 					"倍率は2倍になる",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive}(現在 倍率 {C:mult}#4#{}{C:inactive}){}",
@@ -2882,7 +2882,7 @@ return {
                 text = {
                     "ディスカード {C:mult}+#3#{}, {C:attention}性格{}",
 					"このラウンドで {C:attention}#6#, #7#, #8#{} カードが",
-					"ディスカードされるたびに, 他の {X:fire,C:white}炎{} か {X:earth,C:white}闘{} カード1枚につき",
+					"ディスカードされるたびに, 他の {X:poke_fire,C:white}炎{} か {X:poke_earth,C:white}闘{} カード1枚につき",
 					"倍率 {C:mult}+#4#{}, {X:red,C:white} X#1# {} を得る",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive}(現在 倍率 {C:mult}+#5#{C:inactive}, {X:red,C:white} X#3# {}{C:inactive}){}",
@@ -2894,7 +2894,7 @@ return {
                     "ハンド {C:chips}+#3#{}, {C:attention}性格{}",
                     "プレイされた {C:attention}#4#, #5#, #6#{} カードがスコアされた時",
                     "チップ {C:chips}+#1#{} を与える",
-					"他の {X:water,C:white}水{} か {X:earth,C:white}地面{} カードを有する場合",
+					"他の {X:poke_water,C:white}水{} か {X:poke_earth,C:white}地面{} カードを有する場合",
 					"チップは2倍になる",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive,s:0.8}(チップ {C:chips,s:0.8}#2#{C:inactive,s:0.8} スコアした後に進化)"
@@ -2906,7 +2906,7 @@ return {
                     "ハンド {C:chips}+#3#{}, {C:attention}性格{}",
                     "プレイされた {C:attention}#4#, #5#, #6#{} カードがスコアされた時",
                     "チップ {C:chips}+#1#{} を与える",
-					"他の {X:water,C:white}水{} か {X:earth,C:white}地面{} カードを有する場合",
+					"他の {X:poke_water,C:white}水{} か {X:poke_earth,C:white}地面{} カードを有する場合",
 					"チップは2倍になる",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive,s:0.8}(チップ {C:chips,s:0.8}#2#{C:inactive,s:0.8} スコアした後に進化)"
@@ -2918,7 +2918,7 @@ return {
                     "ハンド {C:chips}+#3#{}, {C:attention}性格{}",
                     "プレイされた {C:attention}#6#, #7#, #8#{} カードがスコアされた時",
                     "チップ {C:chips}+#1#{} を与える",
-					"{X:water,C:white}水{} か {X:earth,C:white}地面{} カード1枚につき",
+					"{X:poke_water,C:white}水{} か {X:poke_earth,C:white}地面{} カード1枚につき",
 					"チップさらに {C:chips}+#5#{} を与える",
                     "{C:inactive,s:0.8}(ジョーカかエネルギー){}",
                     "{C:inactive}(現在 チップ {C:chips}+#4#{}{C:inactive})"
@@ -2927,10 +2927,10 @@ return {
 			j_poke_zigzagoon = {
                 name = "ジグザグマ",
                 text = {
-					"{C:attention}物拾い{} {C:item}アイテム{C:attention} を持っている",
+					"{C:attention}物拾い{} {C:poke_item}アイテム{C:attention} を持っている",
 					"ハンドがプレイされた時",
 					"{C:green}#2#分の#1#{} の確率で",
-					"{C:item}アイテム{} を作る",
+					"{C:poke_item}アイテム{} を作る",
 					"{C:inactive}(空きが必要)",
 					"{C:inactive,s:0.8}({C:attention,s:0.8}#3#{C:inactive,s:0.8} ラウンド後に進化)",
                 }
@@ -2940,7 +2940,7 @@ return {
                 text = {
 					"ハンドがプレイされた時",
 					"{C:green}#2#分の#1#{} の確率で",
-					"{C:item}アイテム{} を作る",
+					"{C:poke_item}アイテム{} を作る",
 					"ハンドが {C:attention}ストレート{} を含む場合",
 					"確率保証",
 					"{C:inactive}(空きが必要)",
@@ -3116,7 +3116,7 @@ return {
             j_poke_jirachi_copy = {
                 name = 'ジラーチ',
                 text = {
-					"右のジョーカーが {C:pink}エナジャイズ{} されたかのように",
+					"右のジョーカーが {C:poke_pink}エナジャイズ{} されたかのように",
 					"その能力をコピーする",
                 }
             },
@@ -3173,7 +3173,7 @@ return {
             j_poke_honchkrow = {
                 name = "ドンカラス",
                 text = {
-					"各 {X:dark,C:white}悪{} タイプのジョーカーが 倍率 {X:red,C:white}X#1#{}",
+					"各 {X:poke_dark,C:white}悪{} タイプのジョーカーが 倍率 {X:red,C:white}X#1#{}",
                 }
             },
 			j_poke_bonsly = {
@@ -3213,8 +3213,8 @@ return {
                 text = {
                     "{C:attention}ベイビィ{}",
 					"ラウンド終了時に",
-					"ランダムな {C:dark_edition}ネガティブ{} {C:item}アイテム{}カードを1枚作る",
-					"{C:item}アイテム{} カードを1枚作る",
+					"ランダムな {C:dark_edition}ネガティブ{} {C:poke_item}アイテム{}カードを1枚作る",
+					"{C:poke_item}アイテム{} カードを1枚作る",
                     "倍率 {X:red,C:white} X#1# {}",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#2#{}{C:inactive,s:0.8} ラウンド後に進化)"
                 }
@@ -3249,7 +3249,7 @@ return {
                 text = {
                     "プレイされた {C:attention}スチール{} カードが",
                     "倍率 {X:red,C:white}X#1#{} を与える",
-					"{X:metal,C:white}鋼{} タイプジョーカーにつき",
+					"{X:poke_metal,C:white}鋼{} タイプジョーカーにつき",
                     "倍率の値が {X:red,C:white}X#2#{} で増える",
                     "{C:inactive}(現在 倍率 {X:red,C:white}X#3#{C:inactive} )"
                 } 
@@ -3272,7 +3272,7 @@ return {
                     "スコアされた時、永久的に",
                     "チップ {C:chips}+#1#{} を得る",
                     "{br:3}ERROR - CONTACT STEAK",
-					"{C:attention}ストーン{} カードを {X:earth,C:white}地面{} タイプジョーカー",
+					"{C:attention}ストーン{} カードを {X:poke_earth,C:white}地面{} タイプジョーカー",
 					"1枚につき再発動する",
                     "{C:inactive}(現在 #2# 再発動)"
                 } 
@@ -3375,8 +3375,8 @@ return {
             j_poke_porygonz = {
                 name = 'ポリゴンZ',
                 text = {
-                    "{C:pink}+3{} エネルギーMAXレベル",
-					"使用された {C:pink}エネルギー{} カード1枚につき",
+                    "{C:poke_pink}+3{} エネルギーMAXレベル",
+					"使用された {C:poke_pink}エネルギー{} カード1枚につき",
                     "倍率 {X:red,C:white} X#2# {} を得る",
                     "{C:inactive}(倍率 {X:red,C:white} X#1# {}{C:inactive})"
                 } 
@@ -3397,7 +3397,7 @@ return {
                   "{C:red}-$#1#{} まで増える",
                   "{br:2.5}ERROR - CONTACT STEAK",
 				  "負債を抱えている中でハンドがプレイされた場合",
-				  "{C:item}アイテム{} カードを作る",
+				  "{C:poke_item}アイテム{} カードを作る",
                   "{C:inactive,s:0.8}(空きが必要)",
                 }
             },
@@ -3671,7 +3671,7 @@ return {
                     "チップ {C:chips}+#1#{}",
                     "{br:2}ERROR - CONTACT STEAK",
 					"{C:attention}キング{} か {C:attention}クイーン{} も含む場合",
-                    "{C:pink}エネルギー{} カードを作る",
+                    "{C:poke_pink}エネルギー{} カードを作る",
                 } 
             },
             j_poke_sylveon = {
@@ -3689,7 +3689,7 @@ return {
                 name = 'アゴジムシ',
                 text = {
                     "倍率 {C:mult}+#1#{}",
-					"{X:lightning, C:black}雷{} タイプジョーカーを有する場合",
+					"{X:poke_lightning, C:black}雷{} タイプジョーカーを有する場合",
 					"倍率が3倍",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#2#{}{C:inactive,s:0.8} ラウンド後に進化)"
                 }  
@@ -3697,7 +3697,7 @@ return {
             j_poke_charjabug = {
                 name = 'デンヂムシ',
                 text = {
-					"それぞれの {X:lightning, C:black}雷{} タイプジョーカーが",
+					"それぞれの {X:poke_lightning, C:black}雷{} タイプジョーカーが",
                     "倍率 {C:mult}#1#{} を与える",
                     "{C:inactive}(現在 {C:mult}#2#{C:inactive})",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}雷の石{}{C:inactive,s:0.8} で進化)"
@@ -3708,7 +3708,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
 					"他のすべての",
-					"{X:lightning, C:black}雷{} タイプジョーカーが",
+					"{X:poke_lightning, C:black}雷{} タイプジョーカーが",
                     "倍率 {X:red,C:white} X#1# {}",
                      "{C:inactive}(現在 倍率 {X:red,C:white} X#2# {}{C:inactive})",
                 }  
@@ -3803,7 +3803,7 @@ return {
 					"{C:attention}ブースターパック{}が",
                     "スキップされた時、",
                     "倍率{C:red}+#2#{}",
-					"{C:dark_edition}ポリクローム {C:item}アイテム{} を作る",
+					"{C:dark_edition}ポリクローム {C:poke_item}アイテム{} を作る",
 					"{C:inactive,s:0.8}(空きが必要)",
 					"{C:inactive}(現在 倍率 {C:mult}+#1#{C:inactive})",
               }
@@ -3836,7 +3836,7 @@ return {
 					"発動した後に {C:attention}ランク{} が増やす",
                     "{C:inactive,s:0.8}(最高ランク場合, 最低になる)",
                     "{C:inactive}(現在 チップ {C:chips}+#1#{C:inactive})",
-                    "{C:inactive,s:0.8}({X:fire,C:white,s:0.8}炎{C:inactive,s:0.8} タイプのジョーカーがある進化)",
+                    "{C:inactive,s:0.8}({X:poke_fire,C:white,s:0.8}炎{C:inactive,s:0.8} タイプのジョーカーがある進化)",
                 }
             },
             j_poke_dachsbun = {
@@ -3846,7 +3846,7 @@ return {
 					"チップ {C:chips}+#2#{} を得る",
 					"発動した後に {C:attention}ランク{} が増やす",
                     "{br:4}ERROR - CONTACT STEAK",
-					"{X:fire,C:white}炎{} タイプのジョーカーにつき",
+					"{X:poke_fire,C:white}炎{} タイプのジョーカーにつき",
 					"チップの増加を {C:chips}+2{} に増える",
                     "{C:inactive,s:0.8}(最高ランク場合, 最低になる)",
                     "{C:inactive}(現在 チップ {C:chips}+#1#{C:inactive})",
@@ -3985,7 +3985,7 @@ return {
             j_poke_pokedex = {
                 name = 'ポケモン図鑑',
                 text = {
-					"{C:pink}タイプステッカー{} 付きジョーカー1枚につき",
+					"{C:poke_pink}タイプステッカー{} 付きジョーカー1枚につき",
 					"倍率 {C:mult}+#2#{}",
 					"{br:3}ERROR - CONTACT STEAK",
 					"同じ進化の系譜の {C:attention}ポケモンジョーカー{} が",
@@ -4017,7 +4017,7 @@ return {
                 name = "おにぎり",
                 text = {
                     "ブラインドが選択された時",
-                    "{C:colorless}無色{C:pink}エネルギー{} 作る",
+                    "{C:poke_colorless}無色{C:poke_pink}エネルギー{} 作る",
                     "{C:inactive}(残り{C:attention}#1#{}{C:inactive}ラウンド){}"
                 },
             },
@@ -4025,8 +4025,8 @@ return {
                 name = "宝食堂",
                 text = {
 					"ブラインドが選択された時",
-					"最左のジョーカーの {C:pink}タイプ{} を",
-					"最右のジョーカーの {C:pink}タイプ{} に",
+					"最左のジョーカーの {C:poke_pink}タイプ{} を",
+					"最右のジョーカーの {C:poke_pink}タイプ{} に",
 					"変換する",
                     "{C:attention}タイプチェンジャー{}",
                     "{C:inactive}(残り{C:attention}#1#{C:inactive}ラウンド){}"
@@ -4062,14 +4062,14 @@ return {
 					"{C:attention}#1#{} ラウンド後に",
 					"{C:attention}たね{} か {C:attention}べいビィー{} ポケモンが",
 					"孵ります",
-					"可能であれば {C:pink}エナジャイズ{} する",
+					"可能であれば {C:poke_pink}エナジャイズ{} する",
                 }
             },
 			j_poke_billion_lions = {
                 name = '10億頭のライオン',
                 text = {
 					"ブラインドが選択された時",
-					"{C:pink}タイプステッカー{} 付きジョーカーを破壊する",
+					"{C:poke_pink}タイプステッカー{} 付きジョーカーを破壊する",
 					"破壊したジョーカーにつき",
 					"倍率 {X:mult,C:white}X#2#{} を得る",
                     "ライオンがない場合 {S:1.1,C:red,E:2}自らを破壊する{}",
@@ -4099,14 +4099,14 @@ return {
                 name = "ステラスリーブ",
                 text = {
                     "すべてのジョーカーは",
-                    "ランダムな {C:pink}タイプ{} のステッカー作成され",
+                    "ランダムな {C:poke_pink}タイプ{} のステッカー作成され",
                 },
             },
 			sleeve_poke_telekineticsleeve = {
                 name = "テレキネシススリーブ",
                 text = {
                     "{C:tarot,T:v_crystal_ball}#1#{} のバウチャーと",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{} の",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{} の",
                     "{C:attention}2{} つのコピーで",
                     "ランをスタートする",
                 } 
@@ -4134,7 +4134,7 @@ return {
                 text = {
 					"選択したか一番左のポケモンを",
 					"{C:attention}最終進化{}させ、可能であれば",
-                    "{C:pink}エナジャイズ{} する",
+                    "{C:poke_pink}エナジャイズ{} する",
                 },
             },
 			c_poke_megastone = {
@@ -4152,14 +4152,14 @@ return {
                 text = {
                     "手札から選んだ",
                     "カード {C:attention}1{} 枚に",
-                    "{C:pink}ピンク{} シールを加える",
+                    "{C:poke_pink}ピンク{} シールを加える",
                 },
             },
             c_poke_nightmare = {
                 name = "悪夢",
                 text = {
-					"選んだ {C:pink}タイプステッカー{} 付きジョーカーを破壊して",
-					"そのジョーカーのタイプの {C:dark_edition}ネガティブ{} {C:pink}エネルギー{} カードを",
+					"選んだ {C:poke_pink}タイプステッカー{} 付きジョーカーを破壊して",
+					"そのジョーカーのタイプの {C:dark_edition}ネガティブ{} {C:poke_pink}エネルギー{} カードを",
 					"{C:attention}2{} 枚作る",
                 },
             },
@@ -4219,7 +4219,7 @@ return {
                 name = "ポケットタグ",
                 text = {
                     "無料の",
-                    "{C:pink}メガポケットパック{}を与える",
+                    "{C:poke_pink}メガポケットパック{}を与える",
 					"{C:attention}アンティ 5+{}場合",
 					"{C:green}25%{} 確率で {C:attention}メガストーン{} を含む",
                 }, 
@@ -4229,7 +4229,7 @@ return {
                 text = {
                     "次のベースショップジョーカーが",
                     "無料になり、以下の",
-                    "エディションになる：{C:colorless}色違い{}",
+                    "エディションになる：{C:poke_colorless}色違い{}",
                 }, 
             },
 			tag_poke_stage_one_tag = {
@@ -4243,7 +4243,7 @@ return {
                 name = "サファリタグ",
                 text = {
                     "ショップに出現：無料の",
-                    "{C:safari}サファリ{} ジョーカー",
+                    "{C:poke_safari}サファリ{} ジョーカー",
                 }, 
             },
         },
@@ -4269,13 +4269,13 @@ return {
             v_poke_energysearch = {
                 name = "エネルギー転送",
                 text = {
-                    "{C:pink}+2{} エネルギーMAXレベル"
+                    "{C:poke_pink}+2{} エネルギーMAXレベル"
                 },
             },
             v_poke_energyresearch = {
                 name = "エネルギー転送PRO",
                 text = {
-                    "{C:pink}+3{} エネルギーMAXレベル"
+                    "{C:poke_pink}+3{} エネルギーMAXレベル"
                 },
             },
             v_poke_goodrod = {
@@ -4289,7 +4289,7 @@ return {
                 name = "すごいつりざお",
                 text = {
 					"すべての {C:attention}消耗{} パックから",
-					"カードを {C:pink}蓄えられる{}",
+					"カードを {C:poke_pink}蓄えられる{}",
                 },
             },
         },
@@ -4298,79 +4298,79 @@ return {
             Grass = {
                 name = "タイプ",
                 text = {
-                  "{X:grass,C:white}草{}",
+                  "{X:poke_grass,C:white}草{}",
                 }
             },
             Fire = {
                 name = "タイプ",
                 text = {
-                  "{X:fire,C:white}炎{}",
+                  "{X:poke_fire,C:white}炎{}",
                 }
             },
             Water = {
                 name = "タイプ",
                 text = {
-                  "{X:water,C:white}水{}",
+                  "{X:poke_water,C:white}水{}",
                 }
             },
             Lightning = {
                 name = "タイプ",
                 text = {
-                  "{X:lightning,C:black}雷{}",
+                  "{X:poke_lightning,C:black}雷{}",
                 }
             },
             Psychic = {
                 name = "タイプ",
                 text = {
-                  "{X:psychic,C:white}超{}",
+                  "{X:poke_psychic,C:white}超{}",
                 }
             },
             Fighting = {
                 name = "タイプ",
                 text = {
-                  "{X:fighting,C:white}闘{}",
+                  "{X:poke_fighting,C:white}闘{}",
                 }
             },
             Colorless = {
                 name = "タイプ",
                 text = {
-                  "{X:colorless,C:white}無色{}",
+                  "{X:poke_colorless,C:white}無色{}",
                 }
             },
             Dark = {
                 name = "タイプ",
                 text = {
-                  "{X:dark,C:white}悪{}",
+                  "{X:poke_dark,C:white}悪{}",
                 }
             },
             Metal = {
                 name = "タイプ",
                 text = {
-                  "{X:metal,C:white}鋼{}",
+                  "{X:poke_metal,C:white}鋼{}",
                 }
             },
             Fairy = {
                 name = "タイプ",
                 text = {
-                  "{X:fairy,C:white}フェアリー{}",
+                  "{X:poke_fairy,C:white}フェアリー{}",
                 }
             },
             Dragon = {
                 name = "タイプ",
                 text = {
-                  "{X:dragon,C:white}ドラゴン{}",
+                  "{X:poke_dragon,C:white}ドラゴン{}",
                 }
             },
             Earth = {
                 name = "タイプ",
                 text = {
-                  "{X:earth,C:white}地面{}",
+                  "{X:poke_earth,C:white}地面{}",
                 }
             },
             Bird = {
                 name = "タイプ",
                 text = {
-                  "{X:bird,C:white}バード{}",
+                  "{X:poke_bird,C:white}バード{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -4549,7 +4549,7 @@ return {
                 name = "プレゼント",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}アイテム{} {C:attention}カード",
+                    "{C:green}30%{} - {C:poke_item}アイテム{} {C:attention}カード",
                     "{C:green}20%{} - {C:attention}クーポンタグ",
                     "{C:green}15%{} - {C:dark_edition}ポリクローム{} {C:attention}ギフトカード",
                 }
@@ -4557,7 +4557,7 @@ return {
 			pickup = {
               name = "物拾い",
               text = {
-                "{C:green}34%{} - {C:item}アイテム{} {C:attention}カード",
+                "{C:green}34%{} - {C:poke_item}アイテム{} {C:attention}カード",
                 "{C:green}25%{} - {C:attention}食べ残し",
                 "{C:green}25%{} - {C:attention}モンスターボール",
                 "{C:green}15%{} - {C:attention}スーパーボール",
@@ -4590,14 +4590,14 @@ return {
             eeveelution = {
                 name = "イーブイの進化",
                 text = {
-                    "{C:attention}水の石{} - {X:water,C:white}シャワーズ{}",
-                    "{C:attention}雷の石{} - {X:lightning,C:black}サンダース{}",
-                    "{C:attention}炎の石{} - {X:fire,C:white}ブースター{}",
-                    "{C:attention}太陽の石{} - {X:psychic,C:white}エーフィ{}",
-                    "{C:attention}月の石{} - {X:dark,C:white}ブラッキー{}",
-                    "{C:attention}リーフの石{} - {X:grass,C:white}リーフィア{}",
-                    "{C:attention}氷の石{} - {X:water,C:white}グレイシア{}",
-                    "{C:attention}光の石{} - {X:fairy,C:white}ニンフィア{}"
+                    "{C:attention}水の石{} - {X:poke_water,C:white}シャワーズ{}",
+                    "{C:attention}雷の石{} - {X:poke_lightning,C:black}サンダース{}",
+                    "{C:attention}炎の石{} - {X:poke_fire,C:white}ブースター{}",
+                    "{C:attention}太陽の石{} - {X:poke_psychic,C:white}エーフィ{}",
+                    "{C:attention}月の石{} - {X:poke_dark,C:white}ブラッキー{}",
+                    "{C:attention}リーフの石{} - {X:poke_grass,C:white}リーフィア{}",
+                    "{C:attention}氷の石{} - {X:poke_water,C:white}グレイシア{}",
+                    "{C:attention}光の石{} - {X:poke_fairy,C:white}ニンフィア{}"
                 }
             },
 			poke_egg_tip = {
@@ -4656,7 +4656,7 @@ return {
             precise_energy_tooltip = {
                 name = "精密なエネルギーボーナス数値",
                 text = {
-                    "{s:0.8}{C:pink,s:0.8}エネルギー{}{s:0.8}ボーナス を適用する際にはすべての値に{C:attention,s:0.8}小数{}を使用します{}",
+                    "{s:0.8}{C:poke_pink,s:0.8}エネルギー{}{s:0.8}ボーナス を適用する際にはすべての値に{C:attention,s:0.8}小数{}を使用します{}",
                     "{C:attention,s:0.8}OFF{}{s:0.8}にするとボーナスに対して以下の処理する:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X 倍率{}{s:0.8} - 小数を使用",
                     "{C:attenion}2. {s:0.8}{C:mult,s:0.8}倍率{}{s:0.8} や {C:chips,s:0.8}チップ{}{s:0.8} - 近い整数に切り上げ",
@@ -4728,7 +4728,7 @@ return {
                 name = "ピンクシール",
                 text = {
 					"ラウンドの{C:attention}ファーストハンド{}に",
-					"スコアされた時{C:pink}エネルギー{}カードを作る"
+					"スコアされた時{C:poke_pink}エネルギー{}カードを作る"
                 },
             },
 			poke_silver_seal = {
@@ -4736,79 +4736,79 @@ return {
                 text = {
 					"カードがスコアされた時",
 					"手札にある場合",
-					"{C:item}アイテム{} カードを作って, ディスカードされる",
+					"{C:poke_item}アイテム{} カードを作って, ディスカードされる",
                 }
             },
             --[[grass_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:grass,C:white}草{}"
+                    "{X:poke_grass,C:white}草{}"
                 } 
             },
             fire_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:fire,C:white}炎{}"
+                    "{X:poke_fire,C:white}炎{}"
                 } 
             },
             water_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:water,C:white}水{}"
+                    "{X:poke_water,C:white}水{}"
                 } 
             },
             lightning_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:lightning,C:white}雷{}"
+                    "{X:poke_lightning,C:white}雷{}"
                 } 
             },
             psychic_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:psychic,C:white}超{}"
+                    "{X:poke_psychic,C:white}超{}"
                 } 
             },
             fighting_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:fighting,C:white}闘{}"
+                    "{X:poke_fighting,C:white}闘{}"
                 } 
             },
             colorless_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:colorless,C:white}無色{}"
+                    "{X:poke_colorless,C:white}無色{}"
                 } 
             },
             dark_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:dark,C:white}悪{}"
+                    "{X:poke_dark,C:white}悪{}"
                 } 
             },
             metal_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:metal,C:white}鋼{}"
+                    "{X:poke_metal,C:white}鋼{}"
                 } 
             },
             fairy_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:fairy,C:white}フェアリー{}"
+                    "{X:poke_fairy,C:white}フェアリー{}"
                 } 
             },
             dragon_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:dragon,C:white}ドラゴン{}"
+                    "{X:poke_dragon,C:white}ドラゴン{}"
                 } 
             },
             earth_sticker = {
                 name = "タイプ",
                 text = {
-                    "{X:earth,C:white}地面{}"
+                    "{X:poke_earth,C:white}地面{}"
                 } 
             },
 			--]]
@@ -4836,7 +4836,7 @@ return {
                 name = "ポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4844,7 +4844,7 @@ return {
                 name = "ポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4852,7 +4852,7 @@ return {
                 name = "ジャンボポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4860,7 +4860,7 @@ return {
                 name = "メガPocket Pack",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4868,7 +4868,7 @@ return {
                 name = "ポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4876,7 +4876,7 @@ return {
                 name = "ポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4884,7 +4884,7 @@ return {
                 name = "ジャンボポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },
@@ -4892,7 +4892,7 @@ return {
                 name = "メガポケットパック",
                 text = {
                     "{C:attention}#2#{} 枚までの",
-					"{C:pink}エネルギー{} か {C:item}アイテム{} カードから{}",
+					"{C:poke_pink}エネルギー{} か {C:poke_item}アイテム{} カードから{}",
                     "{C:attention}#1#{} 枚を選んで",
                 },
             },

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -42,7 +42,7 @@ return {
                 name = "염동력 덱",
                 text = {
                     "{C:tarot,T:v_crystal_ball}#1#{} 바우처와",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{} 카드를",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{} 카드를",
                     "{C:attention}2{}장 보유하고 시작합니다",
                 } 
             },
@@ -62,8 +62,8 @@ return {
             b_poke_luminousdeck = {
                 name = "루미너스 덱",
                 text = {
-                    "모든 조커가 {C:pink}에너지화{}된 상태로,",
-                    "무작위 {C:pink}타입{} 스티커가 붙어서",
+                    "모든 조커가 {C:poke_pink}에너지화{}된 상태로,",
+                    "무작위 {C:poke_pink}타입{} 스티커가 붙어서",
                     "생성됩니다"
                 }
             },
@@ -71,7 +71,7 @@ return {
                 name = "증폭 덱",
                 text = {
                     "{C:tarot,T:v_poke_energysearch}#1#{} 바우처와",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#{} 카드를",
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{} 카드를",
                     "보유하고 시작합니다",
                 } 
             },
@@ -110,7 +110,7 @@ return {
 			b_poke_diceydeck = {
                 name = "잔해 덱",
                 text = {
-                    "{C:hazard}+#1#{} 위험 수치 및 한도, {C:attention}+#1#{} 손 크기",
+                    "{C:poke_hazard}+#1#{} 위험 수치 및 한도, {C:attention}+#1#{} 손 크기",
                     "매 라운드 종료 시:",
                     "{C:attention}전체 덱{}에 있는 각 {C:attention}위험{}",
                     "카드 한 장당 {C:money}$#4#{} 획득",
@@ -311,17 +311,17 @@ return {
                 name = "테라오브",
                 text = {
                     "{C:attention}타입 변경:{} {B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.8}({C:pink,s:0.8}타입{C:inactive,s:0.8}은 핸드를 낼 때마다 변경됩니다){}",
+                    "{C:inactive,s:0.8}({C:poke_pink,s:0.8}타입{C:inactive,s:0.8}은 핸드를 낼 때마다 변경됩니다){}",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "가장 왼쪽 또는 선택한 조커가",
-                    "이미 {B:1,V:2}#1#{} {C:pink}타입{}이라면",
-                    "{C:pink}에너지화{}합니다",
+                    "이미 {B:1,V:2}#1#{} {C:poke_pink}타입{}이라면",
+                    "{C:poke_pink}에너지화{}합니다",
                 },
             },
             c_poke_metalcoat = {
                 name = "금속코트",
                 text = {
-                    "{C:attention}타입 변경:{} {X:metal,C:white}강철{}",
+                    "{C:attention}타입 변경:{} {X:poke_metal,C:white}강철{}",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "선택한 카드 {C:attention}1{}장의",
                     "{C:attention}스틸{} 복제본을 생성합니다",
@@ -330,9 +330,9 @@ return {
             c_poke_dragonscale = {
                 name = "용의비늘",
                 text = {
-                    "{C:attention}타입 변경:{} {X:dragon,C:white}드래곤{}",
+                    "{C:attention}타입 변경:{} {X:poke_dragon,C:white}드래곤{}",
                     "{br:2}오류 - STEAK에게 문의바람",
-                    "무작위 {C:item}아이템{} 또는 {C:pink}에너지{} 카드를",
+                    "무작위 {C:poke_item}아이템{} 또는 {C:poke_pink}에너지{} 카드를",
                     "최대 {C:attention}3{}장 생성합니다",
                     "{C:inactive}(공간이 있어야 함){}"
                 },
@@ -389,9 +389,9 @@ return {
                 name = "휘어진스푼",
                 text = {
                     "이번 런에서 마지막으로 사용한",
-                    "{C:item}아이템{} 카드 또는 {C:pink}에너지{} 카드를 생성합니다",
-                    "{s:0.8,C:item}휘어진스푼, 재사용 가능 아이템,",
-                    "{s:0.8,C:item}나무열매 주스는 제외됩니다{s:0.8}"
+                    "{C:poke_item}아이템{} 카드 또는 {C:poke_pink}에너지{} 카드를 생성합니다",
+                    "{s:0.8,C:poke_item}휘어진스푼, 재사용 가능 아이템,",
+                    "{s:0.8,C:poke_item}나무열매 주스는 제외됩니다{s:0.8}"
                 }
             },
             c_poke_prismscale = {
@@ -434,7 +434,7 @@ return {
                     "{C:attention}진화 카드{}",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "선택한 카드 {C:attention}1{}장을 {C:attention}석재{} 카드로 강화하며,",
-                    "보유한 {X:earth,C:white}땅{} 조커 하나당",
+                    "보유한 {X:poke_earth,C:white}땅{} 조커 하나당",
                     "{C:chips}+#2#{} 칩을 추가합니다"
                 }
             },
@@ -465,8 +465,8 @@ return {
             c_poke_berry_juice_energy = {
                 name = "에너지화된 나무열매 주스",
                 text = {
-                    "아무 {C:pink}타입{}의 가장 왼쪽 또는 선택한",
-                    "조커를 {C:pink}에너지화{}합니다",
+                    "아무 {C:poke_pink}타입{}의 가장 왼쪽 또는 선택한",
+                    "조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -488,7 +488,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "아이템 나무열매 주스",
                 text = {
-                    "{C:item}휘어진스푼{} 카드를 생성합니다",
+                    "{C:poke_item}휘어진스푼{} 카드를 생성합니다",
                     "{C:green}#1# / #2#{} 확률로",
                     "대신 {C:attention}2{}장을 생성합니다",
                     "{C:inactive}(공간이 있어야 함){}"
@@ -504,7 +504,7 @@ return {
             c_poke_berry_juice_mystery = {
                 name = "의문의 나무열매 주스",
                 text = {
-                    "무작위 {C:item}나무열매 주스{} 카드를",
+                    "무작위 {C:poke_item}나무열매 주스{} 카드를",
                     "생성합니다"
                 }
             },
@@ -565,7 +565,7 @@ return {
                 name = "풀 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:grass,C:white}풀{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_grass,C:white}풀{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -573,7 +573,7 @@ return {
                 name = "불꽃 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:fire,C:white}불꽃{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_fire,C:white}불꽃{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -581,7 +581,7 @@ return {
                 name = "물 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:water,C:white}물{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_water,C:white}물{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -589,7 +589,7 @@ return {
                 name = "전기 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:lightning,C:black}전기{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_lightning,C:black}전기{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -597,7 +597,7 @@ return {
                 name = "에스퍼 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:psychic,C:white}에스퍼{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_psychic,C:white}에스퍼{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -605,7 +605,7 @@ return {
                 name = "격투 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:fighting,C:white}격투{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_fighting,C:white}격투{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -613,8 +613,8 @@ return {
                 name = "노말 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:colorless,C:white}노말{} 조커를 {C:pink}에너지화{}합니다",
-                    "{X:colorless,C:white}노말{}이 아닌 조커에게는",
+                    "{X:poke_colorless,C:white}노말{} 조커를 {C:poke_pink}에너지화{}합니다",
+                    "{X:poke_colorless,C:white}노말{}이 아닌 조커에게는",
                     "효과가 절반입니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)"
                 },
@@ -623,7 +623,7 @@ return {
                 name = "악 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:dark,C:white}악{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_dark,C:white}악{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -631,7 +631,7 @@ return {
                 name = "강철 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:Metal,C:white}강철{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:Metal,C:white}강철{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -639,7 +639,7 @@ return {
                 name = "페어리 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:fairy,C:white}페어리{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_fairy,C:white}페어리{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -648,7 +648,7 @@ return {
                 name = "드래곤 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:dragon,C:white}드래곤{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_dragon,C:white}드래곤{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -656,7 +656,7 @@ return {
                 name = "땅 에너지",
                 text = {
                     "가능하다면 가장 왼쪽 또는 선택한",
-                    "{X:earth,C:white}땅{} 조커를 {C:pink}에너지화{}합니다",
+                    "{X:poke_earth,C:white}땅{} 조커를 {C:poke_pink}에너지화{}합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
                 },
             },
@@ -1316,7 +1316,7 @@ return {
                 name = "캐이시",
                 text = {
                     "{C:green}#1# / #2#{} 확률로 {C:tarot}타로{}",
-                    "또는 {C:item}아이템{} 카드를 생성합니다.",
+                    "또는 {C:poke_item}아이템{} 카드를 생성합니다.",
                     "단, 플레이한 {C:attention}포커 핸드{}가",
                     "이번 라운드에 이미 플레이된 경우여야 합니다",
                     "{C:inactive,s:0.8}(#3# 라운드 후 진화){}",
@@ -1326,7 +1326,7 @@ return {
                 name = "윤겔라",
                 text = {
                     "{C:green}#1# / #2#{} 확률로 {C:tarot}타로{} 또는",
-                    "{C:item}휘어진스푼{} 카드를 생성합니다.",
+                    "{C:poke_item}휘어진스푼{} 카드를 생성합니다.",
                     "단, 플레이한 {C:attention}포커 핸드{}가",
                     "이번 라운드에 이미 플레이된 경우여야 합니다",
                     "{C:inactive,s:0.8}(연결의끈으로 진화){}"
@@ -1337,7 +1337,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} 소모품 슬롯",
                     "{C:green}#1# / #2#{} 확률로 {C:attention}광대{} 또는",
-                    "{C:item}휘어진스푼{} 카드를 생성합니다.",
+                    "{C:poke_item}휘어진스푼{} 카드를 생성합니다.",
                     "단, 플레이한 {C:attention}포커 핸드{}가",
                     "이번 라운드에 이미 플레이된 경우여야 합니다",
                 } 
@@ -1347,7 +1347,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} 소모품 슬롯",
                     "보유한 {C:attention}소모품{}마다 {X:mult,C:white}X#1#{} 배수",
-                    "{C:item}휘어진스푼{}은 {X:mult,C:white}X#2#{} 배수",
+                    "{C:poke_item}휘어진스푼{}은 {X:mult,C:white}X#2#{} 배수",
                 } 
             },
             j_poke_machop = {
@@ -1512,7 +1512,7 @@ return {
                 name = "레어코일",
                 text = {
                     "플레이한 {C:attention}스틸{} 카드가 {X:mult,C:white}X#1#{} 배수 제공",
-                    "추가로 인접한 {X:metal,C:white}강철{} 조커마다",
+                    "추가로 인접한 {X:poke_metal,C:white}강철{} 조커마다",
                     "{X:mult,C:white}X#2#{} 배수를 제공합니다",
                     "{C:inactive}(현재 {X:mult,C:white}X#3#{C:inactive} 배수)",
                     "{C:inactive,s:0.8}(천둥의돌로 진화){}"
@@ -1521,10 +1521,10 @@ return {
             j_poke_farfetchd = {
                 name = '파오리',      
                 text = {
-                    "{C:item}대파{} 보유 시",
+                    "{C:poke_item}대파{} 보유 시",
                     "{C:attention}소모품{} 사용 시 {C:green}#2# / #3#{} 확률로",
                     "{C:money}$#1#{}를 획득합니다,",
-                    "{C:item}대파{} 사용 시에는 {C:money}${} 획득 보장",
+                    "{C:poke_item}대파{} 사용 시에는 {C:money}${} 획득 보장",
                 } 
             },
             j_poke_doduo = {
@@ -1641,7 +1641,7 @@ return {
                     "라운드의 {C:attention}첫 핸드{}에서",
                     "가장 왼쪽 득점 카드가",
                     "{C:attention}석재{} 카드가 됩니다",
-                    "{C:inactive,s:0.8}({C:metal,s:0.8}강철{C:inactive,s:0.8} 스티커로 진화)"
+                    "{C:inactive,s:0.8}({C:poke_metal,s:0.8}강철{C:inactive,s:0.8} 스티커로 진화)"
                 } 
             },
             j_poke_drowzee = {
@@ -1717,10 +1717,10 @@ return {
             j_poke_cubone = {
                 name = '탕구리',
                 text = {
-                    "{C:item}굵은뼈{} 보유 시",
+                    "{C:poke_item}굵은뼈{} 보유 시",
                     "{C:attention}보유한 소모품{}마다",
                     "{C:mult}+#1#{} 배수를 제공합니다",
-                    "{C:inactive,s:0.8}({C:item,s:0.8}굵은뼈{C:inactive,s:0.8}는 2배로 계산){}",
+                    "{C:inactive,s:0.8}({C:poke_item,s:0.8}굵은뼈{C:inactive,s:0.8}는 2배로 계산){}",
                     "{C:inactive}(현재 {C:mult}+#2#{C:inactive} 배수)",
                     "{C:inactive,s:0.8}(소모품 {C:attention,s:0.8}#3#{C:inactive,s:0.8}개 사용 후 진화)",
                 } 
@@ -1847,7 +1847,7 @@ return {
                     "득점한 {C:attention}6{}마다 {C:mult}+#2#{} 배수 증가",
                     "핸드에 {C:attention}킹{}을 보유하고 있다면 2배로 증가",
                     "{C:inactive}(현재 {C:mult}+#1#{C:inactive} 배수)",
-                    "{C:inactive,s:0.8}({C:dragon,s:0.8}드래곤{C:inactive,s:0.8} 스티커로 진화)"
+                    "{C:inactive,s:0.8}({C:poke_dragon,s:0.8}드래곤{C:inactive,s:0.8} 스티커로 진화)"
                 } 
             },
             j_poke_goldeen = {
@@ -1895,7 +1895,7 @@ return {
                     "파괴된 조커가 {C:rare}레어{} 등급 이상이었다면",
                     "{C:dark_edition}포일{}, {C:dark_edition}홀로그램{}, 또는 {C:dark_edition}폴리크롬{}을 얻습니다",
                     "{C:inactive}(현재 {C:mult}+#1#{C:inactive} 배수)",
-                    "{C:inactive,s:0.8}({C:metal,s:0.8}강철{C:inactive,s:0.8} 스티커 또는 {C:attention,s:0.8}딱딱한돌{C:inactive,s:0.8}로 진화)",
+                    "{C:inactive,s:0.8}({C:poke_metal,s:0.8}강철{C:inactive,s:0.8} 스티커 또는 {C:attention,s:0.8}딱딱한돌{C:inactive,s:0.8}로 진화)",
                 } 
             },
             j_poke_jynx = {
@@ -2001,7 +2001,7 @@ return {
                     "{C:attention}오른쪽 불안정{}",
                     "상점 이용 종료 시,",
                     "가장 왼쪽의 조커로 {C:attention}변신{}하며",
-                    "{C:attention}부패{} 속성과 {X:colorless,C:white}노말{} 스티커를 가집니다",
+                    "{C:attention}부패{} 속성과 {X:poke_colorless,C:white}노말{} 스티커를 가집니다",
                     "{C:inactive,s:0.8}(메타몽 제외){}",
                 } 
             },
@@ -2038,10 +2038,10 @@ return {
             j_poke_porygon = {
                 name = '폴리곤',
                 text = {
-                    "{C:pink}+1{} 에너지 한도",
+                    "{C:poke_pink}+1{} 에너지 한도",
                     "아무 {C:attention}부스터 팩{}을 개봉하면",
-                    "{C:pink}에너지{} 카드를 생성합니다",
-                    "{C:inactive,s:0.8}({C:item,s:0.8}업그레이드{C:inactive,s:0.8}로 진화){}",
+                    "{C:poke_pink}에너지{} 카드를 생성합니다",
+                    "{C:inactive,s:0.8}({C:poke_item,s:0.8}업그레이드{C:inactive,s:0.8}로 진화){}",
                 } 
             },
             j_poke_omanyte = {
@@ -2050,7 +2050,7 @@ return {
                     "{C:attention}고대 #1#{}",
                     "{X:attention,C:white}1+{} : {C:tarot}타로{} 카드 생성",
                     "{X:attention,C:white}2+{} : {C:money}$#2#{} 획득",
-                    "{X:attention,C:white}3+{} : {C:item}아이템{} 카드 생성 {C:inactive,s:0.7}({C:attention,s:0.7}#3#{C:inactive,s:0.7}회 발동 시 진화)",
+                    "{X:attention,C:white}3+{} : {C:poke_item}아이템{} 카드 생성 {C:inactive,s:0.7}({C:attention,s:0.7}#3#{C:inactive,s:0.7}회 발동 시 진화)",
                     "{C:inactive,s:0.8}(공간이 있어야 함)",
                 } 
             },
@@ -2060,7 +2060,7 @@ return {
                     "{C:attention}고대 #1#{}",
                     "{X:attention,C:white}1+{} : {C:tarot}타로{} 카드 생성",
                     "{X:attention,C:white}2+{} : {C:money}$#2#{} 획득",
-                    "{X:attention,C:white}3+{} : {C:item}아이템{} 카드 생성",
+                    "{X:attention,C:white}3+{} : {C:poke_item}아이템{} 카드 생성",
                     "{C:inactive,s:0.8}(공간이 있어야 함)",
                     "{X:attention,C:white}4+{} : 라운드당 1회 {C:attention}태그{} 생성{C:inactive}#3#{}",
                 } 
@@ -2110,8 +2110,8 @@ return {
             j_poke_snorlax = {
                 name = '잠만보',
                 text = {
-                    "{C:item}먹다남은음식{} 보유 시",
-                    "라운드 종료 시 보유한 {C:item}먹다남은음식{}마다",
+                    "{C:poke_item}먹다남은음식{} 보유 시",
+                    "라운드 종료 시 보유한 {C:poke_item}먹다남은음식{}마다",
                     "{X:mult,C:white}X#1#{} 배수를 얻습니다",
                     "{C:inactive}(현재 {X:mult,C:white} X#2# {C:inactive} 배수)"
                 } 
@@ -2170,7 +2170,7 @@ return {
                 text = {
                     "{C:attention}보스 블라인드{} 격파 시,",
                     "가장 왼쪽 {C:attention}조커{}의 {C:dark_edition}폴리크롬{} {C:attention}복제본{}을 생성하고",
-                    "그 {C:attention}복제본{}을 {C:pink}에너지화{}한 뒤,",
+                    "그 {C:attention}복제본{}을 {C:poke_pink}에너지화{}한 뒤,",
                     "가장 왼쪽 {C:attention}조커{}를 파괴합니다",
                     "{br:3}오류 - STEAK에게 문의바람",
                     "{C:dark_edition}폴리크롬{} 조커는 {X:mult,C:white} X#1# {} 배수를 제공합니다",
@@ -2187,11 +2187,11 @@ return {
                 name = "메가뮤츠Y",
                 text = {
                     "상점 이용 종료 시",
-                    "가장 왼쪽 {C:attention}조커{}를 {C:attention}2회{} {C:pink}에너지화{}합니다",
+                    "가장 왼쪽 {C:attention}조커{}를 {C:attention}2회{} {C:poke_pink}에너지화{}합니다",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "{C:attention}보스 블라인드{} 격파 시",
-                    "{C:pink}+1{} 에너지 한도",
-                    "{C:inactive}(자신을 {C:pink}에너지화{C:inactive}할 수 없음)",
+                    "{C:poke_pink}+1{} 에너지 한도",
+                    "{C:inactive}(자신을 {C:poke_pink}에너지화{C:inactive}할 수 없음)",
                 } 
             },
             j_poke_mew = {
@@ -2199,7 +2199,7 @@ return {
                 text = {
                     "{C:attention}상점{} 이용 종료 시,",
                     "{C:dark_edition}네거티브{} {C:tarot}타로{},",
-                    "{C:spectral}유령{} 또는 {C:item}아이템{} 카드를 생성합니다",
+                    "{C:spectral}유령{} 또는 {C:poke_item}아이템{} 카드를 생성합니다",
                     "{br:3}오류 - STEAK에게 문의바람",
                     "{C:green}#1#%{} 확률로 대신",
                     "{C:dark_edition}네거티브{} 조커를 생성합니다",
@@ -2384,8 +2384,8 @@ return {
                   "플레이한 핸드에 {C:attention}페어{}가 포함되면",
                   "{C:chips}+#1#{} 칩을 제공하고 {C:money}$#2#{}를 획득합니다",
                   "{br:3}오류 - STEAK에게 문의바람",
-                  "{X:water,C:white}물{} 조커당 추가 {C:chips}+#3#{} 칩",
-                  "{X:lightning,C:black}전기{} 조커당 추가 {C:money}$#4#{}",
+                  "{X:poke_water,C:white}물{} 조커당 추가 {C:chips}+#3#{} 칩",
+                  "{X:poke_lightning,C:black}전기{} 조커당 추가 {C:money}$#4#{}",
                   "{C:inactive}(현재 {C:chips}+#6#{C:inactive} 칩 및 {C:money}$#5#{C:inactive})"
                 }
             },
@@ -2508,9 +2508,9 @@ return {
             j_poke_weird_tree = {
                 name = "이상한 나무",
                 text = {
-                  "{C:attention}타입 변경: {X:grass,C:white}풀{}",
-                  "이 조커가 {X:grass,C:white}풀{} 타입이 아니거나",
-                  "{X:water,C:white}물{} 타입을 보유하고 있다면",
+                  "{C:attention}타입 변경: {X:poke_grass,C:white}풀{}",
+                  "이 조커가 {X:poke_grass,C:white}풀{} 타입이 아니거나",
+                  "{X:poke_water,C:white}물{} 타입을 보유하고 있다면",
                   "라운드 종료 시 {C:}변신{}합니다"
                 }
             },
@@ -2529,7 +2529,7 @@ return {
                 text = {
                     "플레이한 {V:1}#2#{} 카드가 득점 시 {C:mult}+#1#{} 배수",
                     "{br:5}오류 - STEAK에게 문의바람",
-                    "보유한 {X:water,C:white}물{} 조커 수에 따라",
+                    "보유한 {X:poke_water,C:white}물{} 조커 수에 따라",
                     "{V:1}#2#{} 카드를 재트리거합니다",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{C:inactive,s:0.8}회 재트리거를 득점 카드에 균등 분배){}",
                     "{s:0.8}득점 후 수트가 순환됩니다 {C:inactive,s:0.8}(#3#, #4#, #5#, #6#)",
@@ -2639,7 +2639,7 @@ return {
             j_poke_murkrow = {
               name = "니로우",
               text = {
-                "보유한 {X:dark,C:white}악{} 조커마다 {X:mult,C:white} X#1# {} 배수",
+                "보유한 {X:poke_dark,C:white}악{} 조커마다 {X:mult,C:white} X#1# {} 배수",
                 "{C:inactive}(현재 {X:mult,C:white} X#2#{C:inactive} 배수)",
                 "{C:inactive,s:0.8}(어둠의돌로 진화){}"
               }
@@ -2801,8 +2801,8 @@ return {
                 text = {
                   "블라인드 선택 시, 가장 왼쪽의",
                   "{C:attention}소모품{}을 파괴하고",
-                  "{C:item}나무열매 주스{} 카드를 생성합니다",
-                  "{C:inactive}({C:item}나무열매 주스{C:inactive}는 파괴할 수 없음)"
+                  "{C:poke_item}나무열매 주스{} 카드를 생성합니다",
+                  "{C:inactive}({C:poke_item}나무열매 주스{C:inactive}는 파괴할 수 없음)"
                 }
             },
             j_poke_sneasel = {
@@ -2828,7 +2828,7 @@ return {
               name = "링곰",
               text = {
                 "아무 {C:attention}부스터 팩{}을 스킵할 때마다",
-                "{C:mult}+#2#{} 배수를 얻고 {C:item}아이템{}을 생성합니다",
+                "{C:mult}+#2#{} 배수를 얻고 {C:poke_item}아이템{}을 생성합니다",
                 "{C:inactive,s:0.8}(공간이 있어야 함)",
                 "{C:inactive}(현재 {C:mult}+#1#{C:inactive} 배수)",
                 "{C:inactive,s:0.8}(달의돌로 진화){}",
@@ -2900,7 +2900,7 @@ return {
                 "{C:mult}+#1#{} 배수",
                 "{br:2}오류 - STEAK에게 문의바람",
                 "포커 핸드에 {C:attention}5장의 강화된{} 카드가 포함되면",
-                "{C:attention}기본{} {X:water,C:white}물{} 조커를 생성합니다",
+                "{C:attention}기본{} {X:poke_water,C:white}물{} 조커를 생성합니다",
                 "{C:inactive,s:0.8}(공간이 있어야 함)",
                 "{C:inactive}(현재 {C:mult}+#2#{C:inactive} 배수)",
               }
@@ -2976,10 +2976,10 @@ return {
             j_poke_porygon2 = {
                 name = '폴리곤2',
                 text = {
-                    "{C:pink}+2{} 에너지 한도",
+                    "{C:poke_pink}+2{} 에너지 한도",
                     "아무 {C:attention}부스터 팩{}을 개봉하면",
-                    "가장 왼쪽 조커와 같은 {C:pink}타입{}의",
-                    "{C:pink}에너지{} 카드를 생성합니다",
+                    "가장 왼쪽 조커와 같은 {C:poke_pink}타입{}의",
+                    "{C:poke_pink}에너지{} 카드를 생성합니다",
                     "{C:inactive,s:0.8}(괴상한패치로 진화){}",
                 } 
             },
@@ -3080,7 +3080,7 @@ return {
                 name = "밀탱크",
                 text = {
                   "라운드 종료 시 보유한", 
-                  "{X:colorless,C:white}노말{} 조커마다 {C:money}$#1#{} 획득",
+                  "{X:poke_colorless,C:white}노말{} 조커마다 {C:money}$#1#{} 획득",
                   "{C:inactive}(현재 {C:money}$#2#{C:inactive}){}"
                 }
             },
@@ -3203,7 +3203,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} 핸드 크기, {C:attention}네이처: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "플레이한 {C:attention}네이처{} 카드가 득점 시 {C:money}$#1#{}를 획득하며,",
-                    "다른 {X:grass,C:white}풀{} 조커 하나당",
+                    "다른 {X:poke_grass,C:white}풀{} 조커 하나당",
                     "{C:money}$#5#{}를 추가로 획득합니다",
                     "{C:inactive}(현재 총 {C:money}$#4#{C:inactive} 획득){}"
                 } 
@@ -3234,7 +3234,7 @@ return {
                     "{C:mult}+#1#{} 배수를 제공합니다",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "이번 라운드에 {C:attention}네이처{} 카드를 {C:attention}#4# {C:inactive}[#5#]장",
-                    "버렸다면, 각 {X:fire,C:white}불꽃{} 또는 {X:fighting,C:white}격투{} 조커가",
+                    "버렸다면, 각 {X:poke_fire,C:white}불꽃{} 또는 {X:poke_fighting,C:white}격투{} 조커가",
                     "{X:mult,C:white} X#2# {} 배수를 제공합니다"
                 } 
             },
@@ -3264,7 +3264,7 @@ return {
                     "{C:chips}+#1#{} 칩을 제공합니다",
                     "{br:2}오류 - STEAK에게 문의바람",
                     "포커 핸드에 {C:attention}#3#장의 네이처{} 카드가 포함되어 있다면",
-                    "보유한 {X:water,C:white}물{} 또는 {X:earth,C:white}땅{} 조커 {C:attention}2{}개당",
+                    "보유한 {X:poke_water,C:white}물{} 또는 {X:poke_earth,C:white}땅{} 조커 {C:attention}2{}개당",
                     "{C:tarot}타로{} 카드를 1장 생성합니다 {C:inactive}(공간이 있어야 함){}"
                 } 
             },
@@ -3283,7 +3283,7 @@ return {
                 "{C:attention}플레잉 카드{}가 파괴될 때마다",
                 "{C:mult}+#2#{} 배수를 얻습니다",
                 "{br:2}오류 - STEAK에게 문의바람",
-                "보유한 {X:dark,C:white}악{} 조커마다",
+                "보유한 {X:poke_dark,C:white}악{} 조커마다",
                 "획득량이 {C:mult}+#3#{} 배수 증가합니다",
                 "{C:inactive}(현재 {C:mult}+#1#{C:inactive} 배수)",
               }
@@ -3292,7 +3292,7 @@ return {
               name = "지그제구리",
               text = {
                 "핸드를 플레이할 때 {C:green}#1# / #2#{} 확률로",
-                "{C:attention}줍기{} {C:item}아이템{}을 생성합니다",
+                "{C:attention}줍기{} {C:poke_item}아이템{}을 생성합니다",
                 "{C:inactive}(공간이 있어야 함)",
                 "{C:inactive,s:0.8}(#3# 라운드 후 진화){}",
               }
@@ -3301,7 +3301,7 @@ return {
               name = "직구리",
               text = {
                 "핸드를 플레이할 때 {C:green}#1# / #2#{} 확률로",
-                "{C:attention}줍기{} {C:item}아이템{}을 생성합니다",
+                "{C:attention}줍기{} {C:poke_item}아이템{}을 생성합니다",
                 "핸드에 {C:attention}스트레이트{}가 포함되어 있다면",
                 "확정적으로 생성합니다",
                 "{C:inactive}(공간이 있어야 함)"
@@ -3453,7 +3453,7 @@ return {
             j_poke_cacnea = {
             name = "선인왕",
             text = {
-                "{C:hazard}+#1#{} 위험 레이어",
+                "{C:poke_hazard}+#1#{} 위험 레이어",
                 "카드가 파괴될 때마다",
                 "{C:money}$#2#{} 획득",
                 "{C:inactive}({C:attention}#3#{C:inactive} 라운드 후 진화)",
@@ -3462,7 +3462,7 @@ return {
             j_poke_cacturne = {
             name = "밤선인",
             text = {
-                "{C:hazard}+#1#{} 위험 레이어",
+                "{C:poke_hazard}+#1#{} 위험 레이어",
                 "카드가 파괴될 때마다",
                 "{C:money}$#2#{} 획득",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -3609,7 +3609,7 @@ return {
                     "{C:attention}부스터 팩{}을 개봉하면",
                     "핸드 크기 {C:attention}+#1#{}",
                     "{br:2}오류 - STEAK에게 문의바람",
-                    "{C:tarot}타로{} 또는 {C:item}아이템{} 카드가",
+                    "{C:tarot}타로{} 또는 {C:poke_item}아이템{} 카드가",
                     "{C:attention}판매{}되면",
                     "{X:mult,C:white} X#2# {} 배수를 획득하고",
                     "손패에 있는 무작위 카드 {C:attention}1{}장을 파괴합니다",
@@ -3622,7 +3622,7 @@ return {
                     "{C:attention}부스터 팩{}을 개봉하면",
                     "핸드 크기 {C:attention}+#1#{}",
                     "{br:2}오류 - STEAK에게 문의바람",
-                    "{C:tarot}타로{} 또는 {C:item}아이템{} 카드가",
+                    "{C:tarot}타로{} 또는 {C:poke_item}아이템{} 카드가",
                     "{C:attention}사용{}되면",
                     "{X:mult,C:white} X#2# {} 배수를 획득합니다",
                     "{C:inactive}(현재 {X:mult,C:white} X#3# {C:inactive} 배수)"
@@ -3724,7 +3724,7 @@ return {
                 name = '지라치',
                 text = {
                     "오른쪽 {C:attention}조커{}의 능력을 복사하되,",
-                    "추가로 한 번 더 {C:pink}에너지화{}된 것처럼 적용합니다",
+                    "추가로 한 번 더 {C:poke_pink}에너지화{}된 것처럼 적용합니다",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -3825,7 +3825,7 @@ return {
             j_poke_honchkrow = {
                 name = "돈크로우",
                 text = {
-                  "각 {X:dark,C:white}악{} 조커가 {X:mult,C:white}X#1#{} 배수를 제공합니다",
+                  "각 {X:poke_dark,C:white}악{} 조커가 {X:mult,C:white}X#1#{} 배수를 제공합니다",
                 }
             },
             j_poke_bonsly = {
@@ -3860,7 +3860,7 @@ return {
                 name = '먹고자',
                 text = {
                     "{C:attention}아기 포켓몬{}, {X:mult,C:white} X#1# {} 배수",
-                    "라운드 종료 시 {C:dark_edition}네거티브 {C:item}아이템{}을",
+                    "라운드 종료 시 {C:dark_edition}네거티브 {C:poke_item}아이템{}을",
                     "생성합니다",
                     "{C:inactive,s:0.8}(#2# 라운드 후 진화){}",
                 }
@@ -3887,7 +3887,7 @@ return {
                 name = "타만타",
                 text = {
                   "{C:attention}아기 포켓몬{}, {X:mult,C:white}X#2#{} 배수",
-                  "라운드 종료 시 {C:dark_edition}네거티브{} {C:item}악마{} 카드의",
+                  "라운드 종료 시 {C:dark_edition}네거티브{} {C:poke_item}악마{} 카드의",
                   "복제본을 생성합니다",
                   "{C:inactive,s:0.8}(#3# 라운드 후 진화){}",
                 }
@@ -3906,7 +3906,7 @@ return {
                 name = '자포코일',
                 text = {
                     "플레이한 {C:attention}스틸{} 카드가 {X:mult,C:white}X#1#{} 배수를 제공하며,",
-                    "보유한 {X:metal,C:white}강철{} 조커마다 {X:mult,C:white}X#2#{} 배수를",
+                    "보유한 {X:poke_metal,C:white}강철{} 조커마다 {X:mult,C:white}X#2#{} 배수를",
                     "추가로 제공합니다",
                     "{C:inactive}(현재 {X:mult,C:white}X#3#{C:inactive} 배수){}",
                 } 
@@ -3928,7 +3928,7 @@ return {
                     "영구적으로 {C:chips}+#1#{} 칩을 얻고",
                     "득점 시 재발동합니다",
                     "{br:3}오류 - 제작자(STEAK)에게 문의하세요",
-                    "보유한 {C:attention}3{}개의 {X:earth,C:white}땅{} 속성 조커당",
+                    "보유한 {C:attention}3{}개의 {X:poke_earth,C:white}땅{} 속성 조커당",
                     "{C:attention}스톤{} 카드가 추가로 한 번 더 재발동합니다",
                     "{C:inactive}(현재 #2#번 재발동)"
                 } 
@@ -4025,11 +4025,11 @@ return {
             j_poke_porygonz = {
                 name = '폴리곤Z',
                 text = {
-                    "{C:pink}에너지{} 한도 +#3#",
-                    "이번 런에서 사용한 {C:pink}에너지{} 카드당",
+                    "{C:poke_pink}에너지{} 한도 +#3#",
+                    "이번 런에서 사용한 {C:poke_pink}에너지{} 카드당",
                     "{X:mult,C:white} X#2# {} 배수",
                     "{br:2}텍스트가 여기에 있어야 작동합니다",
-                    "{C:pink}에너지{} 사용 시 새로운 {C:pink}에너지{}를 생성합니다",
+                    "{C:poke_pink}에너지{} 사용 시 새로운 {C:poke_pink}에너지{}를 생성합니다",
                     "{C:inactive}(빈 슬롯이 있어야 함)",
                     "{C:inactive}(현재 {X:mult,C:white} X#1# {C:inactive} 배수)"
                 } 
@@ -4059,7 +4059,7 @@ return {
                     "최대 {C:mult}-$#1#{}까지 빚을 질 수 있습니다",
                     "{br:2.5}오류 - 제작자(STEAK)에게 문의하세요",
                     "빚이 있는 상태에서 핸드를 플레이하면",
-                    "{C:item}아이템{} 카드를 생성합니다",
+                    "{C:poke_item}아이템{} 카드를 생성합니다",
                     "{C:inactive,s:0.8}(빈 슬롯이 있어야 함)"
                 }
             },
@@ -4067,7 +4067,7 @@ return {
                 name = "로토무",
                 text = {
                     "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                    "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                    "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                     "{C:attention}부스터 팩{}의 가격이 {C:money}$1{} 저렴해집니다",
                     "{C:inactive}({C:attention}가전제품{C:inactive} 사용 시 폼체인지){}"
@@ -4077,7 +4077,7 @@ return {
                 name = "로토무 (히트)",
                 text = {
                     "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                    "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                    "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                     "첫 버리기가 정확히 {C:attention}2{}장이라면,",
                     "두 카드 모두 {C:attention}배수{} 카드로 {C:attention}강화{}합니다",
@@ -4088,7 +4088,7 @@ return {
                 name = "로토무 (워시)",
                 text = {
                     "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                    "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                    "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                     "플레이된 각 {C:attention}강화{} 카드가 득점 시 {C:money}$#3#{}를 벌지만,",
                     "해당 카드의 {C:attention}강화{}가 제거됩니다",
@@ -4099,7 +4099,7 @@ return {
               name = "로토무 (프로스트)",
               text = {
                 "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                 "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                 "{C:attention}블라인드{} 선택 시, {C:dark_edition}포일{}, {C:dark_edition}홀로그램{},",
                 "또는 {C:dark_edition}폴리크롬{} 에디션이 부여된 무작위 {C:attention}소모품{}을 생성합니다",
@@ -4110,7 +4110,7 @@ return {
                 name = "로토무 (스핀)",
                 text = {
                     "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                    "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                    "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                     "{C:attention}블라인드{} 선택 시, 오른쪽에 있는 조커를",
                     "파괴하고 {C:attention}태그{}를 생성합니다",
@@ -4121,7 +4121,7 @@ return {
                 name = "로토무 (커트)",
                 text = {
                     "아무 {C:attention}부스터 팩{}을 열 때 {C:green}#2#분의 #1#{} 확률로",
-                    "{C:item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
+                    "{C:poke_item}아이템{} 카드를 생성합니다 {C:inactive}(빈 슬롯 필요){}",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                     "라운드 종료 시 핸드에 {C:attention}들고 있는{}",
                     "첫 {C:attention}2{}장의 카드의 랭크(숫자)를 {C:attention}감소{}시킵니다",
@@ -4192,7 +4192,7 @@ return {
             j_poke_roggenrola = {
                 name = "단굴",
                 text = {
-                    "{C:hazard}+#1#{} 위험 레이어",
+                    "{C:poke_hazard}+#1#{} 위험 레이어",
                     "핸드에 {C:attention}랭크가 없는{} 카드를 들고 있을 때마다",
                     "{C:mult}+#2#{} 배수를 부여합니다",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#3#{C:inactive,s:0.8}번 발동 후 진화합니다)"
@@ -4201,7 +4201,7 @@ return {
             j_poke_boldore = {
                 name = "암트르",
                 text = {
-                    "{C:hazard}+#1#{} 위험 레이어",
+                    "{C:poke_hazard}+#1#{} 위험 레이어",
                     "핸드에 {C:attention}랭크가 없는{} 카드를 들고 있을 때마다",
                     "{C:mult}+#2#{} 배수를 부여합니다",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}연결끈{C:inactive,s:0.8}으로 진화합니다)"
@@ -4210,7 +4210,7 @@ return {
             j_poke_gigalith = {
                 name = "기가이어스",
                 text = {
-                    "{C:hazard}+#1#{} 위험 레이어",
+                    "{C:poke_hazard}+#1#{} 위험 레이어",
                     "핸드에 {C:attention}랭크가 없는{} 카드를 들고 있을 때마다",
                     "{C:mult}+#2#{} 배수를 부여하고 재발동합니다"
                 }
@@ -4343,7 +4343,7 @@ return {
             j_poke_ferroseed = {
                 name = "철시드",
                 text = {
-                  "{C:hazard}+#2#{} 위험 레이어",
+                  "{C:poke_hazard}+#2#{} 위험 레이어",
                   "{C:attention}와일드{} 카드와 {C:attention}위험{} 카드는",
                   "{C:attention}스틸{} 카드이기도 합니다",
                   "{C:inactive,s:0.8}({C:attention,s:0.8}#1#{C:inactive,s:0.8} 라운드 후 진화합니다)"
@@ -4352,7 +4352,7 @@ return {
             j_poke_ferrothorn = {
               name = "너트령",
               text = {
-                "{C:hazard}+#1#{} 위험 레이어",
+                "{C:poke_hazard}+#1#{} 위험 레이어",
                 "{C:attention}와일드{} 카드와 {C:attention}위험{} 카드는",
                 "{C:attention}스틸{} 카드이기도 합니다",
                 "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
@@ -4411,7 +4411,7 @@ return {
             j_poke_golett = {
                 name = "골비람",
                 text = {
-                  "{C:hazard}+#1#{} 위험 레이어",
+                  "{C:poke_hazard}+#1#{} 위험 레이어",
                   "핸드에 든 카드가 {C:green}#5#분의 #4#{} 확률로 {X:mult,C:white}X#2#{} 배수를 부여합니다",
                   "{C:attention}위험{} 카드는 확률이 확정적으로 적용됩니다",
                   "{C:inactive,s:0.8}({C:attention,s:0.8}#3#{C:inactive,s:0.8} 라운드 후 진화합니다)"
@@ -4420,7 +4420,7 @@ return {
             j_poke_golurk = {
                 name = "골루그",
                 text = {
-                  "{C:hazard}+#1#{} 위험 레이어",
+                  "{C:poke_hazard}+#1#{} 위험 레이어",
                   "핸드에 든 카드가 {C:green}#4#분의 #3#{} 확률로 {X:mult,C:white}X#2#{} 배수를 부여합니다",
                   "{C:attention}위험{} 카드는 확률이 확정적으로 적용됩니다"
                 }
@@ -4477,7 +4477,7 @@ return {
                 text = {
                     "플레이 핸드에 {C:attention}플러시{}가 포함되어 있으면 {C:chips}+#1#{} 칩",
                     "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
-                    "{C:attention}K{} 또는 {C:attention}Q{}도 포함되어 있다면 {C:pink}에너지{} 카드를 생성합니다"
+                    "{C:attention}K{} 또는 {C:attention}Q{}도 포함되어 있다면 {C:poke_pink}에너지{} 카드를 생성합니다"
                 } 
             },
             j_poke_sylveon = {
@@ -4532,7 +4532,7 @@ return {
                   "{C:inactive}(빈 슬롯 필요)",
                   "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                   "{C:spectral}스펙트럼{} 카드 사용 시 {C:money}$#3#{}를 벌고,",
-                  "가장 왼쪽 {C:attention}조커{}에 {X:psychic,C:white}에스퍼{} 스티커를 부착합니다"
+                  "가장 왼쪽 {C:attention}조커{}에 {X:poke_psychic,C:white}에스퍼{} 스티커를 부착합니다"
                 }
             },
             j_poke_gourgeist_average = {
@@ -4543,7 +4543,7 @@ return {
                   "{C:inactive}(빈 슬롯 필요)",
                   "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                   "{C:spectral}스펙트럼{} 카드 사용 시 {C:money}$#3#{}를 벌고,",
-                  "가장 왼쪽 {C:attention}조커{}에 {X:psychic,C:white}에스퍼{} 스티커를 부착합니다"
+                  "가장 왼쪽 {C:attention}조커{}에 {X:poke_psychic,C:white}에스퍼{} 스티커를 부착합니다"
                 }
             },
             j_poke_gourgeist_large = {
@@ -4554,7 +4554,7 @@ return {
                   "{C:inactive}(빈 슬롯 필요)",
                   "{br:2}오류 - 제작자(STEAK)에게 문의하세요",
                   "{C:spectral}스펙트럼{} 카드 사용 시 {C:money}$#3#{}를 벌고,",
-                  "가장 왼쪽 {C:attention}조커{}에 {X:psychic,C:white}에스퍼{} 스티커를 부착합니다"
+                  "가장 왼쪽 {C:attention}조커{}에 {X:poke_psychic,C:white}에스퍼{} 스티커를 부착합니다"
                 }
             },
 			j_poke_gourgeist_super = {
@@ -4565,7 +4565,7 @@ return {
                   "{C:inactive}(공간이 있어야 함)",
                   "{br:2}오류 - STEAK에게 문의바람",
                   "{C:spectral}스펙트럴{} 카드 사용 시 {C:money}$#3#{}를 획득하고",
-                  "가장 왼쪽 {C:attention}조커{}에 {X:psychic,C:white}사이코{}",
+                  "가장 왼쪽 {C:attention}조커{}에 {X:poke_psychic,C:white}사이코{}",
                   "스티커를 부착합니다"
                 }
             },
@@ -4573,14 +4573,14 @@ return {
                 name = '턱지충이',
                 text = {
                     "{C:mult}+#1#{} 배수",
-                    "{X:lightning, C:black}전기{} 타입 조커 보유 시 {C:attention}3배{}가 됩니다",
+                    "{X:poke_lightning, C:black}전기{} 타입 조커 보유 시 {C:attention}3배{}가 됩니다",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#2#{C:inactive,s:0.8} 라운드 후 진화)",
                 }  
             },
             j_poke_charjabug = {
                 name = '전지충이',
                 text = {
-                    "보유한 {X:lightning, C:black}전기{} 타입 조커",
+                    "보유한 {X:poke_lightning, C:black}전기{} 타입 조커",
                     "하나당 {C:mult}+#1#{} 배수",
                     "{C:inactive}(현재 {C:mult}+#2#{C:inactive} 배수)",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}천둥의돌{C:inactive,s:0.8} 사용 시 진화)"
@@ -4590,7 +4590,7 @@ return {
                 name = '투구뿌논',
                 text = {
                     "{C:mult}+#3#{} 배수",
-                    "다른 {X:lightning, C:black}전기{} 타입 조커 하나당",
+                    "다른 {X:poke_lightning, C:black}전기{} 타입 조커 하나당",
                     "{X:mult,C:white} X#1# {} 배수",
                     "{C:inactive}(현재 {X:mult,C:white} X#2# {C:inactive} 배수)",
                 }
@@ -4766,21 +4766,21 @@ return {
               text = {
                 "{C:attention}부스터 팩{}을 건너뛸 때마다 {C:mult}+#2#{} 배수를 얻고",
                 "{C:dark_edition}포일{}, {C:dark_edition}홀로그램{}, 또는 {C:dark_edition}폴리크롬{} 효과가",
-                "부여된 무작위 {C:item}아이템{}을 생성합니다",
+                "부여된 무작위 {C:poke_item}아이템{}을 생성합니다",
                 "{C:inactive}(공간이 있어야 하며, 현재 {C:mult}+#1#{C:inactive} 배수)",
               }
             },
             j_poke_tarountula = {
                 name = "타랜툴라",
                 text = {
-                    "{C:hazard}+#1#{} 해저드 레이어, {C:attention}+#3#{} 핸드 크기",
+                    "{C:poke_hazard}+#1#{} 해저드 레이어, {C:attention}+#3#{} 핸드 크기",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#2#{C:inactive,s:0.8} 라운드 후 진화)",
                 }
             },
             j_poke_spidops = {
                 name = "트래피더",
                 text = {
-                    "{C:hazard}+#1#{} 해저드 레이어, {C:attention}+#2#{} 핸드 크기",
+                    "{C:poke_hazard}+#1#{} 해저드 레이어, {C:attention}+#2#{} 핸드 크기",
                     "덱에 추가되는 매 {C:attention}#3#번째 {C:inactive}[#4#]{}",
                     "{C:attention}플레잉 카드{}에 무작위 {C:attention}인장{}을 부여합니다"
                 }
@@ -4792,7 +4792,7 @@ return {
                   "발동할 때마다 요구되는 {C:attention}랭크{}가 상승합니다",
                   "{C:inactive,s:0.8}(가장 높은 랭크일 경우 다시 가장 낮게 돌아감)",
                   "{C:inactive}(현재 {C:chips}+#1#{C:inactive} 칩)",
-                  "{C:inactive,s:0.8}({X:fire,C:white,s:0.8}불꽃{C:inactive,s:0.8} 타입 조커 보유 시 진화)",
+                  "{C:inactive,s:0.8}({X:poke_fire,C:white,s:0.8}불꽃{C:inactive,s:0.8} 타입 조커 보유 시 진화)",
                 }
             },
             j_poke_dachsbun = {
@@ -4801,7 +4801,7 @@ return {
                   "포커 핸드에 {C:attention}#3#{} 랭크가 포함되면 {C:chips}+#2#{} 칩을 얻습니다",
                   "발동할 때마다 요구되는 {C:attention}랭크{}가 상승합니다",
                   "{br:4}오류 - STEAK에게 문의바람",
-                  "보유한 {X:fire,C:white}불꽃{} 타입 조커 하나당 칩 상승량이",
+                  "보유한 {X:poke_fire,C:white}불꽃{} 타입 조커 하나당 칩 상승량이",
                   "{C:chips}+2{}만큼 증가합니다",
                   "{C:inactive,s:0.8}(가장 높은 랭크일 경우 다시 가장 낮게 돌아감)",
                   "{C:inactive}(현재 {C:chips}+#1#{C:inactive} 칩)",
@@ -5000,7 +5000,7 @@ return {
             j_poke_rotomdex = {
                 name = '로토무도감',
                 text = {
-                    "보유한 조커의 서로 다른 {C:pink}타입{}",
+                    "보유한 조커의 서로 다른 {C:poke_pink}타입{}",
                     "하나당 {C:attention}부스터 팩{} 비용 {C:money}$1{} 감소",
                     "{C:inactive}(현재 {C:money}$#1#{C:inactive} 할인)"
                 } 
@@ -5027,7 +5027,7 @@ return {
                 name = "젤리 도넛",
                 text = {
                   "{C:attention}블라인드{} 선택 시",
-                  "{X:colorless,C:white}노말{C:pink} 에너지{} 생성",
+                  "{X:poke_colorless,C:white}노말{C:poke_pink} 에너지{} 생성",
                   "{C:inactive}({C:attention}#1#{C:inactive} 라운드 남음){}"
                 }
             },
@@ -5056,8 +5056,8 @@ return {
                 name = "보물 식당",
                 text = {
                   "{C:attention}타입 체인저{}",
-                  "가장 왼쪽에 있는 조커의 {C:pink}타입{}을",
-                  "가장 오른쪽에 있는 조커의 {C:pink}타입{}으로 변경",
+                  "가장 왼쪽에 있는 조커의 {C:poke_pink}타입{}을",
+                  "가장 오른쪽에 있는 조커의 {C:poke_pink}타입{}으로 변경",
                   "{C:attention}블라인드{} 선택 시 발동",
                   "{C:inactive}({C:attention}#1#{C:inactive} 라운드 남음){}"
                 }
@@ -5109,7 +5109,7 @@ return {
                 text = {
                   "{C:attention}#1#{} 라운드 후 {C:attention}기본{} 또는",
                   "{C:attention}아기{} 포켓몬 조커로 변신",
-                  "변신 시 가능한 경우 {C:pink}에너자이징{} 상태가 됨"
+                  "변신 시 가능한 경우 {C:poke_pink}에너자이징{} 상태가 됨"
                 }
             },
             j_poke_daycare = {
@@ -5124,7 +5124,7 @@ return {
                 name = '10억 마리의 사자',
                 text = {
                     "{C:attention}블라인드{} 선택 시 보유한 모든",
-                    "{C:pink}타입{} 조커를 파괴하고 마리당 {X:mult,C:white}X#2#{} 배수 획득",
+                    "{C:poke_pink}타입{} 조커를 파괴하고 마리당 {X:mult,C:white}X#2#{} 배수 획득",
                     "사자가 모두 소진되면 {S:1.1,C:red,E:2}자폭{}합니다",
                     "{C:inactive}(현재 {X:mult,C:white}X#1#{C:inactive} 배수, {C:attention}#3#{C:inactive}마리 남음)"
                 } 
@@ -5174,10 +5174,10 @@ return {
 			            sleeve_poke_obituarysleeve_alt = {
                 name = "부고 슬리브",
                 text = {
-                    "{C:pink}핑크 인장{}은 발동 후 {C:green}#1# / #2#{} 확률로",
+                    "{C:poke_pink}핑크 인장{}은 발동 후 {C:green}#1# / #2#{} 확률로",
                     "제거됩니다",
                     "조커가 판매되거나 파괴될 때 해당 타입의",
-                    "{C:dark_edition}네거티브 {C:pink}에너지{}를 생성합니다",
+                    "{C:dark_edition}네거티브 {C:poke_pink}에너지{}를 생성합니다",
                 },
             },
             sleeve_poke_revenantsleeve = {
@@ -5190,7 +5190,7 @@ return {
               name = "망령 슬리브",
               text = {
                   "{C:blue}+#1#{} 소모품 슬롯",
-                  "{C:pink}포켓 팩{}이 상점에",
+                  "{C:poke_pink}포켓 팩{}이 상점에",
                   "등장하지 않습니다",
               },
             },
@@ -5198,16 +5198,16 @@ return {
             sleeve_poke_luminoussleeve = {
                 name = "루미너스 슬리브",
                 text = {
-                    "모든 조커가 무작위 {C:pink}타입{} 스티커를",
+                    "모든 조커가 무작위 {C:poke_pink}타입{} 스티커를",
                     "가지고 생성되며,",
-                    "한 번 {C:pink}에너지화{}됩니다",
+                    "한 번 {C:poke_pink}에너지화{}됩니다",
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "루미너스 슬리브",
                 text = {
                     "리롤 시 {C:green}#1# / #2#{} 확률로",
-                    "{C:item}테라오브{}를 생성합니다",
+                    "{C:poke_item}테라오브{}를 생성합니다",
 
                 },
             },
@@ -5215,7 +5215,7 @@ return {
                 name = "염동력 슬리브",
                 text = {
                     "{C:tarot,T:v_crystal_ball}#1#{} 바우처와",
-                                        "{C:item,T:c_poke_twisted_spoon}#2#{} 카드를",
+                                        "{C:poke_item,T:c_poke_twisted_spoon}#2#{} 카드를",
                     "{C:attention}2{}장 보유하고 시작합니다"
                 } 
             },
@@ -5223,7 +5223,7 @@ return {
                 name = "염동력 슬리브",
                 text = {
                     "{C:attention}소모품{} 슬롯에 있는",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{}마다",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{}마다",
                     "{C:blue}+1{} 소모품 슬롯을 얻습니다",
                 }
             },
@@ -5231,16 +5231,16 @@ return {
                 name = "증폭 슬리브",
                 text = {
                     "{C:tarot,T:v_poke_energysearch}#1#{} 바우처와",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#{} 카드를",
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{} 카드를",
                     "보유하고 시작합니다"
                 } 
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "증폭 슬리브",
                 text = {
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#{} 대신",
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{} 대신",
                     "{C:dark_edition}네거티브 {C:attention,T:j_poke_jelly_donut}#1#{}를 보유하고 시작합니다",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{}가 더 이상 {X:colorless,C:white}노말{}이 아닌",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{}가 더 이상 {X:poke_colorless,C:white}노말{}이 아닌",
                     "조커에게 효과가 절반이 되지 않습니다",
 
                 } 
@@ -5333,7 +5333,7 @@ return {
                 name = "변신",
                 text = {
                     "가장 왼쪽 또는 선택한 포켓몬을",
-                    "가장 높은 {C:attention}단계{}로 진화시키고 {C:pink}에너지화{}합니다", 
+                    "가장 높은 {C:attention}단계{}로 진화시키고 {C:poke_pink}에너지화{}합니다", 
 
                 },
             },
@@ -5352,16 +5352,16 @@ return {
                 name = "부고",
                 text = {
                     "선택한 카드 {C:attention}1{}장에",
-                    "{C:pink}분홍색 인장{}을 추가합니다",
+                    "{C:poke_pink}분홍색 인장{}을 추가합니다",
                 }
             },
             c_poke_nightmare = {
                 name = "악몽",
                 text = {
                     "가장 왼쪽 또는 선택한 조커를 파괴하고",
-                    "해당 조커의 {C:pink}타입{}에 맞는 {C:attention}2{}장의 {C:dark_edition}네거티브{}",
-                    "{C:pink}에너지{} 카드를 생성합니다",
-                    "{C:inactive}(타입이 없는 조커는 {X:colorless,C:white}노말{C:inactive} 에너지를 생성합니다)"
+                    "해당 조커의 {C:poke_pink}타입{}에 맞는 {C:attention}2{}장의 {C:dark_edition}네거티브{}",
+                    "{C:poke_pink}에너지{} 카드를 생성합니다",
+                    "{C:inactive}(타입이 없는 조커는 {X:poke_colorless,C:white}노말{C:inactive} 에너지를 생성합니다)"
 
                 },
             },
@@ -5369,14 +5369,14 @@ return {
                 name = "망령",
                 text = {
                     "선택한 카드 {C:attention}1{}장에",
-                    "{C:item}실버 인장{}을 추가합니다",
+                    "{C:poke_item}실버 인장{}을 추가합니다",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "더블 레인보우 에너지",
                 text = {
-                    "가장 왼쪽 또는 선택한 아무 {C:pink}타입{}의",
-                    "조커를 {C:red}2{C:attention}회{C:green} {C:blue}연{C:purple}속 {C:pink}에너지화{}합니다",
+                    "가장 왼쪽 또는 선택한 아무 {C:poke_pink}타입{}의",
+                    "조커를 {C:red}2{C:attention}회{C:green} {C:blue}연{C:purple}속 {C:poke_pink}에너지화{}합니다",
                     "이번 라운드에 이자를 획득하지 못합니다",
                     "{C:inactive}(조커당 최대 {C:attention}#1#{C:inactive}회 증가)",
 
@@ -5398,7 +5398,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "포켓 태그",
                 text = {
-                    "무료 {C:pink}메가 포켓 팩{}을 지급합니다",
+                    "무료 {C:poke_pink}메가 포켓 팩{}을 지급합니다",
                     "{C:attention}앤티 5{} 이상에서 팩에 {C:attention}메가스톤{}이",
                     "포함될 확률 {C:green}#1#%{}",
                     "{C:inactive,s:0.8}(확률을 높일 수 없음){}",
@@ -5408,7 +5408,7 @@ return {
                 name = "이로치 태그",
                 text = {
                     "다음 상점의 기본 에디션 조커가",
-                    "무료가 되며 {C:colorless}이로치(Shiny){}가 됩니다",
+                    "무료가 되며 {C:poke_colorless}이로치(Shiny){}가 됩니다",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -5420,7 +5420,7 @@ return {
             tag_poke_safari_tag = {
                 name = "사파리 태그",
                 text = {
-                    "상점에 무료 {C:safari}사파리{} 조커가 나타납니다",
+                    "상점에 무료 {C:poke_safari}사파리{} 조커가 나타납니다",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -5449,11 +5449,11 @@ return {
         Voucher = {
             v_poke_energysearch = {
                 name = "에너지 서치",
-                text = { "{C:pink}에너지 한도 +2{}" },
+                text = { "{C:poke_pink}에너지 한도 +2{}" },
             },
             v_poke_energyresearch = {
                 name = "에너지 리서치",
-                text = { "{C:pink}에너지 한도 +3{}" },
+                text = { "{C:poke_pink}에너지 한도 +3{}" },
             },
             v_poke_goodrod = {
                 name = "좋은 낚시대",
@@ -5461,24 +5461,24 @@ return {
             },
             v_poke_superrod = {
                 name = "대단한 낚시대",
-                text = { "모든 {C:attention}소모품 팩{}에서 카드를 {C:pink}보관{}할 수 있습니다" },
+                text = { "모든 {C:attention}소모품 팩{}에서 카드를 {C:poke_pink}보관{}할 수 있습니다" },
             },
         },
         Other = {
             -- 타입 설명 (Type)
-            Grass = { name = "타입", text = { "{X:grass,C:white}풀{}" } },
-            Fire = { name = "타입", text = { "{X:fire,C:white}불꽃{}" } },
-            Water = { name = "타입", text = { "{X:water,C:white}물{}" } },
-            Lightning = { name = "타입", text = { "{X:lightning,C:black}전기{}" } },
-            Psychic = { name = "타입", text = { "{X:psychic,C:white}에스퍼{}" } },
-            Fighting = { name = "타입", text = { "{X:fighting,C:white}격투{}" } },
-            Colorless = { name = "타입", text = { "{X:colorless,C:white}노말{}" } },
-            Dark = { name = "타입", text = { "{X:dark,C:white}악{}" } },
-            Metal = { name = "타입", text = { "{X:metal,C:white}강철{}" } },
-            Fairy = { name = "타입", text = { "{X:fairy,C:white}페어리{}" } },
-            Dragon = { name = "타입", text = { "{X:dragon,C:white}드래곤{}" } },
-            Earth = { name = "타입", text = { "{X:earth,C:white}땅{}" } },
-            Bird = { name = "타입", text = { "{X:bird,C:white}비행{}" } },
+            Grass = { name = "타입", text = { "{X:poke_grass,C:white}풀{}" } },
+            Fire = { name = "타입", text = { "{X:poke_fire,C:white}불꽃{}" } },
+            Water = { name = "타입", text = { "{X:poke_water,C:white}물{}" } },
+            Lightning = { name = "타입", text = { "{X:poke_lightning,C:black}전기{}" } },
+            Psychic = { name = "타입", text = { "{X:poke_psychic,C:white}에스퍼{}" } },
+            Fighting = { name = "타입", text = { "{X:poke_fighting,C:white}격투{}" } },
+            Colorless = { name = "타입", text = { "{X:poke_colorless,C:white}노말{}" } },
+            Dark = { name = "타입", text = { "{X:poke_dark,C:white}악{}" } },
+            Metal = { name = "타입", text = { "{X:poke_metal,C:white}강철{}" } },
+            Fairy = { name = "타입", text = { "{X:poke_fairy,C:white}페어리{}" } },
+            Dragon = { name = "타입", text = { "{X:poke_dragon,C:white}드래곤{}" } },
+            Earth = { name = "타입", text = { "{X:poke_earth,C:white}땅{}" } },
+            Bird = { name = "타입", text = { "{X:poke_bird,C:white}비행{}" } },
 
             ancient = {
                 name = "고대",
@@ -5692,7 +5692,7 @@ return {
                 name = "선물",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}아이템{} 카드",
+                    "{C:green}30%{} - {C:poke_item}아이템{} 카드",
                     "{C:green}20%{} - {C:attention}쿠폰 태그",
                     "{C:green}15%{} - {C:dark_edition}폴리크롬{} {C:attention}기프트 카드",
                 }
@@ -5721,10 +5721,10 @@ return {
             pickup = {
               name = "픽업",
               text = {
-                "{C:green}34%{} - {C:item}아이템{}",
-                "{C:green}25%{} - {C:item}진화 아이템",
-                "{C:green}20%{} - {C:item}먹다남은음식",
-                "{C:green}20%{} - {C:item}휘어진스푼",
+                "{C:green}34%{} - {C:poke_item}아이템{}",
+                "{C:green}25%{} - {C:poke_item}진화 아이템",
+                "{C:green}20%{} - {C:poke_item}먹다남은음식",
+                "{C:green}20%{} - {C:poke_item}휘어진스푼",
                 "{C:green}1%{} - {C:spectral}변화",
               }
             },
@@ -5768,14 +5768,14 @@ return {
             eeveelution = {
                 name = "진화",
                 text = {
-                    "{C:attention}물의돌{} - {X:water,C:white}샤미드{}",
-                    "{C:attention}천둥의돌{} - {X:lightning,C:black}쥬피썬더{}",
-                    "{C:attention}불꽃의돌{} - {X:fire,C:white}부스터{}",
-                    "{C:attention}태양의돌{} - {X:psychic,C:white}에브이{}",
-                    "{C:attention}달의돌{} - {X:dark,C:white}블래키{}",
-                    "{C:attention}리프의돌{} - {X:grass,C:white}리피아{}",
-                    "{C:attention}얼음의돌{} - {X:water,C:white}글레이시아{}",
-                    "{C:attention}빛의돌{} - {X:fairy,C:white}님피아{}"
+                    "{C:attention}물의돌{} - {X:poke_water,C:white}샤미드{}",
+                    "{C:attention}천둥의돌{} - {X:poke_lightning,C:black}쥬피썬더{}",
+                    "{C:attention}불꽃의돌{} - {X:poke_fire,C:white}부스터{}",
+                    "{C:attention}태양의돌{} - {X:poke_psychic,C:white}에브이{}",
+                    "{C:attention}달의돌{} - {X:poke_dark,C:white}블래키{}",
+                    "{C:attention}리프의돌{} - {X:poke_grass,C:white}리피아{}",
+                    "{C:attention}얼음의돌{} - {X:poke_water,C:white}글레이시아{}",
+                    "{C:attention}빛의돌{} - {X:poke_fairy,C:white}님피아{}"
                 }
             },
             poke_egg_tip = {
@@ -5833,14 +5833,14 @@ return {
             unlimited_energy_tooltip = {
               name = "무한 에너지",
               text = {
-                "조커에게 {C:pink}에너지{}를",
+                "조커에게 {C:poke_pink}에너지{}를",
                 "횟수 제한 없이 사용할 수 있습니다"
               }
             },
             precise_energy_tooltip = {
                 name = "정밀 에너지 스케일링",
                 text = {
-                    "{s:0.8}{C:pink,s:0.8}에너지{}{s:0.8} 보너스 적용 시 모든 값에 {C:attention,s:0.8}소수점{}을 사용합니다{}",
+                    "{s:0.8}{C:poke_pink,s:0.8}에너지{}{s:0.8} 보너스 적용 시 모든 값에 {C:attention,s:0.8}소수점{}을 사용합니다{}",
                     "{s:0.8}이 옵션이 {C:attention,s:0.8}꺼져 있으면{}{s:0.8} 보너스에 다음이 적용됩니다:{}",
 
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}배수 - 소수점 사용",
@@ -6015,7 +6015,7 @@ return {
             allowpokeballs_tooltip = {
               name = "몬스터볼 허용",
               text = {
-                "몬스터볼 {C:item}아이템{}이 등장하도록 합니다.",
+                "몬스터볼 {C:poke_item}아이템{}이 등장하도록 합니다.",
               }
             },
             pokemaster_tooltip = {
@@ -6068,7 +6068,7 @@ return {
                 name = "핑크 실",
                 text = {
                     "라운드의 {C:attention}첫 번째 핸드{}로 득점 시,",
-                    "소유한 조커의 {C:pink}타입{}과 일치하는 {C:pink}에너지{} 카드 생성",
+                    "소유한 조커의 {C:poke_pink}타입{}과 일치하는 {C:poke_pink}에너지{} 카드 생성",
                     "{C:inactive}(공간이 있어야 함){}"
                 },
             },
@@ -6077,7 +6077,7 @@ return {
                 name = "실버 실",
                 text = {
                   "카드가 득점할 때 손에 {C:attention}들고 있다면{}",
-                  "{C:item}아이템{} 카드를 생성하고 {C:attention}버려집니다{}"
+                  "{C:poke_item}아이템{} 카드를 생성하고 {C:attention}버려집니다{}"
                 }
             },
 
@@ -6092,64 +6092,64 @@ return {
 				p_poke_pokepack_normal_1 = {
                 name = "포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "점보 포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "메가 포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "점보 포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "메가 포켓 팩",
                 text = {
-                    "{C:attention}#2#{}장의 {C:item}아이템{} 카드와",
-                    "{C:attention}#3#{}장의 {C:pink}에너지{} 카드 중",
+                    "{C:attention}#2#{}장의 {C:poke_item}아이템{} 카드와",
+                    "{C:attention}#3#{}장의 {C:poke_pink}에너지{} 카드 중",
                     "{C:attention}#1#{}장을 선택하세요",
                 },
             },

--- a/localization/nl.lua
+++ b/localization/nl.lua
@@ -48,8 +48,8 @@ return {
                 name = "Luminous Deck",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
-                    "and have {C:attention}+1{} {C:pink}Energy{}"
+                    "with random {C:poke_pink}Type{} stickers",
+                    "and have {C:attention}+1{} {C:poke_pink}Energy{}"
                 }
             },
         },
@@ -163,15 +163,15 @@ return {
                 name = "Tera Orb",
                 text = {
                     "Applies a random",
-                    "{C:pink}Type{} sticker",
+                    "{C:poke_pink}Type{} sticker",
                     "to leftmost Joker{}", 
-                    "and gives {C:attention}+1{} {C:pink}Energy{}"
+                    "and gives {C:attention}+1{} {C:poke_pink}Energy{}"
                 },
             },
             c_poke_metalcoat = {
                 name = "Metal Coat",
                 text = {
-                    "Applies a {C:metal}Metal{} sticker",
+                    "Applies a {C:poke_metal}Metal{} sticker",
                     "to leftmost Joker.",
                     "Creates a {C:attention}Chariot{} card",
                     "{C:inactive}(Must have room){}"
@@ -180,7 +180,7 @@ return {
             c_poke_dragonscale = {
                 name = "Dragon Scale",
                 text = {
-                    "Applies a {C:dragon}Dragon{} sticker",
+                    "Applies a {C:poke_dragon}Dragon{} sticker",
                     "to leftmost Joker.",
                     "Creates an {C:attention}Emperor{} card",
                     "{C:inactive}(Must have room){}"
@@ -1209,7 +1209,7 @@ return {
                     "The leftmost scoring card of",
                     "your {C:attention}first hand{} of round",
                     "becomes a {C:attention}Stone{} card",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1414,7 +1414,7 @@ return {
                     "for each scoring {C:attention}6{}",
                     "in your first {C:attention}2{} hands",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive}(Evolves with a {C:dragon}Dragon{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_dragon}Dragon{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1464,7 +1464,7 @@ return {
                     "Joker to the right and gain {C:mult}+#2#{} Mult or {C:chips}+#4#{} Chips",
                     "Gain {C:attention}Foil{}, {C:attention}Holographic{}, or {C:attention}Polychrome{}",
                     "if Joker was {C:red}Rare{} or higher",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}",
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult, {C:chips}+#3#{C:inactive} Chips)"
                 } 
             },
@@ -1588,7 +1588,7 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "Create an {C:pink}Energy{} card",
+                    "Create an {C:poke_pink}Energy{} card",
                     "when any {C:attention}Booster Pack{}",
                     "is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -1710,7 +1710,7 @@ return {
                 text = {
                     "At end of shop, create a",
                     "{C:dark_edition}Polychrome{} {C:attention}duplicate{} of",
-                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:pink}Energy{}",
+                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:poke_pink}Energy{}",
                     "then destroy leftmost {C:attention}Joker{}",
                     "{C:dark_edition}Polychrome{} Jokers each give {X:mult,C:white} X#1# {} Mult",
                     "{C:inactive}(Can't destroy self)",
@@ -1721,7 +1721,7 @@ return {
                 text = {
                     "At end of shop, create",
                     "a random {C:dark_edition}Negative{} {C:attention}Tarot{}",
-                    "{C:spectral}Spectral{} or {C:item}Item{} card",
+                    "{C:spectral}Spectral{} or {C:poke_item}Item{} card",
                     "{C:green}#1# in {C:green}#2#{} chance to create",
                     "a random {C:dark_edition}Negative{} Joker {C:attention}instead{}",
                     "{C:inactive,s:0.8}(Odds can't be increased){}"
@@ -1802,7 +1802,7 @@ return {
                     "Played cards with {V:1}#2#{} suit give",
                     "{C:mult}+#1#{} Mult when scored",
                     "Those cards retrigger based on",
-                    "how many {X:water,C:white}Water{} Jokers you have",
+                    "how many {X:poke_water,C:white}Water{} Jokers you have",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} Retrigger(s) divided evenly between scoring cards){}",
                     "Suit changes in order {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -1873,9 +1873,9 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+1{} Energy Limit",
-                    "Create an {C:pink}Energy{} card",
-                    "of the same {C:pink}Type{} of",
+                    "{C:poke_pink}+1{} Energy Limit",
+                    "Create an {C:poke_pink}Energy{} card",
+                    "of the same {C:poke_pink}Type{} of",
                     "leftmost Joker when any",
                     "{C:attention}Booster Pack{} is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -2025,7 +2025,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}",
-                    "Create a random {C:item}Item{} card with",
+                    "Create a random {C:poke_item}Item{} card with",
                     "{C:dark_edition}Negative{} at end of round",
                     "{X:red,C:white} X#1# {} Mult",
                     "{C:inactive}(Yes, this will {C:attention}reduce{C:inactive} your Mult)",
@@ -2037,7 +2037,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards",
                     "give {X:red,C:white}X#1#{} Mult",
-                    "{X:metal,C:white}Metal{} Jokers next to",
+                    "{X:poke_metal,C:white}Metal{} Jokers next to",
                     "this Joker each give {X:red,C:white}X#2#{} Mult"
                 } 
             },
@@ -2057,7 +2057,7 @@ return {
                     "permanently gains",
                     "{C:chips}+#1#{} Chips when scored",
                     "{C:attention}Stone{} cards retrigger for each",
-                    "{C:attention}other{} {X:earth,C:white}Earth{} Joker you have",
+                    "{C:attention}other{} {X:poke_earth,C:white}Earth{} Joker you have",
                     "{C:inactive}(Currently #2# retriggers)"
                 } 
             },
@@ -2116,10 +2116,10 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energy Limit",
+                    "{C:poke_pink}+3{} Energy Limit",
                     "This Joker gains",
                     "{X:red,C:white} X#2# {} Mult every time",
-                    "an {C:pink}Energy{} card is used",
+                    "an {C:poke_pink}Energy{} card is used",
                     "{C:inactive}(Currently {X:red,C:white} X#1# {}{C:inactive} Mult)"
                 } 
             },
@@ -2140,7 +2140,7 @@ return {
                     "{C:mult}+#1#{} Mult",
                     "This card scores {C:attention}triple{}",
                     "its Mult if you have",
-                    "a {X:lightning, C:black}Lightning{} Joker",
+                    "a {X:poke_lightning, C:black}Lightning{} Joker",
                     "{C:inactive}(Evolves after {C:attention}#2#{}{C:inactive} rounds)"
                 }  
             },
@@ -2148,7 +2148,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult",
-                    "for each {X:lightning, C:black}Lightning{} Joker",
+                    "for each {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have {C:inactive}(includes self){}",
                      "{C:inactive}(Currently {C:mult}#2#{C:inactive} Mult)",
                     "{C:inactive}(Evolves with a{} {C:attention}Thunder Stone{}{C:inactive} card)"
@@ -2159,7 +2159,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult for each",
-                    "other {X:lightning, C:black}Lightning{} Joker",
+                    "other {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have{}",
                      "{C:inactive}(Currently {X:red,C:white} X#2# {}{C:inactive} Mult)",
                 }  
@@ -2202,7 +2202,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult for each",
-                    "Joker with a {C:pink}Type{} you have",
+                    "Joker with a {C:poke_pink}Type{} you have",
                     "{C:attention}Pokemon{} may appear",
                     "multiple times",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)"
@@ -2238,7 +2238,7 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
+                    "with random {C:poke_pink}Type{} stickers",
                 },
             },
         },
@@ -2272,7 +2272,7 @@ return {
             c_poke_obituary = {
                 name = "Obituary",
                 text = {
-                    "Adds a {C:pink}Pink{} seal",
+                    "Adds a {C:poke_pink}Pink{} seal",
                     "to {C:attention}1{} selected card",
                 }
             },
@@ -2281,7 +2281,7 @@ return {
                 text = {
                     "Destroys a random Pokemon",
                     "Joker and creates {C:attention}3{}",
-                    "random {C:pink}Energy{} with {C:dark_edition}Negative{}"
+                    "random {C:poke_pink}Energy{} with {C:dark_edition}Negative{}"
                 },
             },
         },
@@ -2290,7 +2290,7 @@ return {
                 name = "Pocket Tag",
                 text = {
                     "Gives a free",
-                    "{C:pink}Mega Pocket Pack",
+                    "{C:poke_pink}Mega Pocket Pack",
                 }, 
             },
             tag_poke_shiny_tag = {
@@ -2298,7 +2298,7 @@ return {
                 text = {
                     "Next base edition shop",
                     "Joker is free and",
-                    "becomes {C:colorless}Shiny{}",
+                    "becomes {C:poke_colorless}Shiny{}",
                 }, 
             },
         },
@@ -2309,13 +2309,13 @@ return {
             v_poke_energysearch = {
                 name = "Energy Search",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_energyresearch = {
                 name = "Energy Research",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_goodrod = {
@@ -2338,79 +2338,79 @@ return {
             Grass = {
                 name = "Type",
                 text = {
-                  "{X:grass,C:white}Grass{}",
+                  "{X:poke_grass,C:white}Grass{}",
                 }
             },
             Fire = {
                 name = "Type",
                 text = {
-                  "{X:fire,C:white}Fire{}",
+                  "{X:poke_fire,C:white}Fire{}",
                 }
             },
             Water = {
                 name = "Type",
                 text = {
-                  "{X:water,C:white}Water{}",
+                  "{X:poke_water,C:white}Water{}",
                 }
             },
             Lightning = {
                 name = "Type",
                 text = {
-                  "{X:lightning,C:black}Lightning{}",
+                  "{X:poke_lightning,C:black}Lightning{}",
                 }
             },
             Psychic = {
                 name = "Type",
                 text = {
-                  "{X:psychic,C:white}Psychic{}",
+                  "{X:poke_psychic,C:white}Psychic{}",
                 }
             },
             Fighting = {
                 name = "Type",
                 text = {
-                  "{X:fighting,C:white}Fighting{}",
+                  "{X:poke_fighting,C:white}Fighting{}",
                 }
             },
             Colorless = {
                 name = "Type",
                 text = {
-                  "{X:colorless,C:white}Colorless{}",
+                  "{X:poke_colorless,C:white}Colorless{}",
                 }
             },
             Dark = {
                 name = "Type",
                 text = {
-                  "{X:dark,C:white}Dark{}",
+                  "{X:poke_dark,C:white}Dark{}",
                 }
             },
             Metal = {
                 name = "Type",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Type",
                 text = {
-                  "{X:fairy,C:white}Fairy{}",
+                  "{X:poke_fairy,C:white}Fairy{}",
                 }
             },
             Dragon = {
                 name = "Type",
                 text = {
-                  "{X:dragon,C:white}Dragon{}",
+                  "{X:poke_dragon,C:white}Dragon{}",
                 }
             },
             Earth = {
                 name = "Type",
                 text = {
-                  "{X:earth,C:white}Earth{}",
+                  "{X:poke_earth,C:white}Earth{}",
                 }
             },
             Bird = {
                 name = "Type",
                 text = {
-                  "{X:bird,C:white}Bird{}",
+                  "{X:poke_bird,C:white}Bird{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -2485,7 +2485,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Pink Seal",
                 text = {
-                    "Creates an {C:pink}Energy{} card",
+                    "Creates an {C:poke_pink}Energy{} card",
                     "if it scores in the",
                     "{C:attention}first hand{} of round"
                 },
@@ -2494,73 +2494,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Grass{}"
+                    "{X:poke_grass,C:white}Grass{}"
                 } 
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Fire{}"
+                    "{X:poke_fire,C:white}Fire{}"
                 } 
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Water{}"
+                    "{X:poke_water,C:white}Water{}"
                 } 
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Lightning{}"
+                    "{X:poke_lightning,C:white}Lightning{}"
                 } 
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psychic{}"
+                    "{X:poke_psychic,C:white}Psychic{}"
                 } 
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Fighting{}"
+                    "{X:poke_fighting,C:white}Fighting{}"
                 } 
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Colorless{}"
+                    "{X:poke_colorless,C:white}Colorless{}"
                 } 
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Dark{}"
+                    "{X:poke_dark,C:white}Dark{}"
                 } 
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fairy{}"
+                    "{X:poke_fairy,C:white}Fairy{}"
                 } 
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 } 
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Earth{}"
+                    "{X:poke_earth,C:white}Earth{}"
                 } 
             },
             --Since these are normally discovered by default these will probably not matter
@@ -2588,7 +2588,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
@@ -2596,7 +2596,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
@@ -2604,7 +2604,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
@@ -2612,7 +2612,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
@@ -2620,7 +2620,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
@@ -2628,7 +2628,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
@@ -2636,7 +2636,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
@@ -2644,7 +2644,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
         },

--- a/localization/pl.lua
+++ b/localization/pl.lua
@@ -47,8 +47,8 @@ return {
                 name = "Luminous Deck",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
-                    "and have {C:attention}+1{} {C:pink}Energy{}"
+                    "with random {C:poke_pink}Type{} stickers",
+                    "and have {C:attention}+1{} {C:poke_pink}Energy{}"
                 }
             },
         },
@@ -162,15 +162,15 @@ return {
                 name = "Tera Orb",
                 text = {
                     "Applies a random",
-                    "{C:pink}Type{} sticker",
+                    "{C:poke_pink}Type{} sticker",
                     "to leftmost Joker{}", 
-                    "and gives {C:attention}+1{} {C:pink}Energy{}"
+                    "and gives {C:attention}+1{} {C:poke_pink}Energy{}"
                 },
             },
             c_poke_metalcoat = {
                 name = "Metal Coat",
                 text = {
-                    "Applies a {C:metal}Metal{} sticker",
+                    "Applies a {C:poke_metal}Metal{} sticker",
                     "to leftmost Joker.",
                     "Creates a {C:attention}Chariot{} card",
                     "{C:inactive}(Must have room){}"
@@ -179,7 +179,7 @@ return {
             c_poke_dragonscale = {
                 name = "Dragon Scale",
                 text = {
-                    "Applies a {C:dragon}Dragon{} sticker",
+                    "Applies a {C:poke_dragon}Dragon{} sticker",
                     "to leftmost Joker.",
                     "Creates an {C:attention}Emperor{} card",
                     "{C:inactive}(Must have room){}"
@@ -1208,7 +1208,7 @@ return {
                     "The leftmost scoring card of",
                     "your {C:attention}first hand{} of round",
                     "becomes a {C:attention}Stone{} card",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1413,7 +1413,7 @@ return {
                     "for each scoring {C:attention}6{}",
                     "in your first {C:attention}2{} hands",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive}(Evolves with a {C:dragon}Dragon{} {C:inactive}sticker){}"
+                    "{C:inactive}(Evolves with a {C:poke_dragon}Dragon{} {C:inactive}sticker){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1463,7 +1463,7 @@ return {
                     "Joker to the right and gain {C:mult}+#2#{} Mult or {C:chips}+#4#{} Chips",
                     "Gain {C:attention}Foil{}, {C:attention}Holographic{}, or {C:attention}Polychrome{}",
                     "if Joker was {C:red}Rare{} or higher",
-                    "{C:inactive}(Evolves with a {C:metal}Metal{} {C:inactive}sticker){}",
+                    "{C:inactive}(Evolves with a {C:poke_metal}Metal{} {C:inactive}sticker){}",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult, {C:chips}+#3#{C:inactive} Chips)"
                 } 
             },
@@ -1587,7 +1587,7 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "Create an {C:pink}Energy{} card",
+                    "Create an {C:poke_pink}Energy{} card",
                     "when any {C:attention}Booster Pack{}",
                     "is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -1709,7 +1709,7 @@ return {
                 text = {
                     "At end of shop, create a",
                     "{C:dark_edition}Polychrome{} {C:attention}duplicate{} of",
-                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:pink}Energy{}",
+                    "leftmost {C:attention}Joker{} with {C:attention}+1{} {C:poke_pink}Energy{}",
                     "then destroy leftmost {C:attention}Joker{}",
                     "{C:dark_edition}Polychrome{} Jokers each give {X:mult,C:white} X#1# {} Mult",
                     "{C:inactive}(Can't destroy self)",
@@ -1720,7 +1720,7 @@ return {
                 text = {
                     "At end of shop, create",
                     "a random {C:dark_edition}Negative{} {C:attention}Tarot{}",
-                    "{C:spectral}Spectral{} or {C:item}Item{} card",
+                    "{C:spectral}Spectral{} or {C:poke_item}Item{} card",
                     "{C:green}#1# in {C:green}#2#{} chance to create",
                     "a random {C:dark_edition}Negative{} Joker {C:attention}instead{}",
                     "{C:inactive,s:0.8}(Odds can't be increased){}"
@@ -1801,7 +1801,7 @@ return {
                     "Played cards with {V:1}#2#{} suit give",
                     "{C:mult}+#1#{} Mult when scored",
                     "Those cards retrigger based on",
-                    "how many {X:water,C:white}Water{} Jokers you have",
+                    "how many {X:poke_water,C:white}Water{} Jokers you have",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} Retrigger(s) divided evenly between scoring cards){}",
                     "Suit changes in order {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -1872,9 +1872,9 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+1{} Energy Limit",
-                    "Create an {C:pink}Energy{} card",
-                    "of the same {C:pink}Type{} of",
+                    "{C:poke_pink}+1{} Energy Limit",
+                    "Create an {C:poke_pink}Energy{} card",
+                    "of the same {C:poke_pink}Type{} of",
                     "leftmost Joker when any",
                     "{C:attention}Booster Pack{} is opened",
                     "{C:inactive}(Evolves with a{} {C:attention}Upgrade{}{C:inactive} card)"
@@ -2024,7 +2024,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Baby{}",
-                    "Create a random {C:item}Item{} card with",
+                    "Create a random {C:poke_item}Item{} card with",
                     "{C:dark_edition}Negative{} at end of round",
                     "{X:red,C:white} X#1# {} Mult",
                     "{C:inactive}(Yes, this will {C:attention}reduce{C:inactive} your Mult)",
@@ -2036,7 +2036,7 @@ return {
                 text = {
                     "Played {C:attention}Steel{} cards",
                     "give {X:red,C:white}X#1#{} Mult",
-                    "{X:metal,C:white}Metal{} Jokers next to",
+                    "{X:poke_metal,C:white}Metal{} Jokers next to",
                     "this Joker each give {X:red,C:white}X#2#{} Mult"
                 } 
             },
@@ -2056,7 +2056,7 @@ return {
                     "permanently gains",
                     "{C:chips}+#1#{} Chips when scored",
                     "{C:attention}Stone{} cards retrigger for each",
-                    "{C:attention}other{} {X:earth,C:white}Earth{} Joker you have",
+                    "{C:attention}other{} {X:poke_earth,C:white}Earth{} Joker you have",
                     "{C:inactive}(Currently #2# retriggers)"
                 } 
             },
@@ -2115,10 +2115,10 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Energy Limit",
+                    "{C:poke_pink}+3{} Energy Limit",
                     "This Joker gains",
                     "{X:red,C:white} X#2# {} Mult every time",
-                    "an {C:pink}Energy{} card is used",
+                    "an {C:poke_pink}Energy{} card is used",
                     "{C:inactive}(Currently {X:red,C:white} X#1# {}{C:inactive} Mult)"
                 } 
             },
@@ -2139,7 +2139,7 @@ return {
                     "{C:mult}+#1#{} Mult",
                     "This card scores {C:attention}triple{}",
                     "its Mult if you have",
-                    "a {X:lightning, C:black}Lightning{} Joker",
+                    "a {X:poke_lightning, C:black}Lightning{} Joker",
                     "{C:inactive}(Evolves after {C:attention}#2#{}{C:inactive} rounds)"
                 }  
             },
@@ -2147,7 +2147,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult",
-                    "for each {X:lightning, C:black}Lightning{} Joker",
+                    "for each {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have {C:inactive}(includes self){}",
                      "{C:inactive}(Currently {C:mult}#2#{C:inactive} Mult)",
                     "{C:inactive}(Evolves with a{} {C:attention}Thunder Stone{}{C:inactive} card)"
@@ -2158,7 +2158,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:red,C:white} X#1# {} Mult for each",
-                    "other {X:lightning, C:black}Lightning{} Joker",
+                    "other {X:poke_lightning, C:black}Lightning{} Joker",
                     "you have{}",
                      "{C:inactive}(Currently {X:red,C:white} X#2# {}{C:inactive} Mult)",
                 }  
@@ -2201,7 +2201,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult for each",
-                    "Joker with a {C:pink}Type{} you have",
+                    "Joker with a {C:poke_pink}Type{} you have",
                     "{C:attention}Pokemon{} may appear",
                     "multiple times",
                     "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)"
@@ -2237,7 +2237,7 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
+                    "with random {C:poke_pink}Type{} stickers",
                 },
             },
         },
@@ -2271,7 +2271,7 @@ return {
             c_poke_obituary = {
                 name = "Obituary",
                 text = {
-                    "Adds a {C:pink}Pink{} seal",
+                    "Adds a {C:poke_pink}Pink{} seal",
                     "to {C:attention}1{} selected card",
                 }
             },
@@ -2280,7 +2280,7 @@ return {
                 text = {
                     "Destroys a random Pokemon",
                     "Joker and creates {C:attention}3{}",
-                    "random {C:pink}Energy{} with {C:dark_edition}Negative{}"
+                    "random {C:poke_pink}Energy{} with {C:dark_edition}Negative{}"
                 },
             },
         },
@@ -2289,7 +2289,7 @@ return {
                 name = "Pocket Tag",
                 text = {
                     "Gives a free",
-                    "{C:pink}Mega Pocket Pack",
+                    "{C:poke_pink}Mega Pocket Pack",
                 }, 
             },
             tag_poke_shiny_tag = {
@@ -2297,7 +2297,7 @@ return {
                 text = {
                     "Next base edition shop",
                     "Joker is free and",
-                    "becomes {C:colorless}Shiny{}",
+                    "becomes {C:poke_colorless}Shiny{}",
                 }, 
             },
         },
@@ -2308,13 +2308,13 @@ return {
             v_poke_energysearch = {
                 name = "Energy Search",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_energyresearch = {
                 name = "Energy Research",
                 text = {
-                    "{C:pink}+1{} Energy Limit"
+                    "{C:poke_pink}+1{} Energy Limit"
                 },
             },
             v_poke_goodrod = {
@@ -2337,79 +2337,79 @@ return {
             Grass = {
                 name = "Type",
                 text = {
-                  "{X:grass,C:white}Grass{}",
+                  "{X:poke_grass,C:white}Grass{}",
                 }
             },
             Fire = {
                 name = "Type",
                 text = {
-                  "{X:fire,C:white}Fire{}",
+                  "{X:poke_fire,C:white}Fire{}",
                 }
             },
             Water = {
                 name = "Type",
                 text = {
-                  "{X:water,C:white}Water{}",
+                  "{X:poke_water,C:white}Water{}",
                 }
             },
             Lightning = {
                 name = "Type",
                 text = {
-                  "{X:lightning,C:black}Lightning{}",
+                  "{X:poke_lightning,C:black}Lightning{}",
                 }
             },
             Psychic = {
                 name = "Type",
                 text = {
-                  "{X:psychic,C:white}Psychic{}",
+                  "{X:poke_psychic,C:white}Psychic{}",
                 }
             },
             Fighting = {
                 name = "Type",
                 text = {
-                  "{X:fighting,C:white}Fighting{}",
+                  "{X:poke_fighting,C:white}Fighting{}",
                 }
             },
             Colorless = {
                 name = "Type",
                 text = {
-                  "{X:colorless,C:white}Colorless{}",
+                  "{X:poke_colorless,C:white}Colorless{}",
                 }
             },
             Dark = {
                 name = "Type",
                 text = {
-                  "{X:dark,C:white}Dark{}",
+                  "{X:poke_dark,C:white}Dark{}",
                 }
             },
             Metal = {
                 name = "Type",
                 text = {
-                  "{X:metal,C:white}Metal{}",
+                  "{X:poke_metal,C:white}Metal{}",
                 }
             },
             Fairy = {
                 name = "Type",
                 text = {
-                  "{X:fairy,C:white}Fairy{}",
+                  "{X:poke_fairy,C:white}Fairy{}",
                 }
             },
             Dragon = {
                 name = "Type",
                 text = {
-                  "{X:dragon,C:white}Dragon{}",
+                  "{X:poke_dragon,C:white}Dragon{}",
                 }
             },
             Earth = {
                 name = "Type",
                 text = {
-                  "{X:earth,C:white}Earth{}",
+                  "{X:poke_earth,C:white}Earth{}",
                 }
             },
             Bird = {
                 name = "Type",
                 text = {
-                  "{X:bird,C:white}Bird{}",
+                  "{X:poke_bird,C:white}Bird{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -2484,7 +2484,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Pink Seal",
                 text = {
-                    "Creates an {C:pink}Energy{} card",
+                    "Creates an {C:poke_pink}Energy{} card",
                     "if it scores in the",
                     "{C:attention}first hand{} of round"
                 },
@@ -2493,73 +2493,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Grass{}"
+                    "{X:poke_grass,C:white}Grass{}"
                 } 
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Fire{}"
+                    "{X:poke_fire,C:white}Fire{}"
                 } 
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Water{}"
+                    "{X:poke_water,C:white}Water{}"
                 } 
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Lightning{}"
+                    "{X:poke_lightning,C:white}Lightning{}"
                 } 
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psychic{}"
+                    "{X:poke_psychic,C:white}Psychic{}"
                 } 
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Fighting{}"
+                    "{X:poke_fighting,C:white}Fighting{}"
                 } 
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Colorless{}"
+                    "{X:poke_colorless,C:white}Colorless{}"
                 } 
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Dark{}"
+                    "{X:poke_dark,C:white}Dark{}"
                 } 
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 } 
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fairy{}"
+                    "{X:poke_fairy,C:white}Fairy{}"
                 } 
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 } 
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Earth{}"
+                    "{X:poke_earth,C:white}Earth{}"
                 } 
             },
             --Since these are normally discovered by default these will probably not matter
@@ -2587,7 +2587,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
@@ -2595,7 +2595,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
@@ -2603,7 +2603,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
@@ -2611,7 +2611,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
@@ -2619,7 +2619,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
@@ -2627,7 +2627,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
@@ -2635,7 +2635,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
@@ -2643,7 +2643,7 @@ return {
                 text = {
                     "Choose {C:attention}#1#{} of",
                     "up to {C:attention}#2#",
-                    "{C:pink}Energy{} or {C:item}Item{} Cards{}",
+                    "{C:poke_pink}Energy{} or {C:poke_item}Item{} Cards{}",
                 },
             },
         },

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -44,7 +44,7 @@ return {
                     "Inicia a partida com o",
                     "{C:tarot,T:v_crystal_ball}#1#{} voucher",
                     "e {C:attention}2{} cópias",
-                    "de {C:item,T:c_poke_twisted_spoon}#2#"
+                    "de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 } 
             },
 			--Fun fact: this and luminious deck had their descriptions mixed up
@@ -64,8 +64,8 @@ return {
                 name = "Baralho Luminoso",
                 text = {
                     "Todos os Coringas são",
-                    "criados {C:pink}Energizados{} e",
-                    "com {C:pink}Tipos{} de adesivos aleatórios"
+                    "criados {C:poke_pink}Energizados{} e",
+                    "com {C:poke_pink}Tipos{} de adesivos aleatórios"
                 }
             },
             b_poke_ampeddeck = {
@@ -74,7 +74,7 @@ return {
                     "Inicia a partida com o",
                     "{C:tarot,T:v_poke_energysearch}#1#{} voucher",
                     "e uma cópia de",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
         },
@@ -212,16 +212,16 @@ return {
             c_poke_teraorb = {
                 name = "Orbe Tera",
                 text = {
-                    "{C:attention}Modificador de Tipo:{} {X:pink,C:white}Aleatório{}",
+                    "{C:attention}Modificador de Tipo:{} {X:poke_pink,C:white}Aleatório{}",
                     "{br:2}ERRO - CONTATE STEAK",
-                    "{C:pink}Energiza{} o Coringa mais à",
+                    "{C:poke_pink}Energiza{} o Coringa mais à",
                     "esquerda ou selecionado{}",
                 },
             },
             c_poke_metalcoat = {
                 name = "Revestimento Metálico",
                 text = {
-                    "{C:attention}Modificador de Tipo:{} {X:metal,C:white}Metálico{}",
+                    "{C:attention}Modificador de Tipo:{} {X:poke_metal,C:white}Metálico{}",
                     "{br:2}ERRO - CONTATE STEAK",
                     "Cria uma cópia {C:attention}Aço{} de",
                     "{C:attention}1{} carta selecionada",
@@ -230,10 +230,10 @@ return {
             c_poke_dragonscale = {
                 name = "Escama de Dragão",
                 text = {
-                    "{C:attention}Modificador de Tipo:{} {X:dragon,C:white}Dragão{}",
+                    "{C:attention}Modificador de Tipo:{} {X:poke_dragon,C:white}Dragão{}",
                     "{br:2}ERRO - CONTATE STEAK",
                     "Cria até {C:attention}3{} cartas aleatórias",
-                    "de {C:item}Item{} ou {C:pink}Energia{}",
+                    "de {C:poke_item}Item{} ou {C:poke_pink}Energia{}",
                     "{C:inactive}(É necessário espaço){}"
                 },
             },
@@ -290,10 +290,10 @@ return {
                 name = "Colher Torcida",
                 text = {
                     "Cria a última",
-                    "carta de {C:item}Item{} ou {C:pink}Energia{}",
+                    "carta de {C:poke_item}Item{} ou {C:poke_pink}Energia{}",
                     "usada durante esta partida",
-                    "{s:0.8,C:item}Colher Torcida, Reutilizáveis",
-                    "{s:0.8,C:item}e Sucos de Baga{s:0.8} excluídos"
+                    "{s:0.8,C:poke_item}Colher Torcida, Reutilizáveis",
+                    "{s:0.8,C:poke_item}e Sucos de Baga{s:0.8} excluídos"
                 }
             },
             c_poke_prismscale = {
@@ -337,7 +337,7 @@ return {
                     "{br:2}ERRO - CONTATE STEAK",
                     "Aprimora {C:attention}1{} carta selecionada em uma",
                     "{C:attention}Carta de Pedra{} com {C:chips}+#2#{} Fichas extras",
-                    "para cada Coringa {X:earth,C:white}Terrestre{} que você tem"
+                    "para cada Coringa {X:poke_earth,C:white}Terrestre{} que você tem"
                 }
             },
             c_poke_berry_juice = {
@@ -350,8 +350,8 @@ return {
             c_poke_berry_juice_energy = {
                 name = "Suco de Baga Energizado",
                 text = {
-                    "{C:pink}Energiza{} o Coringa mais à esquerda",
-                    "ou selecionado de qualquer {C:pink}Tipo{}",
+                    "{C:poke_pink}Energiza{} o Coringa mais à esquerda",
+                    "ou selecionado de qualquer {C:poke_pink}Tipo{}",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
             },
@@ -373,7 +373,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "Suco de Baga Itemizado",
                 text = {
-                    "Cria uma carta {C:item}Colher Torcida{}",
+                    "Cria uma carta {C:poke_item}Colher Torcida{}",
                     "{C:green}#1# em #2#{} chance de",
                     "criar {C:attention}2{} em vez disso",
                     "{C:inactive}(É necessário espaço){}"
@@ -390,7 +390,7 @@ return {
                 name = "Suco de Baga Misterioso",
                 text = {
                     "Cria uma carta",
-                    "{C:item}Suco de Baga{} aleatória"
+                    "{C:poke_item}Suco de Baga{} aleatória"
                 }
             },
         },
@@ -398,7 +398,7 @@ return {
             c_poke_grass_energy = {
                 name = "Energia de Grama",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:grass,C:white}Grama{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_grass,C:white}Grama{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -406,7 +406,7 @@ return {
             c_poke_fire_energy = {
                 name = "Energia de Fogo",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:fire,C:white}Fogo{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_fire,C:white}Fogo{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -414,7 +414,7 @@ return {
             c_poke_water_energy = {
                 name = "Energia de Água",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:water,C:white}Água{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_water,C:white}Água{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -422,7 +422,7 @@ return {
             c_poke_lightning_energy = {
                 name = "Energia de Raio",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:lightning,C:black}Raio{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_lightning,C:black}Raio{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -430,7 +430,7 @@ return {
             c_poke_psychic_energy = {
                 name = "Energia Psíquica",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:psychic,C:white}Psíquico{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_psychic,C:white}Psíquico{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -438,7 +438,7 @@ return {
             c_poke_fighting_energy = {
                 name = "Energia de Lutador",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:fighting,C:white}Lutador{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_fighting,C:white}Lutador{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -446,17 +446,17 @@ return {
             c_poke_colorless_energy = {
                 name = "Energia Incolor",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:colorless,C:white}Incolor{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_colorless,C:white}Incolor{}",
                     "mais à esquerda ou selecionado se possível",
                     "Metade da eficácia com",
-                    "Coringas não {X:colorless,C:white}Incolor{}",
+                    "Coringas não {X:poke_colorless,C:white}Incolor{}",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)"
                 },
             },
             c_poke_darkness_energy = {
                 name = "Energia das Trevas",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:dark,C:white}Trevas{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_dark,C:white}Trevas{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -464,7 +464,7 @@ return {
             c_poke_metal_energy = {
                 name = "Energia Metálica",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:Metal,C:white}Metálico{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:Metal,C:white}Metálico{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -472,7 +472,7 @@ return {
             c_poke_fairy_energy = {
                 name = "Energia de Fada",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:fairy,C:white}Fada{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_fairy,C:white}Fada{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -481,7 +481,7 @@ return {
             c_poke_dragon_energy = {
                 name = "Energia de Dragão",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:dragon,C:white}Dragão{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_dragon,C:white}Dragão{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -489,7 +489,7 @@ return {
             c_poke_earth_energy = {
                 name = "Energia Terrestre",
                 text = {
-                    "{C:pink}Energiza{} o Coringa {X:earth,C:white}Terrestre{}",
+                    "{C:poke_pink}Energiza{} o Coringa {X:poke_earth,C:white}Terrestre{}",
                     "mais à esquerda ou selecionado se possível",
                     "{C:inactive}(Máx de {C:attention}#1#{C:inactive} aumentos por Coringa)",
                 },
@@ -1129,7 +1129,7 @@ return {
             j_poke_abra = {
                 name = "Abra",
                 text = {
-                    "{C:green}#1# em #2#{} chance de criar um {C:item}Item",
+                    "{C:green}#1# em #2#{} chance de criar um {C:poke_item}Item",
                     "ou carta {C:tarot}Tarot{} se a {C:attention}mão de poker{} jogada",
                     "já foi jogada esta rodada",
                     "{C:inactive,s:0.8}(Evolui após {C:attention,s:0.8}#3#{C:inactive,s:0.8} rodadas)",
@@ -1139,7 +1139,7 @@ return {
                 name = "Kadabra",
                 text = {
                     "{C:green}#1# em #2#{} chance de criar uma carta {C:tarot}Tarot{} ou",
-                    "{C:item}Colher Torcida{} se a {C:attention}mão de poker{} jogada",
+                    "{C:poke_item}Colher Torcida{} se a {C:attention}mão de poker{} jogada",
                     "já foi jogada esta rodada",
                     "{C:inactive,s:0.8}(Evolui com um {C:attention,s:0.8}Cabo de Ligação{C:inactive,s:0.8})"
                 } 
@@ -1149,7 +1149,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} slot de consumível",
                     "{C:green}#1# em #2#{} chance de criar uma carta {C:attention}O Tol{} ou",
-                    "{C:item}Colher Torcida{} se a {C:attention}mão de poker{} jogada",
+                    "{C:poke_item}Colher Torcida{} se a {C:attention}mão de poker{} jogada",
                     "já foi jogada esta rodada",
                 } 
             },
@@ -1158,7 +1158,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} slot de consumível",
                     "Cada {C:attention}Consumível{} segurado dá {X:mult,C:white}X#1#{} Mult",
-                    "{C:item}Colheres Torcidas{} dão {X:mult,C:white}X#2#{} Mult",
+                    "{C:poke_item}Colheres Torcidas{} dão {X:mult,C:white}X#2#{} Mult",
                 } 
             },
             j_poke_machop = {
@@ -1317,7 +1317,7 @@ return {
                 text = {
                     "Cartas {C:attention}Aço{} jogadas dão {X:mult,C:white}X#1#{} Mult",
                     "mais {X:mult,C:white}X#2#{} Mult para cada",
-                    "Coringa {X:metal,C:white}Metálico{} adjacente",
+                    "Coringa {X:poke_metal,C:white}Metálico{} adjacente",
                     "{C:inactive}(Atualmente {X:mult,C:white}X#3#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolui com uma {C:attention,s:0.8}Pedra do Trovão{C:inactive,s:0.8})"
                 } 
@@ -1325,7 +1325,7 @@ return {
             j_poke_farfetchd = {
                 name = 'Farfetch\'d',      
                 text = {
-                    "{C:attention}Segurando {C:item}Alho-poró{}",
+                    "{C:attention}Segurando {C:poke_item}Alho-poró{}",
                     "{C:green}#2# em #3#{} chance de ganhar {C:money}$#1#",
                     "quando um {C:attention}Consumível{} é usado",
                     "{C:money}${} garantido ao usar {C:attention}Alho-poró{}",
@@ -1447,7 +1447,7 @@ return {
                     "A carta pontuada mais à esquerda da",
                     "{C:attention}primeira mão{} da rodada",
                     "se torna uma carta {C:attention}Pedra{}",
-                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:metal,s:0.8}Metálico{C:inactive,s:0.8})"
+                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:poke_metal,s:0.8}Metálico{C:inactive,s:0.8})"
                 } 
             },
             j_poke_drowzee = {
@@ -1523,7 +1523,7 @@ return {
             j_poke_cubone = {
                 name = 'Cubone',
                 text = {
-                    "{C:attention}Segurando {C:item}Clube Grosso{}",
+                    "{C:attention}Segurando {C:poke_item}Clube Grosso{}",
                     "Dá {C:mult}+#1#{} Mult para",
                     "cada {C:attention}consumível segurado{}",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}Clubes Grossos{C:inactive,s:0.8} contam como double){}",
@@ -1652,7 +1652,7 @@ return {
                     "Ganha {C:mult}+#2#{} Mult para cada {C:attention}6{} pontuado",
                     "Dobrado se um {C:attention}Rei{} estiver segurado na mão",
                     "{C:inactive}(Atualmente {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:dragon,s:0.8}Dragão{C:inactive,s:0.8})"
+                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:poke_dragon,s:0.8}Dragão{C:inactive,s:0.8})"
                 } 
             },
             j_poke_goldeen = {
@@ -1700,7 +1700,7 @@ return {
                     "Ganha {C:dark_edition}Foil{}, {C:dark_edition}Holográfico{} ou {C:dark_edition}Policromático{}",
                     "se era {C:rare}Raro{} ou superior",
                     "{C:inactive}(Atualmente {C:mult}+#1#{C:inactive} Mult)",
-                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:metal,s:0.8}Metálico{C:inactive,s:0.8} ou uma {C:attention,s:0.8}Pedra Dura{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolui com um adesivo {C:poke_metal,s:0.8}Metálico{C:inactive,s:0.8} ou uma {C:attention,s:0.8}Pedra Dura{C:inactive,s:0.8})",
                 } 
             },
             j_poke_jynx = {
@@ -1805,7 +1805,7 @@ return {
                 text = {
                     "{C:attention}Transforma-se{} no Coringa mais à esquerda",
                     "com {C:attention}Perishable{}",
-                    "e um adesivo {C:colorless}Incolor{}",
+                    "e um adesivo {C:poke_colorless}Incolor{}",
                     "no final da loja",
                     "{C:inactive,s:0.8}(Exclui Dittos)",
                 } 
@@ -1844,10 +1844,10 @@ return {
             j_poke_porygon = {
                 name = 'Porygon',
                 text = {
-                    "{C:pink}+1{} Limite de Energia",
-                    "Cria uma carta {C:pink}Energia{} quando",
+                    "{C:poke_pink}+1{} Limite de Energia",
+                    "Cria uma carta {C:poke_pink}Energia{} quando",
                     "qualquer {C:attention}Pacote de Reforço{} é aberto",
-                    "{C:inactive,s:0.8}(Evolui com uma {C:metal,s:0.8}Melhoria{C:inactive,s:0.8})",
+                    "{C:inactive,s:0.8}(Evolui com uma {C:poke_metal,s:0.8}Melhoria{C:inactive,s:0.8})",
                 } 
             },
             j_poke_omanyte = {
@@ -1856,7 +1856,7 @@ return {
                     "{C:attention}Antigo #1#s{}",
                     "{X:attention,C:white}1+{} : Cria uma carta {C:tarot}Tarot{}",
                     "{X:attention,C:white}2+{} : Ganhe {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Cria uma carta {C:item}Item{} {C:inactive,s:0.7}(Acione {C:attention,s:0.7}#3#{C:inactive,s:0.7} vezes para evoluir)",
+                    "{X:attention,C:white}3+{} : Cria uma carta {C:poke_item}Item{} {C:inactive,s:0.7}(Acione {C:attention,s:0.7}#3#{C:inactive,s:0.7} vezes para evoluir)",
                     "{C:inactive,s:0.8}(É necessário espaço)",
                 } 
             },
@@ -1866,7 +1866,7 @@ return {
                     "{C:attention}Antigo #1#s{}",
                     "{X:attention,C:white}1+{} : Cria uma carta {C:tarot}Tarot{}",
                     "{X:attention,C:white}2+{} : Ganhe {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : Cria uma carta {C:item}Item{}",
+                    "{X:attention,C:white}3+{} : Cria uma carta {C:poke_item}Item{}",
                     "{C:inactive,s:0.8}(É necessário espaço)",
                     "{X:attention,C:white}4+{} : Cria uma {C:attention}tag{} uma vez por rodada{C:inactive}#3#{}",
                 } 
@@ -1915,7 +1915,7 @@ return {
             j_poke_snorlax = {
                 name = 'Snorlax',
                 text = {
-                    "{C:attention}Segurando {C:item}Sobras{}",
+                    "{C:attention}Segurando {C:poke_item}Sobras{}",
                     "No final da rodada ganha {X:mult,C:white}X#1#{} Mult",
                     "para cada {C:attention}Sobras{} que você tem",
                     "{C:inactive}(Atualmente {X:mult,C:white} X#2# {C:inactive} Mult)"
@@ -1978,7 +1978,7 @@ return {
                 text = {
                     "Quando {C:attention}Blind Chefe{} é derrotado, cria uma",
                     "{C:dark_edition}Policromática{} {C:attention}cópia{} do Coringa mais à",
-                    "{C:attention}esquerda{} e {C:pink}Energiza{} a {C:attention}cópia{}",
+                    "{C:attention}esquerda{} e {C:poke_pink}Energiza{} a {C:attention}cópia{}",
                     "então destrói o Coringa mais à {C:attention}esquerda{}",
                     "{br:3}ERRO - CONTATE STEAK",
                     "Coringas {C:dark_edition}Policromáticos{} dão {X:mult,C:white} X#1# {} Mult",
@@ -1994,12 +1994,12 @@ return {
             j_poke_mega_mewtwo_y = {
                 name = "Mega Mewtwo Y",
                 text = {
-                    "{C:pink}Energiza{} o coringa mais à esquerda {C:attention}duas vezes{}",
+                    "{C:poke_pink}Energiza{} o coringa mais à esquerda {C:attention}duas vezes{}",
                     "no final da loja",
                     "{br:2}ERRO - CONTATE STEAK",
-                    "{C:pink}+1{} Limite de Energia quando",
+                    "{C:poke_pink}+1{} Limite de Energia quando",
                     "{C:attention}Blind Chefe{} é derrotado",
-                    "{C:inactive}(Não pode {C:pink}Energizar{C:inactive} a si mesmo)",
+                    "{C:inactive}(Não pode {C:poke_pink}Energizar{C:inactive} a si mesmo)",
                 } 
             },
             j_poke_mew = {
@@ -2007,7 +2007,7 @@ return {
                 text = {
                     "No final da {C:attention}loja{},",
                     "cria uma carta {C:dark_edition}Negativa{} {C:tarot}Tarot{},",
-                    "{C:spectral}Espectral{} ou {C:item}Item{}",
+                    "{C:spectral}Espectral{} ou {C:poke_item}Item{}",
                     "{br:3}ERRO - CONTATE STEAK",
                     "{C:green}#1#%{} chance de criar um",
                     "Coringa {C:dark_edition}Negativo{} {C:attention}em vez disso{}",
@@ -2193,8 +2193,8 @@ return {
                   "Dá {C:chips}+#1#{} Fichas e ganha {C:money}$#2#{}",
                   "se a mão de pontuação contiver um {C:attention}Par",
                   "{br:3}ERRO - CONTATE STEAK",
-                  "{C:chips}+#3#{} Fichas extra por Coringa {X:water,C:white}Água{}",
-                  "{C:money}$#4#{} extra por Coringa {X:lightning,C:black}Raio{}",
+                  "{C:chips}+#3#{} Fichas extra por Coringa {X:poke_water,C:white}Água{}",
+                  "{C:money}$#4#{} extra por Coringa {X:poke_lightning,C:black}Raio{}",
                   "{C:inactive}(Atualmente {C:chips}+#6#{C:inactive} Fichas e {C:money}$#5#{C:inactive})"
                 }
             },
@@ -2323,11 +2323,11 @@ return {
             j_poke_weird_tree = {
                 name = "Árvore Estranha",
                 text = {
-                  "{C:attention}Modificador de Tipo: {X:grass,C:white}Grama{}",
+                  "{C:attention}Modificador de Tipo: {X:poke_grass,C:white}Grama{}",
                   "{C:}Transforma-se{} no final da rodada",
                   "se este Coringa não for",
-                  "do tipo {X:grass,C:white}Grama{} ou você",
-                  "tiver um tipo {X:water,C:white}Água{}"
+                  "do tipo {X:poke_grass,C:white}Grama{} ou você",
+                  "tiver um tipo {X:poke_water,C:white}Água{}"
                 }
             },
             j_poke_bellossom = {
@@ -2346,7 +2346,7 @@ return {
                     "Cartas {V:1}#2#{} jogadas dão {C:mult}+#1#{} Mult quando pontuadas",
                     "{br:5}ERRO - CONTATE STEAK",
                     "Reativa cartas {V:1}#2#{} baseado em",
-                    "quantos Coringas {X:water,C:white}Água{} você tem",
+                    "quantos Coringas {X:poke_water,C:white}Água{} você tem",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{C:inactive,s:0.8} Reativação(ões) divididas igualmente entre cartas pontuadas){}",
                     "{s:0.8}Naipe cicla após pontuar {C:inactive,s:0.8}(#3#, #4#, #5#, #6#)",
                 } 
@@ -2457,7 +2457,7 @@ return {
               name = "Murkrow",
               text = {
                 "{X:mult,C:white} X#1# {} Mult para cada",
-                "Coringa {X:dark,C:white}Trevas{} que você tem",
+                "Coringa {X:poke_dark,C:white}Trevas{} que você tem",
                 "{C:inactive}(Atualmente {X:mult,C:white} X#2#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolui com uma {C:attention,s:0.8}Pedra do Crepúsculo{C:inactive,s:0.8})"
               }
@@ -2622,8 +2622,8 @@ return {
                 text = {
                   "Quando {C:attention}Blind{} é selecionada, destrói",
                   "o {C:attention}Consumível{} mais à esquerda e",
-                  "cria uma carta de {C:item}Suco de Baga{}",
-                  "{C:inactive}(Não pode destruir {C:item}Suco de Baga{C:inactive})"
+                  "cria uma carta de {C:poke_item}Suco de Baga{}",
+                  "{C:inactive}(Não pode destruir {C:poke_item}Suco de Baga{C:inactive})"
                 }
             },
             j_poke_sneasel = {
@@ -2647,7 +2647,7 @@ return {
               name = "Ursaring",
               text = {
                 "Ganha {C:mult}+#2#{} Mult e",
-                "cria um {C:item}Item{} quando qualquer",
+                "cria um {C:poke_item}Item{} quando qualquer",
                 "{C:attention}Pacote de Reforços{} é pulado {C:inactive,s:0.8}(Precisa ter espaço)",
                 "{C:inactive}(Atualmente {C:mult}+#1#{C:inactive} Mult)",
                 "{C:inactive,s:0.8}(Evolui com uma {C:attention,s:0.8}Pedra da Lua{C:inactive,s:0.8})",
@@ -2718,7 +2718,7 @@ return {
                 "{C:mult}+#1#{} Mult para cada carta {C:attention}Aprimorada{}",
                 "no seu baralho completo",
                 "{br:2}ERRO - CONTATE STEAK",
-                "Cria um Joker {C:attention}Básico{} {X:water,C:white}Água{} se a mão",
+                "Cria um Joker {C:attention}Básico{} {X:poke_water,C:white}Água{} se a mão",
                 "pontuada contiver {C:attention}5 cartas Aprimoradas{}",
                 "{C:inactive,s:0.8}(Precisa ter espaço)",
                 "{C:inactive}(Atualmente {C:mult}+#2#{C:inactive} Mult)",
@@ -2797,11 +2797,11 @@ return {
             j_poke_porygon2 = {
                 name = 'Porygon2',
                 text = {
-                    "{C:pink}+2{} Limite de Energia",
+                    "{C:poke_pink}+2{} Limite de Energia",
                     "Quando qualquer {C:attention}Pacote de Reforços{} é aberto",
-                    "cria uma carta de {C:pink}Energia{}",
-                    "do mesmo {C:pink}Tipo{} do Joker mais à esquerda",
-                    "{C:inactive,s:0.8}(Evolui com um {C:metal,s:0.8}Disco Dubioso{C:inactive,s:0.8})",
+                    "cria uma carta de {C:poke_pink}Energia{}",
+                    "do mesmo {C:poke_pink}Tipo{} do Joker mais à esquerda",
+                    "{C:inactive,s:0.8}(Evolui com um {C:poke_metal,s:0.8}Disco Dubioso{C:inactive,s:0.8})",
                 }
             },
             j_poke_stantler = {
@@ -2905,7 +2905,7 @@ return {
                 name = "Miltank",
                 text = {
                   "Ganhe {C:money}$#1#{} para cada",
-                  "Joker {C:colorless}Incolor{} que você tem",
+                  "Joker {C:poke_colorless}Incolor{} que você tem",
                   "no final da rodada",
                   "{C:inactive}(Atualmente {C:money}$#2#{C:inactive}){}"
                 }
@@ -3011,7 +3011,7 @@ return {
                     "{C:attention}+#3#{} tamanho de mão, {C:attention}Natureza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas têm",
                     "uma chance de {C:green}#4# em #5#{} de ganhar {C:money}$#1#{} quando pontuadas",
-                    "Garantido se você tiver outras cartas {X:grass,C:white}Grama{}",
+                    "Garantido se você tiver outras cartas {X:poke_grass,C:white}Grama{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive,s:0.8}(Evolui após ganhar {C:money,s:0.8}$#2#{C:inactive,s:0.8})",
                 }
@@ -3022,7 +3022,7 @@ return {
                     "{C:attention}+#3#{} tamanho de mão, {C:attention}Natureza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas têm",
                     "uma chance de {C:green}#4# em #5#{} de ganhar {C:money}$#1#{} quando pontuadas",
-                    "Garantido se você tiver outras cartas {X:grass,C:white}Grama{}",
+                    "Garantido se você tiver outras cartas {X:poke_grass,C:white}Grama{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive,s:0.8}(Evolui após ganhar {C:money,s:0.8}$#2#{C:inactive,s:0.8})",
                 }
@@ -3032,7 +3032,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} tamanho de mão, {C:attention}Natureza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas ganham {C:money}$#1#{}",
-                    "mais {C:money}$#5#{} para cada outra carta {X:grass,C:white}Grama{}",
+                    "mais {C:money}$#5#{} para cada outra carta {X:poke_grass,C:white}Grama{}",
                     "que você tem quando pontuadas",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive}(Atualmente {C:money}$#4#{C:inactive} total){}"
@@ -3043,7 +3043,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} descartes, {C:attention}Natureza: {C:inactive}({C:attention}#5#, #6#, #7#{C:inactive}){}",
                     "{C:mult}+#1#{} Mult para cada carta {C:attention}Natureza{} descartada nesta rodada",
-                    "Dobrado com outras cartas {X:fire,C:white}Fogo{} ou {X:earth,C:white}Lutador{}",
+                    "Dobrado com outras cartas {X:poke_fire,C:white}Fogo{} ou {X:poke_earth,C:white}Lutador{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive}(Atualmente {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolui após pontuar {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult)",
@@ -3054,7 +3054,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} descartes, {C:attention}Natureza: {C:inactive}({C:attention}#5#, #6#, #7#{C:inactive}){}",
                     "{C:mult}+#1#{} Mult para cada carta {C:attention}Natureza{} descartada nesta rodada",
-                    "Dobrado com outras cartas {X:fire,C:white}Fogo{} ou {X:earth,C:white}Lutador{}",
+                    "Dobrado com outras cartas {X:poke_fire,C:white}Fogo{} ou {X:poke_earth,C:white}Lutador{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive}(Atualmente {C:mult}+#4#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolui após pontuar {C:mult,s:0.8}#2#{C:inactive,s:0.8} Mult)",
@@ -3066,7 +3066,7 @@ return {
                     "{C:mult}+#2#{} descartes, {C:attention}Natureza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Para cada carta {C:attention}Natureza{} descartada nesta rodada",
                     "ganhe {C:mult}+#4#{} Mult e {X:mult,C:white}X#1#{} Mult para",
-                    "cada carta {X:fire,C:white}Fogo{} ou {X:earth,C:white}Lutador{} que você tem",
+                    "cada carta {X:poke_fire,C:white}Fogo{} ou {X:poke_earth,C:white}Lutador{} que você tem",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive}(Atualmente {C:mult}+#5#{C:inactive} Mult, {X:mult,C:white}X#3#{C:inactive} Mult){}",
                 }
@@ -3076,7 +3076,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} mãos, {C:attention}Natureza: {C:inactive}({C:attention}#4#, #5#, #6#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas dão {C:chips}+#1#{} Fichas",
-                    "Dobrado com outras cartas {X:water,C:white}Água{} ou {X:earth,C:white}Terrestre{}",
+                    "Dobrado com outras cartas {X:poke_water,C:white}Água{} ou {X:poke_earth,C:white}Terrestre{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive,s:0.8}(Evolui após ganhar {C:chips,s:0.8}#2#{C:inactive,s:0.8} Fichas)"
                 }
@@ -3086,7 +3086,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} mãos, {C:attention}Natureza: {C:inactive}({C:attention}#4#, #5#, #6#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas dão {C:chips}+#1#{} Fichas",
-                    "Dobrado com outras cartas {X:water,C:white}Água{} ou {X:earth,C:white}Terrestre{}",
+                    "Dobrado com outras cartas {X:poke_water,C:white}Água{} ou {X:poke_earth,C:white}Terrestre{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive,s:0.8}(Evolui após ganhar {C:chips,s:0.8}#2#{C:inactive,s:0.8} Fichas)"
                 }
@@ -3096,7 +3096,7 @@ return {
                 text = {
                     "{C:chips}+#3#{} mãos, {C:attention}Natureza: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "Cartas {C:attention}Natureza{} jogadas dão {C:chips}+#1#{} Fichas",
-                    "e {C:chips}+#5#{} Fichas por outra carta {X:water,C:white}Água{} ou {X:earth,C:white}Terrestre{}",
+                    "e {C:chips}+#5#{} Fichas por outra carta {X:poke_water,C:white}Água{} ou {X:poke_earth,C:white}Terrestre{}",
                     "{C:inactive,s:0.8}(inclui Jokers e cartas de Energia){}",
                     "{C:inactive}(Atualmente {C:chips}+#4#{C:inactive} total)"
                 }
@@ -3117,7 +3117,7 @@ return {
                 "{C:attention}carta de jogo{} é destruída",
                 "{br:2}ERRO - CONTATE STEAK",
                 "Ganho aumentado em {C:mult}+#3#{} Mult",
-                "para cada Joker {X:dark,C:white}Sombrio{} que você tem",
+                "para cada Joker {X:poke_dark,C:white}Sombrio{} que você tem",
                 "{C:inactive}(Atualmente {C:mult}+#1#{C:inactive} Mult)",
               }
             },
@@ -3125,7 +3125,7 @@ return {
               name = "Zigzagoon",
               text = {
                 "Chance de {C:green}#1# em #2#{} para criar um",
-                "{C:attention}Coleta{} {C:item}Item{} quando a mão é jogada",
+                "{C:attention}Coleta{} {C:poke_item}Item{} quando a mão é jogada",
                 "{C:inactive}(Precisa ter espaço)",
                 "{C:inactive,s:0.8}(Evolui após {C:attention}#3#{C:inactive,s:0.8} rodadas)",
               }
@@ -3134,7 +3134,7 @@ return {
               name = "Linoone",
               text = {
                 "Chance de {C:green}#1# em #2#{} para criar um",
-                "{C:attention}Coleta{} {C:item}Item{} quando a mão é jogada",
+                "{C:attention}Coleta{} {C:poke_item}Item{} quando a mão é jogada",
                 "Garantido se a mão",
                 "contiver um {C:attention}Sequência{}",
                 "{C:inactive}(Precisa ter espaço)"
@@ -3351,7 +3351,7 @@ return {
                 name = 'Jirachi',
                 text = {
                     "Copia a habilidade do {C:attention}Joker{} à direita",
-                    "como se estivesse {C:pink}Energizado{} uma vez extra",
+                    "como se estivesse {C:poke_pink}Energizado{} uma vez extra",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -3435,7 +3435,7 @@ return {
             j_poke_honchkrow = {
                 name = "Honchkrow",
                 text = {
-                  "Cada Joker {X:dark,C:white}Sombrio{} dá {X:mult,C:white}X#1#{} Mult",
+                  "Cada Joker {X:poke_dark,C:white}Sombrio{} dá {X:mult,C:white}X#1#{} Mult",
                 }
             },
             j_poke_bonsly = {
@@ -3471,7 +3471,7 @@ return {
                 name = 'Munchlax',
                 text = {
                     "{C:attention}Bebê{}, {X:mult,C:white} X#1# {} Mult",
-                    "Cria um {C:dark_edition}Negativo{C:item} Item",
+                    "Cria um {C:dark_edition}Negativo{C:poke_item} Item",
                     "no final da {C:attention}rodada",
                     "{C:inactive,s:0.8}(Evolui após {C:attention,s:0.8}#2#{C:inactive,s:0.8} rodadas)",
                 }
@@ -3500,7 +3500,7 @@ return {
                 text = {
                     "Cartas {C:attention}Aço{} jogadas dão {X:mult,C:white}X#1#{} Mult",
                     "mais {X:mult,C:white}X#2#{} Mult para cada",
-                    "Joker {X:metal,C:white}Metal{} que você tem",
+                    "Joker {X:poke_metal,C:white}Metal{} que você tem",
                     "{C:inactive}(Atualmente {X:mult,C:white}X#3#{C:inactive} Mult){}",
                 }
             },
@@ -3523,7 +3523,7 @@ return {
                     "{br:3}ERRO - CONTATE STEAK",
                     "Cartas {C:attention}Pedra{} reativam uma",
                     "vez adicional para cada",
-                    "{C:attention}3{} Jokers {X:earth,C:white}Terrestre{} que você tem",
+                    "{C:attention}3{} Jokers {X:poke_earth,C:white}Terrestre{} que você tem",
                     "{C:inactive}(Atualmente #2# reativações)"
                 }
             },
@@ -3623,12 +3623,12 @@ return {
             j_poke_porygonz = {
                 name = 'Porygon-Z',
                 text = {
-                    "{C:pink}+3{} Limite de Energia",
-                    "{X:mult,C:white} X#2# {} Mult por carta {C:pink}Energia{}",
+                    "{C:poke_pink}+3{} Limite de Energia",
+                    "{X:mult,C:white} X#2# {} Mult por carta {C:poke_pink}Energia{}",
                     "usada nesta {C:attention}partida{}",
                     "{br:2}texto precisa estar aqui para funcionar",
-                    "Cria uma {C:pink}Energia",
-                    "quando você usa uma {C:pink}Energia",
+                    "Cria uma {C:poke_pink}Energia",
+                    "quando você usa uma {C:poke_pink}Energia",
                     "{C:inactive}(Atualmente {X:mult,C:white} X#1# {C:inactive} Mult)"
                 }
             },
@@ -3646,7 +3646,7 @@ return {
                 text = {
                   "Pode ficar até {C:mult}-$#1#{} em dívida",
                   "{br:2.5}ERRO - CONTATE STEAK",
-                  "Cria uma carta de {C:item}Item{} se",
+                  "Cria uma carta de {C:poke_item}Item{} se",
                   "a mão for jogada enquanto estiver em dívida",
                   "{C:inactive,s:0.8}(Precisa ter espaço)",
                 }
@@ -3947,7 +3947,7 @@ return {
                 text = {
                     "{C:chips}+#1#{} Fichas se a mão jogada contiver um {C:attention}Flush{}",
                     "{br:2}ERRO - CONTATE STEAK",
-                    "Cria uma carta {C:pink}Energia{} se ela",
+                    "Cria uma carta {C:poke_pink}Energia{} se ela",
                     "também contiver um {C:attention}Rei{} ou {C:attention}Rainha{}"
                 }
             },
@@ -3965,7 +3965,7 @@ return {
                 text = {
                     "{C:mult}+#1#{} Mult",
                     "{C:attention}Triplicado{} se você tiver",
-                    "um Joker {X:lightning, C:black}Raio{}",
+                    "um Joker {X:poke_lightning, C:black}Raio{}",
                     "{C:inactive,s:0.8}(Evolui após {C:attention,s:0.8}#2#{C:inactive,s:0.8} rodadas)",
                 }
             },
@@ -3973,7 +3973,7 @@ return {
                 name = 'Charjabug',
                 text = {
                     "{C:mult}+#1#{} Mult para cada",
-                    "Joker {X:lightning, C:black}Raio{} que você tem",
+                    "Joker {X:poke_lightning, C:black}Raio{} que você tem",
                     "{C:inactive}(Atualmente {C:mult}+#2#{C:inactive} Mult)",
                     "{C:inactive,s:0.8}(Evolui com uma {C:attention,s:0.8}Pedra do Trovão{C:inactive,s:0.8})"
                 }
@@ -3983,7 +3983,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} Mult",
                     "{X:mult,C:white} X#1# {} Mult para cada outro",
-                    "Joker {X:lightning, C:black}Raio{} que você tem",
+                    "Joker {X:poke_lightning, C:black}Raio{} que você tem",
                     "{C:inactive}(Atualmente {X:mult,C:white} X#2# {C:inactive} Mult)",
                 }
             },
@@ -4121,7 +4121,7 @@ return {
               name = "Ursaluna",
               text = {
                 "Ganha {C:mult}+#2#{} Mult e cria",
-                "um {C:item}Item{} com {C:dark_edition}Policromado{} quando qualquer",
+                "um {C:poke_item}Item{} com {C:dark_edition}Policromado{} quando qualquer",
                 "{C:attention}Pacote de Reforços{} é pulado {C:inactive,s:0.8}(Precisa ter espaço)",
                 "{C:inactive}(Atualmente {C:mult}+#1#{C:inactive} Mult)",
               }
@@ -4153,7 +4153,7 @@ return {
                   "O {C:attention}rank{} necessário aumenta a cada ativação",
                   "{C:inactive,s:0.8}(Se o rank for o mais alto, ele se torna o mais baixo)",
                   "{C:inactive}(Atualmente {C:chips}+#1#{C:inactive} Fichas)",
-                  "{C:inactive,s:0.8}(Evolui quando você tem um Joker {X:fire,C:white,s:0.8}Fogo{C:inactive,s:0.8})",
+                  "{C:inactive,s:0.8}(Evolui quando você tem um Joker {X:poke_fire,C:white,s:0.8}Fogo{C:inactive,s:0.8})",
                 }
             },
             j_poke_dachsbun = {
@@ -4163,7 +4163,7 @@ return {
                   "O {C:attention}rank{} necessário aumenta a cada ativação",
                   "{br:4}ERRO - CONTATE STEAK",
                   "Aumenta o ganho de Fichas em {C:chips}+2{} para cada",
-                  "Joker {X:fire,C:white}Fogo{} que você tem",
+                  "Joker {X:poke_fire,C:white}Fogo{} que você tem",
                   "{C:inactive,s:0.8}(Se o rank for o mais alto, ele se torna o mais baixo)",
                   "{C:inactive}(Atualmente {C:chips}+#1#{C:inactive} Fichas)",
                 }
@@ -4295,7 +4295,7 @@ return {
                 name = 'Pokedex',
                 text = {
                     "{C:mult}+#2#{} Mult para cada Joker",
-                    "que você tem que tem um {C:pink}Tipo{}",
+                    "que você tem que tem um {C:poke_pink}Tipo{}",
                     "{br:3}ERRO - CONTATE STEAK",
                     "{C:attention}Pokémon{} da mesma",
                     "linha evolutiva podem aparecer",
@@ -4322,7 +4322,7 @@ return {
             j_poke_jelly_donut = {
                 name = "Rosquinha de Geléia",
                 text = {
-                  "Cria uma {C:colorless}Incolor {C:pink}Energia{}",
+                  "Cria uma {C:poke_colorless}Incolor {C:poke_pink}Energia{}",
                   "quando uma blind é selecionada",
                   "{C:inactive}({C:attention}#1#{C:inactive} rodadas restantes){}"
                 }
@@ -4353,8 +4353,8 @@ return {
                 text = {
                   "{C:attention}Modificador de Tipo{}",
                   "{br:2}ERRO - CONTATE STEAK",
-                  "Converte o {C:pink}tipo{} do Joker mais à esquerda",
-                  "no {C:pink}tipo{} do Joker mais à direita",
+                  "Converte o {C:poke_pink}tipo{} do Joker mais à esquerda",
+                  "no {C:poke_pink}tipo{} do Joker mais à direita",
                   "quando uma blind é selecionada",
                   "{C:inactive}({C:attention}#1#{C:inactive} rodadas restantes){}"
                 }
@@ -4388,14 +4388,14 @@ return {
                 text = {
                   "Eclode em um Joker {C:attention}Básico{} ou",
                   "{C:attention}Bebê{} após {C:attention}#1#{} rodadas",
-                  "que está {C:pink}Energizado{} se aplicável"
+                  "que está {C:poke_pink}Energizado{} se aplicável"
                 }
             },
             j_poke_billion_lions = {
                 name = 'Um Bilhão de Leões',
                 text = {
                     "Quando uma blind é selecionada",
-                    "destrói cada Joker {C:pink}tipado{} que você tem",
+                    "destrói cada Joker {C:poke_pink}tipado{} que você tem",
                     "então ganha {X:mult,C:white}X#2#{} Mult para cada",
                     "{S:1.1,C:red,E:2}autodestrói{} quando ficar sem leões",
                     "{C:inactive}(Atualmente {X:mult,C:white}X#1#{C:inactive} Mult, {C:attention}#3#{C:inactive} leões)"
@@ -4445,8 +4445,8 @@ return {
                 name = "Sleeve Luminosa",
                 text = {
                     "Todos os Jokers são criados",
-                    "com {C:pink}Tipos{} aleatórios",
-                    "e são {C:pink}Energizados{} uma vez",
+                    "com {C:poke_pink}Tipos{} aleatórios",
+                    "e são {C:poke_pink}Energizados{} uma vez",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -4455,7 +4455,7 @@ return {
                     "Comece a partida com o",
                     "voucher {C:tarot,T:v_crystal_ball}#1#{}",
                     "e {C:attention}2{} cópias",
-                    "de {C:item,T:c_poke_twisted_spoon}#2#"
+                    "de {C:poke_item,T:c_poke_twisted_spoon}#2#"
                 }
             },
             sleeve_poke_ampedsleeve = {
@@ -4464,7 +4464,7 @@ return {
                     "Comece a partida com o",
                     "voucher {C:tarot,T:v_poke_energysearch}#1#{}",
                     "e uma cópia de",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 }
             },
         },
@@ -4489,7 +4489,7 @@ return {
                 name = "Transformação",
                 text = {
                     "Evolui o Pokémon mais à esquerda ou selecionado para",
-                    "o {C:attention}estágio{} mais alto e o {C:pink}Energiza{}",
+                    "o {C:attention}estágio{} mais alto e o {C:poke_pink}Energiza{}",
                 },
             },
             c_poke_megastone = {
@@ -4506,30 +4506,30 @@ return {
             c_poke_obituary = {
                 name = "Obituário",
                 text = {
-                    "Adiciona um selo {C:pink}Rosa{}",
+                    "Adiciona um selo {C:poke_pink}Rosa{}",
                     "a {C:attention}1{} carta selecionada",
                 }
             },
             c_poke_nightmare = {
                 name = "Pesadelo",
                 text = {
-                    "Destrói o Joker selecionado com um {C:pink}Tipo{}",
-                    "e cria {C:attention}2{} {C:pink}Energias{} {C:dark_edition}Negativas{}",
-                    "do {C:pink}tipo{} daquele Joker"
+                    "Destrói o Joker selecionado com um {C:poke_pink}Tipo{}",
+                    "e cria {C:attention}2{} {C:poke_pink}Energias{} {C:dark_edition}Negativas{}",
+                    "do {C:poke_pink}tipo{} daquele Joker"
                 },
             },
             c_poke_revenant = {
                 name = "Revenante",
                 text = {
-                    "Adiciona um selo {C:item}Prata{}",
+                    "Adiciona um selo {C:poke_item}Prata{}",
                     "a {C:attention}1{} carta selecionada",
                 }
             },
             c_poke_double_rainbow_energy = {
                 name = "Energia Duplo Arco-Íris",
                 text = {
-                    "{C:pink}Energiza{} o Joker mais à esquerda ou",
-                    "selecionado de qualquer {C:pink}Tipo{} {C:red}d{C:attention}u{C:green}a{C:blue}s{C:purple} vezes{}",
+                    "{C:poke_pink}Energiza{} o Joker mais à esquerda ou",
+                    "selecionado de qualquer {C:poke_pink}Tipo{} {C:red}d{C:attention}u{C:green}a{C:blue}s{C:purple} vezes{}",
                     "Não ganhe juros esta rodada",
                     "{C:inactive}(Máx. de {C:attention}#1#{C:inactive} aumentos por Joker)",
                 },
@@ -4581,7 +4581,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "Tag de Bolso",
                 text = {
-                    "Dá um {C:pink}Pacote de Bolso Mega{} grátis",
+                    "Dá um {C:poke_pink}Pacote de Bolso Mega{} grátis",
                     "Chance de {C:green}#1#%{} do pacote conter",
                     "uma {C:attention}Pedra Mega{} no {C:attention}Ante 5+{}",
                     "{C:inactive,s:0.8}(Chances não podem ser aumentadas){}",
@@ -4592,7 +4592,7 @@ return {
                 text = {
                     "Próximo Joker de edição base",
                     "na loja é grátis e",
-                    "se torna {C:colorless}Shiny{}",
+                    "se torna {C:poke_colorless}Shiny{}",
                 },
             },
             tag_poke_stage_one_tag = {
@@ -4606,7 +4606,7 @@ return {
                 name = "Tag de Safari",
                 text = {
                     "A loja tem um",
-                    "Joker {C:safari}Safari{} grátis",
+                    "Joker {C:poke_safari}Safari{} grátis",
                 },
             },
         },
@@ -4632,13 +4632,13 @@ return {
             v_poke_energysearch = {
                 name = "Busca de Energia",
                 text = {
-                    "{C:pink}+2{} Limite de Energia"
+                    "{C:poke_pink}+2{} Limite de Energia"
                 },
             },
             v_poke_energyresearch = {
                 name = "Pesquisa de Energia",
                 text = {
-                    "{C:pink}+3{} Limite de Energia"
+                    "{C:poke_pink}+3{} Limite de Energia"
                 },
             },
             v_poke_goodrod = {
@@ -4651,7 +4651,7 @@ return {
             v_poke_superrod = {
                 name = "Super Vara",
                 text = {
-                    "Você pode {C:pink}Salvar{} cartas",
+                    "Você pode {C:poke_pink}Salvar{} cartas",
                     "de todos os pacotes {C:attention}consumíveis{}",
                 },
             },
@@ -4661,80 +4661,80 @@ return {
 			Grass = {
 				name = "Tipo",
 				text = {
-				  "{X:grass,C:white}Grama{}",
+				  "{X:poke_grass,C:white}Grama{}",
 				}
 			},
 			Fire = {
 				name = "Tipo",
 				text = {
-				  "{X:fire,C:white}Fogo{}",
+				  "{X:poke_fire,C:white}Fogo{}",
 				}
 			},
 			Water = {
 				name = "Tipo",
 				text = {
-				  "{X:water,C:white}Água{}",
+				  "{X:poke_water,C:white}Água{}",
 				}
 			},
 			Lightning = {
 				name = "Tipo",
 				text = {
-				  "{X:lightning,C:black}Elétrico{}",
+				  "{X:poke_lightning,C:black}Elétrico{}",
 				}
 			},
 			Psychic = {
 				name = "Tipo",
 				text = {
-				  "{X:psychic,C:white}Psíquico{}",
+				  "{X:poke_psychic,C:white}Psíquico{}",
 				}
 			},
 			Fighting = {
 				name = "Tipo",
 				text = {
-				  "{X:fighting,C:white}Lutador{}",
+				  "{X:poke_fighting,C:white}Lutador{}",
 				}
 			},
 			Colorless = {
 				name = "Tipo",
 				text = {
-				  "{X:colorless,C:white}Incolor{}",
+				  "{X:poke_colorless,C:white}Incolor{}",
 				}
 			},
 			Dark = {
 				name = "Tipo",
 				text = {
-				  "{X:dark,C:white}Sombrio{}",
+				  "{X:poke_dark,C:white}Sombrio{}",
 				}
 			},
 			Metal = {
 				name = "Tipo",
 				text = {
-				  "{X:metal,C:white}Metálico{}",
+				  "{X:poke_metal,C:white}Metálico{}",
 				}
 			},
 			Fairy = {
 				name = "Tipo",
 				text = {
-				  "{X:fairy,C:white}Fada{}",
+				  "{X:poke_fairy,C:white}Fada{}",
 				}
 			},
 			Dragon = {
 				name = "Tipo",
 				text = {
-				  "{X:dragon,C:white}Dragão{}",
+				  "{X:poke_dragon,C:white}Dragão{}",
 				}
 			},
 			Earth = {
 				name = "Tipo",
 				text = {
-				  "{X:earth,C:white}Terrestre{}",
+				  "{X:poke_earth,C:white}Terrestre{}",
 				}
 			},
 			--Have you Heard? Bird is the wordddd
 			Bird = {
 				name = "Tipo",
 				text = {
-				  "{X:bird,C:white}Pássaro{}",
+				  "{X:poke_bird,C:white}Pássaro{}",
 				}
 			},
 			--infoqueue used for things like kabuto and omanyte
@@ -4942,7 +4942,7 @@ return {
 				name = "Presentes",
 				text = {
 					"{C:green}35%{} - {C:money}$8{}",
-					"{C:green}30%{} - {C:item}Carta{} de {C:item}Item{}",
+					"{C:green}30%{} - {C:poke_item}Carta{} de {C:poke_item}Item{}",
 					"{C:green}20%{} - Etiqueta de {C:attention}Cupom{}",
 					"{C:green}15%{} - {C:dark_edition}Policromática{} {C:attention}Carta de Presente{}",
 				}
@@ -4950,10 +4950,10 @@ return {
 			pickup = {
 			  name = "Coletar",
 			  text = {
-				"{C:green}34%{} - {C:item}Item{}",
-				"{C:green}25%{} - {C:item}Item de Evolução{}",
-				"{C:green}20%{} - {C:item}Sobras{}",
-				"{C:green}20%{} - {C:item}Colher Torcida{}",
+				"{C:green}34%{} - {C:poke_item}Item{}",
+				"{C:green}25%{} - {C:poke_item}Item de Evolução{}",
+				"{C:green}20%{} - {C:poke_item}Sobras{}",
+				"{C:green}20%{} - {C:poke_item}Colher Torcida{}",
 				"{C:green}1%{} - {C:spectral}Transformação{}",
 			  }
 			},
@@ -4983,14 +4983,14 @@ return {
 			eeveelution = {
 				name = "Evoluções",
 				text = {
-					"{C:attention}Pedra da Água{} - {X:water,C:white}Vaporeon{}",
-					"{C:attention}Pedra do Trovão{} - {X:lightning,C:black}Jolteon{}",
-					"{C:attention}Pedra do Fogo{} - {X:fire,C:white}Flareon{}",
-					"{C:attention}Pedra do Sol{} - {X:psychic,C:white}Espeon{}",
-					"{C:attention}Pedra da Lua{} - {X:dark,C:white}Umbreon{}",
-					"{C:attention}Pedra da Folha{} - {X:grass,C:white}Leafeon{}",
-					"{C:attention}Pedra do Gelo{} - {X:water,C:white}Glaceon{}",
-					"{C:attention}Pedra Brilhante{} - {X:fairy,C:white}Sylveon{}"
+					"{C:attention}Pedra da Água{} - {X:poke_water,C:white}Vaporeon{}",
+					"{C:attention}Pedra do Trovão{} - {X:poke_lightning,C:black}Jolteon{}",
+					"{C:attention}Pedra do Fogo{} - {X:poke_fire,C:white}Flareon{}",
+					"{C:attention}Pedra do Sol{} - {X:poke_psychic,C:white}Espeon{}",
+					"{C:attention}Pedra da Lua{} - {X:poke_dark,C:white}Umbreon{}",
+					"{C:attention}Pedra da Folha{} - {X:poke_grass,C:white}Leafeon{}",
+					"{C:attention}Pedra do Gelo{} - {X:poke_water,C:white}Glaceon{}",
+					"{C:attention}Pedra Brilhante{} - {X:poke_fairy,C:white}Sylveon{}"
 				}
 			},
 			poke_egg_tip = {
@@ -5052,14 +5052,14 @@ return {
 			unlimited_energy_tooltip = {
 			  name = "Energia Ilimitada",
 			  text = {
-				"Curingas podem ter {C:pink}Energia{} usada",
+				"Curingas podem ter {C:poke_pink}Energia{} usada",
 				"neles qualquer número de vezes"
 			  }
 			},
 			precise_energy_tooltip = {
 				name = "Escala de Energia Precisão",
 				text = {
-					"{s:0.8}Usa {C:attention,s:0.8}decimais{} para todos os valores ao aplicar bônus de {C:pink,s:0.8}Energia{}{s:0.8}",
+					"{s:0.8}Usa {C:attention,s:0.8}decimais{} para todos os valores ao aplicar bônus de {C:poke_pink,s:0.8}Energia{}{s:0.8}",
 					"{s:0.8}Com esta opção {C:attention,s:0.8}desligada{}{s:0.8} o seguinte ocorrerá para o bônus:{}",
 					"{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Mult - Usa Decimais",
 					"{C:attenion}2. {s:0.8}{C:mult,s:0.8}Mult{} Fixo{s:0.8} e {C:chips,s:0.8}Fichas{s:0.8} - Arredonda para o número inteiro mais próximo",
@@ -5215,7 +5215,7 @@ return {
 			allowpokeballs_tooltip = {
 			  name = "Permitir Pokébolas",
 			  text = {
-				"Permite que {C:item}itens{} de Pokébola apareçam",
+				"Permite que {C:poke_item}itens{} de Pokébola apareçam",
 			  }
 			},
 			pokemaster_tooltip = {
@@ -5269,7 +5269,7 @@ return {
 			poke_pink_seal_seal = {
 				name = "Selo Rosa",
 				text = {
-					"Cria uma carta de {C:pink}Energia{}",
+					"Cria uma carta de {C:poke_pink}Energia{}",
 					"correspondente ao {C:attention}tipo{} de um Curinga possuído",
 					"se ele pontuar na",
 					"{C:attention}primeira mão{} da rodada",
@@ -5281,7 +5281,7 @@ return {
 			poke_silver_seal = {
 				name = "Selo Prateado",
 				text = {
-				  "Cria uma carta de {C:item}Item{}",
+				  "Cria uma carta de {C:poke_item}Item{}",
 				  "e é {C:attention}descartada{} se {C:attention}segurada{}",
 				  "na mão quando as cartas são pontuadas"
 				}
@@ -5290,73 +5290,73 @@ return {
 			grass_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:grass,C:white}Grama{}"
+					"{X:poke_grass,C:white}Grama{}"
 				}
 			},
 			fire_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:fire,C:white}Fogo{}"
+					"{X:poke_fire,C:white}Fogo{}"
 				}
 			},
 			water_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:water,C:white}Água{}"
+					"{X:poke_water,C:white}Água{}"
 				}
 			},
 			lightning_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:lightning,C:white}Elétrico{}"
+					"{X:poke_lightning,C:white}Elétrico{}"
 				}
 			},
 			psychic_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:psychic,C:white}Psíquico{}"
+					"{X:poke_psychic,C:white}Psíquico{}"
 				}
 			},
 			fighting_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:fighting,C:white}Lutador{}"
+					"{X:poke_fighting,C:white}Lutador{}"
 				}
 			},
 			colorless_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:colorless,C:white}Incolor{}"
+					"{X:poke_colorless,C:white}Incolor{}"
 				}
 			},
 			dark_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:dark,C:white}Sombrio{}"
+					"{X:poke_dark,C:white}Sombrio{}"
 				}
 			},
 			metal_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:metal,C:white}Metálico{}"
+					"{X:poke_metal,C:white}Metálico{}"
 				}
 			},
 			fairy_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:fairy,C:white}Fada{}"
+					"{X:poke_fairy,C:white}Fada{}"
 				}
 			},
 			dragon_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:dragon,C:white}Dragão{}"
+					"{X:poke_dragon,C:white}Dragão{}"
 				}
 			},
 			earth_sticker = {
 				name = "Tipo",
 				text = {
-					"{X:earth,C:white}Terrestre{}"
+					"{X:poke_earth,C:white}Terrestre{}"
 				}
 			},
 			--]]
@@ -5384,64 +5384,64 @@ return {
 				name = "Pacote de Bolso",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_normal_2 = {
 				name = "Pacote de Bolso",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_jumbo_1 = {
 				name = "Pacote de Bolso Jumbo",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_mega_1 = {
 				name = "Pacote de Bolso Mega",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_normal_3 = {
 				name = "Pacote de Bolso",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_normal_4 = {
 				name = "Pacote de Bolso",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_jumbo_2 = {
 				name = "Pacote de Bolso Jumbo",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_mega_2 = {
 				name = "Pacote de Bolso Mega",
 				text = {
 					"Escolha {C:attention}#1#{} entre",
-					"{C:attention}#2#{} Cartas de {C:item}Item{} e",
-					"{C:attention}#3#{} Carta de {C:pink}Energia{}",
+					"{C:attention}#2#{} Cartas de {C:poke_item}Item{} e",
+					"{C:attention}#3#{} Carta de {C:poke_pink}Energia{}",
 				},
 			},
 			p_poke_pokepack_wish_pack = {

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -47,8 +47,8 @@ return {
                 name = "Самоцветная колода",
                 text = {
                     "ВСЕ Покемоны создаются",
-                    "со случайным {C:pink}типом{}",
-                    "и {C:attention}+1{} {C:pink}энергией{}"
+                    "со случайным {C:poke_pink}типом{}",
+                    "и {C:attention}+1{} {C:poke_pink}энергией{}"
                 }
             },
         },
@@ -162,15 +162,15 @@ return {
                 name = "Tera Orb",
                 text = {
                     "Даёт случайный",
-                    "стикер {C:pink}типа{}",
+                    "стикер {C:poke_pink}типа{}",
                     "самому левому Джокеру{}", 
-                    "и {C:attention}+1{} {C:pink}Энергию{}"
+                    "и {C:attention}+1{} {C:poke_pink}Энергию{}"
                 },
             },
             c_poke_metalcoat = {
                 name = "Металлический плащ",
                 text = {
-                    "Даёт {C:metal}Металлический{} стикер",
+                    "Даёт {C:poke_metal}Металлический{} стикер",
                     "Самому левому Джокеру",
                     "Создаёт карту {C:attention}Колесница{}",
                     "{C:inactive}(Должно быть место){}"
@@ -179,7 +179,7 @@ return {
             c_poke_dragonscale = {
                 name = "Чешуя Дракона",
                 text = {
-                    "Даёт {C:dragon}Драконий{} стикер",
+                    "Даёт {C:poke_dragon}Драконий{} стикер",
                     "самому левому Джокеру",
                     "Создаёт карту {C:attention}Император{}",
                     "{C:inactive}(Должно быть место){}"
@@ -232,8 +232,8 @@ return {
                 text = {
                     "Создаёт последнюю",
                     "использованную вами карту",
-                    "{C:item}Предмета{} или {C:pink}Энергии{}",
-                    "Кроме {s:0.8,C:item}Согнутой Ложки{s:0.8}"
+                    "{C:poke_item}Предмета{} или {C:poke_pink}Энергии{}",
+                    "Кроме {s:0.8,C:poke_item}Согнутой Ложки{s:0.8}"
                 }
             },
         },
@@ -952,7 +952,7 @@ return {
                 name = "Кадабра",
                 text = {
                     "{C:green}#1# из #2#{} шанс",
-                    "создать карту {C:attention}Дурак{} или {C:item}Согнутая Ложка{},",
+                    "создать карту {C:attention}Дурак{} или {C:poke_item}Согнутая Ложка{},",
                     "если сыгранная {C:attention}покерная рука{}",
                     "уже игралась в этом раунде",
                     "{C:inactive}(Эволюционирует с картой{} {C:attention}Шнур Связи{}{C:inactive})"
@@ -963,7 +963,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} слот расходуемого",
                     "{C:green}#1# из #2#{} шанс",
-                    "создать карту {C:attention}Дурак{} или {C:item}Согнутая Ложка{},",
+                    "создать карту {C:attention}Дурак{} или {C:poke_item}Согнутая Ложка{},",
                     "если сыгранная {C:attention}покерная рука {}",
                     "уже игралась в этом раунде",
                 } 
@@ -1116,7 +1116,7 @@ return {
                 text = {
                     "Сыгранные {C:attention}стальные{} карты дают {X:red,C:white}X#1#{} множ.",
                     "и {X:red,C:white}X#2#{} множ. за каждого",
-                    "{X:metal,C:white}Металлического{} Джокера рядом с этим Джокером",
+                    "{X:poke_metal,C:white}Металлического{} Джокера рядом с этим Джокером",
                     "{C:inactive}(Сейчас: {X:red,C:white}X#3#{}{C:inactive} множ.){}",
                     "{C:inactive}(Эволюционирует с картой {C:attention}Камень Молнии{}{C:inactive})"
                 } 
@@ -1242,7 +1242,7 @@ return {
                     "Самая левая карта в",
                     "{C:attention}первой руке{} раунда",
                     "становится {C:attention}каменной{} при подсчёте",
-                    "{C:inactive}(Эволюционирует, получив {C:metal}Металлический{} {C:inactive}стикер){}"
+                    "{C:inactive}(Эволюционирует, получив {C:poke_metal}Металлический{} {C:inactive}стикер){}"
                 } 
             },
             j_poke_drowzee = {
@@ -1447,7 +1447,7 @@ return {
                     "Это значение удваивается, если в руке",
                     "есть {C:attention}Король{}",
                     "{C:inactive}(Сейчас: {C:mult}+#1#{C:inactive} множ.)",
-                    "{C:inactive}(Эволюционирует, получив {C:dragon}Драконий{} {C:inactive}стикер){}"
+                    "{C:inactive}(Эволюционирует, получив {C:poke_dragon}Драконий{} {C:inactive}стикер){}"
                 } 
             },
             j_poke_goldeen = {
@@ -1497,7 +1497,7 @@ return {
                     "джокера справа и получает {C:mult}+#2#{} к множ.",
                     "Получает {C:attention}Фольговый{}, {C:attention}Голографический{}, или {C:attention}Полихромный{}",
                     "выпуск, если Джокер был {C:red}Редким{} или выше",
-                    "{C:inactive}(Эволюционирует, получив {C:metal}Металлический{} {C:inactive}стикер){}",
+                    "{C:inactive}(Эволюционирует, получив {C:poke_metal}Металлический{} {C:inactive}стикер){}",
                     "{C:inactive}(Сейчас: {C:mult}+#1#{C:inactive} множ.)"
                 } 
             },
@@ -1623,8 +1623,8 @@ return {
             j_poke_porygon = {
                 name = 'Поригон',
                 text = {
-                    "{C:pink}+1{} к лимиту Энергии",
-                    "Создаёт карту {C:pink}Энергии{}",
+                    "{C:poke_pink}+1{} к лимиту Энергии",
+                    "Создаёт карту {C:poke_pink}Энергии{}",
                     "когда открывается любой",
                     "{C:attention}Набор{}",
                     "{C:inactive}(Эволюционирует с картой{} {C:attention}Улучшение{}{C:inactive})"
@@ -1648,7 +1648,7 @@ return {
                     "{X:attention,C:white}1{} : Получает {C:money}$#2#{} к стоимости продажи",
                     "{X:attention,C:white}2{} : Получите {C:money}$#3#{}",
                     "{X:attention,C:white}3{} : Создаёт случайную карту {C:attention}Таро{}",
-                    "{X:attention,C:white}4+{} : Создаёт случайную карту {C:item}Предмета{}",
+                    "{X:attention,C:white}4+{} : Создаёт случайную карту {C:poke_item}Предмета{}",
                     "{C:inactive}(Должно быть место){}"
                 } 
             },
@@ -1751,7 +1751,7 @@ return {
                 text = {
                     "В конце магазина создайте",
                     "{C:dark_edition}полихромную{} {C:attention}копию{}",
-                    "самого левого {C:attention}Джокера{} с {C:attention}+1{} {C:pink}энергией{},",
+                    "самого левого {C:attention}Джокера{} с {C:attention}+1{} {C:poke_pink}энергией{},",
                     "а затем уничтожьте самого левого {C:attention}Джокера{}",
                     "{C:dark_edition}Полихромные{} Джокеры дают {X:mult,C:white} X#1# {} множ.",
                     "{C:inactive}(Не может уничтожить себя)",
@@ -1762,7 +1762,7 @@ return {
                 text = {
                     "В конце магазина создаёт",
                     "случайную {C:dark_edition}негативную{} карту {C:attention}Таро{},",
-                    "{C:spectral}спектральную{} карту или карту {C:item}предмета{}",
+                    "{C:spectral}спектральную{} карту или карту {C:poke_item}предмета{}",
                     "Иногда создаёт случайного",
                     "{C:dark_edition}негативного{} Джокера {C:attention}вместо этого{}",
                 } 
@@ -1842,7 +1842,7 @@ return {
                     "Сыгранные карты с мастью {V:1}#2#{} дают",
                     "{C:mult}+#1#{} множ. при подсчёте",
                     "Эти карты повторяются ещё раз за каждого",
-                    "{X:water,C:white}Водного{} Джокера у вас",
+                    "{X:poke_water,C:white}Водного{} Джокера у вас",
                     "{C:inactive,s:0.8}({C:attention,s:0.8}#7#{}{C:inactive,s:0.8} повторов разделяются поровну между сыгранными картами){}",
                     "Масть меняется в строгом порядке {C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
                 } 
@@ -1929,9 +1929,9 @@ return {
             j_poke_porygon2 = {
                 name = 'Поригон2',
                 text = {
-                    "{C:pink}+2{} к лимиту Энергии",
-                    "Создайте карту {C:pink}Энергии{}",
-                    "соответствующей {C:pink}Типу{}",
+                    "{C:poke_pink}+2{} к лимиту Энергии",
+                    "Создайте карту {C:poke_pink}Энергии{}",
+                    "соответствующей {C:poke_pink}Типу{}",
                     "самого левого Джокера, когда",
                     "открывается любой {C:attention}Набор{}",
                     "{C:inactive}(Эволюционирует с картой{} {C:attention}Улучшение{}{C:inactive})"
@@ -2014,7 +2014,7 @@ return {
                     "{C:attention}+#3#{} размер руки, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#6#, #7# или #8#{} с шансом",
                     "{C:green}#4# из #5#{} дают {C:money}$#1#{}",
-                    "Шанс гарантирован, если у вас есть другие {X:grass,C:white}Травяные{} карты",
+                    "Шанс гарантирован, если у вас есть другие {X:poke_grass,C:white}Травяные{} карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Эволюционирует, накопив {C:money}$#2#/16{})"
                 } 
@@ -2025,7 +2025,7 @@ return {
                     "{C:attention}+#3#{} размер руки, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#6#, #7# or #8#{} с шансом",
                     "{C:green}#4# из #5#{} дают {C:money}$#1#{}",
-                    "Шанс гарантирован, если у вас есть другие {X:grass,C:white}Травяные{} карты",
+                    "Шанс гарантирован, если у вас есть другие {X:poke_grass,C:white}Травяные{} карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Эволюционирует, накопив {C:money}$#2#/32{})"
                 } 
@@ -2036,7 +2036,7 @@ return {
                     "{C:attention}+#3#{} размер руки, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#5#, #6# или #7#{} дают {C:money}$#1#{}",
                     "Получайте {C:money}$#1#{} в конце раунда за",
-                    "каждую другую {X:grass,C:white}Травяную{} карту у вас",
+                    "каждую другую {X:poke_grass,C:white}Травяную{} карту у вас",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Сейчас: {C:money}$#4#{}, макс. {C:money}$14{}{C:inactive}){}"
                 } 
@@ -2046,7 +2046,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} сброс, {C:attention}Природа{}",
                     "{C:mult}+#1#{} множ. за каждые {C:attention}#5#, #6# или #7#{} сброшенные в этом раунде",
-                    "Множ. удваивается, если у вас есть другие {X:fire,C:white}Огненные{} или {X:earth,C:white}Боевые{} карты",
+                    "Множ. удваивается, если у вас есть другие {X:poke_fire,C:white}Огненные{} или {X:poke_earth,C:white}Боевые{} карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Сейчас: {C:mult}#4#{}{C:inactive} множ.){}",
                     "{C:inactive}(Эволюционирует, подсчитав {C:mult}#2#/60{} {C:inactive}множ.)"
@@ -2057,7 +2057,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} сброс, {C:attention}Природа{}",
                     "{C:mult}+#1#{} множ. за каждые {C:attention}#5#, #6# или #7#{} сброшенные в этом раунде",
-                    "Множ. удваивается, если у вас есть другие {X:fire,C:white}Огненные{} или {X:earth,C:white}Боевые{} карты",
+                    "Множ. удваивается, если у вас есть другие {X:poke_fire,C:white}Огненные{} или {X:poke_earth,C:white}Боевые{} карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Сейчас: {C:mult}#4#{}{C:inactive} множ.){}",
                     "{C:inactive}(Эволюционирует, подсчитав {C:mult}#2#/150{} {C:inactive}множ.)"
@@ -2069,7 +2069,7 @@ return {
                     "{C:mult}+#2#{} сброс, {C:attention}Природа{}",
                     "{C:mult}+#4#{} множ., {X:red,C:white} X#1# {} множ. за каждую {C:attention}#6#, #7# or #8#{}",
                     "сброшенную в этом раунде. {X:red,C:white} X {} Множ. удваивается,",
-                    "если у вас есть другие {X:fire,C:white}Огненные{} или {X:earth,C:white}Боевые{} карты",
+                    "если у вас есть другие {X:poke_fire,C:white}Огненные{} или {X:poke_earth,C:white}Боевые{} карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Сейчас: {C:mult}+#5#{}{C:inactive} множ., {X:red,C:white} X#3# {}{C:inactive} множ.){}",
                 } 
@@ -2080,7 +2080,7 @@ return {
                     "{C:chips}+#3#{} рука, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#4#, #5# или #6#{} дают {C:chips}+#1#{} шт. фишек",
                     "Значение фишек удваивается, если у вас есть",
-                    "другие {X:water,C:white}Водные{} или {X:earth,C:white}Земляные{}карты",
+                    "другие {X:poke_water,C:white}Водные{} или {X:poke_earth,C:white}Земляные{}карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Эволюционирует, подсчитав {C:chips}#2#/400{} {C:inactive}шт. фишек)"
                 } 
@@ -2091,7 +2091,7 @@ return {
                     "{C:chips}+#3#{} рука, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#4#, #5# или #6#{} дают {C:chips}+#1#{} шт. фишек",
                     "Значение фишек удваивается, если у вас есть",
-                    "другие {X:water,C:white}Водные{} или {X:earth,C:white}Земляные{}карты",
+                    "другие {X:poke_water,C:white}Водные{} или {X:poke_earth,C:white}Земляные{}карты",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Эволюционирует, подсчитав {C:chips}#2#/960{} {C:inactive}шт. фишек)"
                 } 
@@ -2102,7 +2102,7 @@ return {
                     "{C:chips}+#3#{} рука, {C:attention}Природа{}",
                     "Сыгранные {C:attention}#5#, #6# или #7#{} дают {C:chips}+#1#{} шт. фишек",
                     "Дают ещё {C:chips}+#5#{} шт. фишек за каждую",
-                    "другую {X:water,C:white}Водную{} или {X:earth,C:white}Земляную{} карту",
+                    "другую {X:poke_water,C:white}Водную{} или {X:poke_earth,C:white}Земляную{} карту",
                     "{C:inactive,s:0.8}(Включая карты Джокеров и Энергии){}",
                     "{C:inactive}(Сейчас: {C:chips}+#4#{}{C:inactive} в общем)"
                 } 
@@ -2183,7 +2183,7 @@ return {
                 text = {
                     "{C:attention}Малыш{}",
                     "Создайте случайную {C:dark_edition}негативную{}",
-                    "карту {C:item}Предмета{} в конце раунда",
+                    "карту {C:poke_item}Предмета{} в конце раунда",
                     "{X:red,C:white} X#1# {} множ.",
                     "{C:inactive}(Да, он {C:attention}уменьшает{C:inactive} ваш множ.)",
                     "{C:inactive}(Эволюционирует после {C:attention}#2#{}{C:inactive} раундов)"
@@ -2205,7 +2205,7 @@ return {
                 text = {
                     "Сыгранные {C:attention}стальные{} карты дают {X:red,C:white}X#1#{} множ.",
                     "и {X:red,C:white}X#2#{} множ. за каждого",
-                    "{X:metal,C:white}Металлического{} Джокера у вас",
+                    "{X:poke_metal,C:white}Металлического{} Джокера у вас",
                     "{C:inactive}(Сейчас: {X:red,C:white}X#3#{}{C:inactive} множ.){}",
                 } 
             },
@@ -2225,7 +2225,7 @@ return {
                     "навсегда получает",
                     "{C:chips}+#1#{} шт. фишек при подсчёте",
                     "{C:attention}Каменные{} карты повторяются ещё раз за каждого",
-                    "{X:earth,C:white}Земляного{} Джокера у вас",
+                    "{X:poke_earth,C:white}Земляного{} Джокера у вас",
                     "{C:inactive}(Сейчас #2# повторений)"
                 } 
             },
@@ -2284,10 +2284,10 @@ return {
             j_poke_porygonz = {
                 name = 'Поригон-Z',
                 text = {
-                    "{C:pink}+3{} к Лимиту Энергии",
+                    "{C:poke_pink}+3{} к Лимиту Энергии",
                     "Этот Джокер получает",
                     "{X:red,C:white} X#2# {} к множ. за каждую использованную",
-                    "карту {C:pink}Энергии{} в этом {C:attention}забеге{}",
+                    "карту {C:poke_pink}Энергии{} в этом {C:attention}забеге{}",
                     "{C:inactive}(Сейчас: {X:red,C:white} X#1# {}{C:inactive} множ.)"
                 } 
             },
@@ -2328,7 +2328,7 @@ return {
                     "{C:mult}+#1#{} множ.",
                     "Это значение вырастает в {C:attention} 3 раза{},",
                     "если у вас есть",
-                    "{X:lightning, C:black}Электрический{} Джокер",
+                    "{X:poke_lightning, C:black}Электрический{} Джокер",
                     "{C:inactive}(Эволюционирует после {C:attention}#2#{}{C:inactive} раундов)"
                 }  
             },
@@ -2336,7 +2336,7 @@ return {
                 name = 'Чарджабаг',
                 text = {
                     "{C:mult}+#1#{} множ.",
-                    "за каждого {X:lightning, C:black}Электрического{} Джокера",
+                    "за каждого {X:poke_lightning, C:black}Электрического{} Джокера",
                     "у вас {C:inactive}(включая себя){}",
                      "{C:inactive}(Сейчас: {C:mult}#2#{C:inactive} множ.)",
                     "{C:inactive}(Эволюционирует с картой{} {C:attention}Камень Молнии{}{C:inactive})"
@@ -2347,7 +2347,7 @@ return {
                 text = {
                     "{C:mult}+#3#{} множ.",
                     "{X:red,C:white} X#1# {} множ. за каждого",
-                    "другого {X:lightning, C:black}Электрического{} Джокера",
+                    "другого {X:poke_lightning, C:black}Электрического{} Джокера",
                     "у вас{}",
                      "{C:inactive}(Сейчас: {X:red,C:white} X#2# {}{C:inactive} множ.)",
                 }  
@@ -2417,7 +2417,7 @@ return {
                   "Требуемое {C:attention}значение{} повышается с каждым срабатыванием",
                   "{C:inactive,s:0.8}(Если значение было наивысшим, оно становится самым низким)",
                   "{C:inactive}(Сейчас: {C:chips}+#1#{C:inactive} шт. фишек)",
-                  "{C:inactive}(Эволюционирует, если у вас есть {X:fire,C:white}Огненный{}{C:inactive} Джокер)",
+                  "{C:inactive}(Эволюционирует, если у вас есть {X:poke_fire,C:white}Огненный{}{C:inactive} Джокер)",
                 }
             },
             j_poke_dachsbun = {
@@ -2426,7 +2426,7 @@ return {
                   "Получает {C:chips}+#2#{} шт. фишек, если сыгранная рука содержит {C:attention}#3#{}",
                   "Требуемое {C:attention}значение{} повышается с каждым срабатыванием",
                   "Получаемые фишки увеличиваются на {C:chips}+1{} за",
-                  "каждого {X:fire,C:white}Огненного{} Джокера у вас",
+                  "каждого {X:poke_fire,C:white}Огненного{} Джокера у вас",
                   "{C:inactive,s:0.8}(Если значение было наивысшим, оно становится самым низким)",
                   "{C:inactive}(Сейчас: {C:chips}+#1#{C:inactive} шт.фишек)",
                 }
@@ -2483,7 +2483,7 @@ return {
                 name = 'Покедекс',
                 text = {
                     "{C:mult}+#2#{} множ. за каждого",
-                    "Джокера с {C:pink}Типом{}",
+                    "Джокера с {C:poke_pink}Типом{}",
                     "{C:attention}Покемоны{} могут появляться",
                     "многократно",
                     "{C:inactive}(Сейчас: {C:mult}+#1#{C:inactive} множ.)"
@@ -2509,8 +2509,8 @@ return {
             j_poke_jelly_donut = {
                 name = "Мармеладный Пончик",
                 text = {
-                  "Создайте карту {C:colorless}Бесцветной",
-                  "{C:pink}Энергии{}, когда выбирается",
+                  "Создайте карту {C:poke_colorless}Бесцветной",
+                  "{C:poke_pink}Энергии{}, когда выбирается",
                   "блайнд",
                   "{C:inactive}({C:attention}#1#{}{C:inactive} раунда){}"
                 }
@@ -2539,7 +2539,7 @@ return {
                 name = "Luminous Sleeve",
                 text = {
                     "All Jokers are created",
-                    "with random {C:pink}Type{} stickers",
+                    "with random {C:poke_pink}Type{} stickers",
                 },
             },
         },
@@ -2573,7 +2573,7 @@ return {
             c_poke_obituary = {
                 name = "Обряд",
                 text = {
-                    "Добавляет {C:pink}розовую{} печать",
+                    "Добавляет {C:poke_pink}розовую{} печать",
                     "{C:attention}1{} выбранной карте",
                 }
             },
@@ -2582,13 +2582,13 @@ return {
                 text = {
                     "Уничтожает случайного Джокера",
                     "Покемона и создаёт {C:attention}3{}",
-                    "случайные {C:dark_edition}Негативные{} карты {C:pink}Энергии{}"
+                    "случайные {C:dark_edition}Негативные{} карты {C:poke_pink}Энергии{}"
                 },
             },
             c_poke_revenant = {
                 name = "Ревенант",
                 text = {
-                    "Добавляет {C:item}серебряную{} печать",
+                    "Добавляет {C:poke_item}серебряную{} печать",
                     "к {C:attention}1{} выбранной карте",
                 }
             },
@@ -2598,7 +2598,7 @@ return {
                 name = "Поке тэг",
                 text = {
                     "Даёт бесплатный",
-                    "{C:pink}Мега Поке набор",
+                    "{C:poke_pink}Мега Поке набор",
                 }, 
             },
             tag_poke_shiny_tag = {
@@ -2606,7 +2606,7 @@ return {
                 text = {
                     "Следующий Джокер базового выпуска",
                     "из магазина бесплатен",
-                    "и становится {C:colorless}Блестящим{}",
+                    "и становится {C:poke_colorless}Блестящим{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -2620,7 +2620,7 @@ return {
                 name = "Тэг Сафари",
                 text = {
                     "В магазине есть бесплатный",
-                    "{C:safari}Сафари{} Джокер",
+                    "{C:poke_safari}Сафари{} Джокер",
 
                 }, 
             },
@@ -2632,13 +2632,13 @@ return {
             v_poke_energysearch = {
                 name = "Поиск Энергии",
                 text = {
-                    "{C:pink}+2{} к лимиту энергии"
+                    "{C:poke_pink}+2{} к лимиту энергии"
                 },
             },
             v_poke_energyresearch = {
                 name = "Технология Энергии",
                 text = {
-                    "{C:pink}+3{} к лимиту энергии"
+                    "{C:poke_pink}+3{} к лимиту энергии"
                 },
             },
             v_poke_goodrod = {
@@ -2661,79 +2661,79 @@ return {
             Grass = {
                 name = "Тип",
                 text = {
-                  "{X:grass,C:white}Травяной{}",
+                  "{X:poke_grass,C:white}Травяной{}",
                 }
             },
             Fire = {
                 name = "Тип",
                 text = {
-                  "{X:fire,C:white}Огненный{}",
+                  "{X:poke_fire,C:white}Огненный{}",
                 }
             },
             Water = {
                 name = "Тип",
                 text = {
-                  "{X:water,C:white}Водный{}",
+                  "{X:poke_water,C:white}Водный{}",
                 }
             },
             Lightning = {
                 name = "Тип",
                 text = {
-                  "{X:lightning,C:black}Электрический{}",
+                  "{X:poke_lightning,C:black}Электрический{}",
                 }
             },
             Psychic = {
                 name = "Тип",
                 text = {
-                  "{X:psychic,C:white}Психический{}",
+                  "{X:poke_psychic,C:white}Психический{}",
                 }
             },
             Fighting = {
                 name = "Тип",
                 text = {
-                  "{X:fighting,C:white}Боевой{}",
+                  "{X:poke_fighting,C:white}Боевой{}",
                 }
             },
             Colorless = {
                 name = "Тип",
                 text = {
-                  "{X:colorless,C:white}Бесцветный{}",
+                  "{X:poke_colorless,C:white}Бесцветный{}",
                 }
             },
             Dark = {
                 name = "Тип",
                 text = {
-                  "{X:dark,C:white}Тёмный{}",
+                  "{X:poke_dark,C:white}Тёмный{}",
                 }
             },
             Metal = {
                 name = "Тип",
                 text = {
-                  "{X:metal,C:white}Металлический{}",
+                  "{X:poke_metal,C:white}Металлический{}",
                 }
             },
             Fairy = {
                 name = "Тип",
                 text = {
-                  "{X:fairy,C:white}Волшебный{}",
+                  "{X:poke_fairy,C:white}Волшебный{}",
                 }
             },
             Dragon = {
                 name = "Тип",
                 text = {
-                  "{X:dragon,C:white}Драконий{}",
+                  "{X:poke_dragon,C:white}Драконий{}",
                 }
             },
             Earth = {
                 name = "Тип",
                 text = {
-                  "{X:earth,C:white}Земляной{}",
+                  "{X:poke_earth,C:white}Земляной{}",
                 }
             },
             Bird = {
                 name = "Тип",
                 text = {
-                  "{X:bird,C:white}Летающий{}",
+                  "{X:poke_bird,C:white}Летающий{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -2840,7 +2840,7 @@ return {
                 name = "Подарки",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:attention}карта {C:item}Предмета{}",
+                    "{C:green}30%{} - {C:attention}карта {C:poke_item}Предмета{}",
                     "{C:green}20%{} - {C:attention}Тэг купона",
                     "{C:green}15%{} - {C:dark_edition}полихромная{} {C:attention}Подарочная Карта",
                 }
@@ -2856,20 +2856,20 @@ return {
             eeveelution = {
                 name = "Эволюции",
                 text = {
-                    "{C:attention}Камень Воды{} - {X:water,C:white}Вапореон{}",
-                    "{C:attention}Камень Молнии{} - {X:lightning,C:black}Джолтеон{}",
-                    "{C:attention}Камень Огня{} - {X:fire,C:white}Флареон{}",
-                    "{C:attention}Камень Солнца{} - {X:psychic,C:white}Эспеон{}",
-                    "{C:attention}Камень Луны{} - {X:dark,C:white}Амбреон{}",
-                    "{C:attention}Камень Листа{} - {X:grass,C:white}Лифион{}",
-                    "{C:attention}Камень Льда{} - {X:water,C:white}Гласеон{}",
-                    "{C:attention}Блестящий Камень{} - {X:fairy,C:white}Сильвеон{}"
+                    "{C:attention}Камень Воды{} - {X:poke_water,C:white}Вапореон{}",
+                    "{C:attention}Камень Молнии{} - {X:poke_lightning,C:black}Джолтеон{}",
+                    "{C:attention}Камень Огня{} - {X:poke_fire,C:white}Флареон{}",
+                    "{C:attention}Камень Солнца{} - {X:poke_psychic,C:white}Эспеон{}",
+                    "{C:attention}Камень Луны{} - {X:poke_dark,C:white}Амбреон{}",
+                    "{C:attention}Камень Листа{} - {X:poke_grass,C:white}Лифион{}",
+                    "{C:attention}Камень Льда{} - {X:poke_water,C:white}Гласеон{}",
+                    "{C:attention}Блестящий Камень{} - {X:poke_fairy,C:white}Сильвеон{}"
                 }
             },
             precise_energy_tooltip = {
                 name = "Точные значения Энергии",
                 text = {
-                    "{s:0.8}Использует {C:attention,s:0.8}дробные{} для всех значений, изменяемых {C:pink,s:0.8}Энергией{}",
+                    "{s:0.8}Использует {C:attention,s:0.8}дробные{} для всех значений, изменяемых {C:poke_pink,s:0.8}Энергией{}",
                     "{s:0.8}Если галочка будет {C:attention,s:0.8}снята{}{s:0.8}, бонусы Энергии изменятся следующим образом:{}",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}X{} {s:0.8}Mult - использует дробные",
                     "{C:attenion}2. {s:0.8}Прямые значения {C:mult,s:0.8}множ.{}{s:0.8} и {C:chips,s:0.8}фишек{}{s:0.8} - округляются до ближайшего полного значения",
@@ -2909,7 +2909,7 @@ return {
             poke_pink_seal_seal = {
                 name = "Розовая печать",
                 text = {
-                    "Создаёт карту {C:pink}Энергии{}",
+                    "Создаёт карту {C:poke_pink}Энергии{}",
                     "если засчитывается в",
                     "{C:attention}первой руке{} раунда"
                 },
@@ -2917,7 +2917,7 @@ return {
             poke_silver_seal = {
                 name = "Серебряная печать",
                 text = {
-                  "Создаёт карту {C:item}Предмета{},",
+                  "Создаёт карту {C:poke_item}Предмета{},",
                   "но{C:attention}сбрасывается{}, если осталась {C:attention}в руке{},",
                   "когда подсчитываются карты"
                 }
@@ -2925,73 +2925,73 @@ return {
             grass_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:grass,C:white}Травяной{}"
+                    "{X:poke_grass,C:white}Травяной{}"
                 } 
             },
             fire_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:fire,C:white}Огненный{}"
+                    "{X:poke_fire,C:white}Огненный{}"
                 } 
             },
             water_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:water,C:white}Водный{}"
+                    "{X:poke_water,C:white}Водный{}"
                 } 
             },
             lightning_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:lightning,C:white}Электрический{}"
+                    "{X:poke_lightning,C:white}Электрический{}"
                 } 
             },
             psychic_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:psychic,C:white}Психический{}"
+                    "{X:poke_psychic,C:white}Психический{}"
                 } 
             },
             fighting_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:fighting,C:white}Боевой{}"
+                    "{X:poke_fighting,C:white}Боевой{}"
                 } 
             },
             colorless_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:colorless,C:white}Бесцветный{}"
+                    "{X:poke_colorless,C:white}Бесцветный{}"
                 } 
             },
             dark_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:dark,C:white}Тёмный{}"
+                    "{X:poke_dark,C:white}Тёмный{}"
                 } 
             },
             metal_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:metal,C:white}Металлический{}"
+                    "{X:poke_metal,C:white}Металлический{}"
                 } 
             },
             fairy_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:fairy,C:white}Волшебный{}"
+                    "{X:poke_fairy,C:white}Волшебный{}"
                 } 
             },
             dragon_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:dragon,C:white}Драконий{}"
+                    "{X:poke_dragon,C:white}Драконий{}"
                 } 
             },
             earth_sticker = {
                 name = "Тип",
                 text = {
-                    "{X:earth,C:white}Земляной{}"
+                    "{X:poke_earth,C:white}Земляной{}"
                 } 
             },
             --Since these are normally discovered by default these will probably not matter
@@ -3019,7 +3019,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_normal_2 = {
@@ -3027,7 +3027,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
@@ -3035,7 +3035,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_mega_1 = {
@@ -3043,7 +3043,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_normal_3 = {
@@ -3051,7 +3051,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_normal_4 = {
@@ -3059,7 +3059,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
@@ -3067,7 +3067,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
             p_poke_pokepack_mega_2 = {
@@ -3075,7 +3075,7 @@ return {
                 text = {
                     "Выберите {C:attention}#1#{}",
                     "из {C:attention}#2# карт",
-                    "{C:pink}Энергии{} или {C:item}Предмета{}",
+                    "{C:poke_pink}Энергии{} или {C:poke_item}Предмета{}",
                 },
             },
         },

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -44,7 +44,7 @@ return {
                     "开局时获得",
                     "{C:tarot,T:v_crystal_ball}#1#{} 优惠券",
                     "和{C:attention}2{}张",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{}",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{}",
                 }
             },
             --Fun fact: this and luminious deck had their descriptions mixed up
@@ -65,8 +65,8 @@ return {
                 name = "发亮牌组",
                 text = {
                     "所有小丑牌生成时",
-                    "{C:pink}能量注入{}并附有",
-                    "随机的{C:pink}属性{}贴纸",
+                    "{C:poke_pink}能量注入{}并附有",
+                    "随机的{C:poke_pink}属性{}贴纸",
                 }
             },
             b_poke_ampeddeck = {
@@ -75,7 +75,7 @@ return {
                     "开局时获得",
                     "{C:tarot,T:v_poke_energysearch}#1#{}优惠券",
                     "和一张",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#{}",
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{}",
                 }
             },
             b_poke_futuredeck = {
@@ -113,7 +113,7 @@ return {
             b_poke_diceydeck = {
                 name = "碎屑牌组",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数和上限，{C:attention}+#1#{}手牌上限",
+                    "{C:poke_hazard}+#1#{}陷阱层数和上限，{C:attention}+#1#{}手牌上限",
                     "每回合结束时：",
                     "牌组中每张{C:attention}陷阱{}牌",
                     "获得{C:money}$#4#{}",
@@ -318,17 +318,17 @@ return {
                 name = "太晶珠",
                 text = {
                     "{C:attention}属性变换:{} {B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.8}({C:pink,s:0.8}属性{C:inactive,s:0.8}每次出牌后改变){}",
+                    "{C:inactive,s:0.8}({C:poke_pink,s:0.8}属性{C:inactive,s:0.8}每次出牌后改变){}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "如果最左边或选定的小丑牌",
-                    "已是 {B:1,V:2}#1#{} {C:pink}属性{}，",
-                    "则为其{C:pink}注入能量{}",
+                    "已是 {B:1,V:2}#1#{} {C:poke_pink}属性{}，",
+                    "则为其{C:poke_pink}注入能量{}",
                 },
             },
             c_poke_metalcoat = {
                 name = "金属膜",
                 text = {
-                    "{C:attention}属性变换:{} {X:metal,C:white}钢{}",
+                    "{C:attention}属性变换:{} {X:poke_metal,C:white}钢{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "为 {C:attention}1{} 张选定牌创造一张",
                     "附带{C:attention}钢铁{}强化的复制品",
@@ -337,10 +337,10 @@ return {
             c_poke_dragonscale = {
                 name = "龙之鳞片",
                 text = {
-                    "{C:attention}属性变换:{} {X:dragon,C:white}龙{}",
+                    "{C:attention}属性变换:{} {X:poke_dragon,C:white}龙{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "随机生成最多 {C:attention}3{} 张",
-                    "{C:item}道具{}或{C:pink}能量{}牌",
+                    "{C:poke_item}道具{}或{C:poke_pink}能量{}牌",
                     "{C:inactive}（必须有空位）{}",
                 },
             },
@@ -395,9 +395,9 @@ return {
                 name = "弯曲的汤匙",
                 text = {
                     "创造本局游戏中最近使用的",
-                    "{C:item}道具{}牌或{C:pink}能量{}牌",
-                    "{s:0.8,C:item}弯曲的汤匙{s:0.8}、{C:item}可重复使用道具",
-                    "{s:0.8,C:item}及树果汁除外",
+                    "{C:poke_item}道具{}牌或{C:poke_pink}能量{}牌",
+                    "{s:0.8,C:poke_item}弯曲的汤匙{s:0.8}、{C:poke_item}可重复使用道具",
+                    "{s:0.8,C:poke_item}及树果汁除外",
                 }
             },
             c_poke_prismscale = {
@@ -439,7 +439,7 @@ return {
                     "{C:attention}进化牌{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "将 {C:attention}1{} 张选定牌强化为{C:attention}石头牌{},",
-                    "每拥有一张{X:earth,C:white}地面{}属性小丑牌，",
+                    "每拥有一张{X:poke_earth,C:white}地面{}属性小丑牌，",
                     "额外增加 {C:chips}+#2#{} 筹码",
                 }
             },
@@ -470,8 +470,8 @@ return {
             c_poke_berry_juice_energy = {
                 name = "能量树果汁",
                 text = {
-                    "为最左边或选定的任意{C:pink}属性{}小丑牌",
-                    "{C:pink}注入能量{}",
+                    "为最左边或选定的任意{C:poke_pink}属性{}小丑牌",
+                    "{C:poke_pink}注入能量{}",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{C:inactive}次)",
                 },
             },
@@ -493,7 +493,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "道具树果汁",
                 text = {
-                    "产生一张{C:item}弯曲的汤匙{}",
+                    "产生一张{C:poke_item}弯曲的汤匙{}",
                     "有 {C:green}#1# / #2#{} 的概率",
                     "改为产生 {C:attention}2{} 张",
                     "{C:inactive}（必须有空位）{}",
@@ -517,7 +517,7 @@ return {
                 name = "谜之树果汁",
                 text = {
                     "随机产生一张",
-                    "{C:item}树果汁{}",
+                    "{C:poke_item}树果汁{}",
                 }
             },
             c_poke_oven = {
@@ -576,65 +576,65 @@ return {
             c_poke_grass_energy = {
                 name = "草能量",
                 text = {
-                    "为最左边或选定的{X:grass,C:white}草{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_grass,C:white}草{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fire_energy = {
                 name = "火能量",
                 text = {
-                    "为最左边或选定的{X:fire,C:white}火{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_fire,C:white}火{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_water_energy = {
                 name = "水能量",
                 text = {
-                    "为最左边或选定的{X:water,C:white}水{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_water,C:white}水{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_lightning_energy = {
                 name = "雷能量",
                 text = {
-                    "为最左边或选定的{X:lightning,C:black}电{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_lightning,C:black}电{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_psychic_energy = {
                 name = "超能量",
                 text = {
-                    "为最左边或选定的{X:psychic,C:white}超能力{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_psychic,C:white}超能力{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fighting_energy = {
                 name = "斗能量",
                 text = {
-                    "为最左边或选定的{X:fighting,C:white}格斗{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_fighting,C:white}格斗{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_colorless_energy = {
                 name = "无色能量",
                 text = {
-                    "为最左边或选定的{X:colorless,C:white}无色{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
-                    "对非{X:colorless,C:white}无色{}属性小丑牌的增强效果减半",
+                    "为最左边或选定的{X:poke_colorless,C:white}无色{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
+                    "对非{X:poke_colorless,C:white}无色{}属性小丑牌的增强效果减半",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_darkness_energy = {
                 name = "恶能量",
                 text = {
-                    "为最左边或选定的{X:dark,C:white}恶{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_dark,C:white}恶{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -642,15 +642,15 @@ return {
                 name = "钢能量",
                 text = {
                     "为最左边或选定的{X:Metal,C:white}钢{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fairy_energy = {
                 name = "妖能量",
                 text = {
-                    "为最左边或选定的{X:fairy,C:white}妖精{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_fairy,C:white}妖精{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -659,16 +659,16 @@ return {
             c_poke_dragon_energy = {
                 name = "龙能量",
                 text = {
-                    "为最左边或选定的{X:dragon,C:white}龙{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_dragon,C:white}龙{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_earth_energy = {
                 name = "地能量",
                 text = {
-                    "为最左边或选定的{X:earth,C:white}地面{}属性小丑牌",
-                    "{C:pink}注入能量{}（若可）",
+                    "为最左边或选定的{X:poke_earth,C:white}地面{}属性小丑牌",
+                    "{C:poke_pink}注入能量{}（若可）",
                     "{C:inactive}(每张小丑牌可增强{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -1348,7 +1348,7 @@ return {
                 text = {
                     "如果打出的{C:attention}牌型{}",
                     "已经在本回合出过时",
-                    "{C:green}#1#/#2#{}几率生成一张{C:item}道具牌{}或{C:tarot}塔罗牌{}",
+                    "{C:green}#1#/#2#{}几率生成一张{C:poke_item}道具牌{}或{C:tarot}塔罗牌{}",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#3#{C:inactive,s:0.8}个回合后进化）",
                 }
             },
@@ -1357,7 +1357,7 @@ return {
                 text = {
                     "如果打出的{C:attention}牌型{}",
                     "已经在本回合出过时",
-                    "{C:green}#1#/#2#{}几率生成一张{C:item}弯曲的汤匙{}或{C:tarot}塔罗牌{}",
+                    "{C:green}#1#/#2#{}几率生成一张{C:poke_item}弯曲的汤匙{}或{C:tarot}塔罗牌{}",
                     "{C:inactive,s:0.8}（使用{}{C:attention,s:0.8}联系绳{}{C:inactive,s:0.8}牌进化）",
                 }
             },
@@ -1367,7 +1367,7 @@ return {
                     "{C:attention}+#3#{}消耗牌上限",
                     "如果打出的{C:attention}牌型{}",
                     "已经在本回合出过时",
-                    "{C:green}#1#/#2#{}几率生成一张{C:attention}愚者{}牌或{C:item}弯曲的汤匙{}",
+                    "{C:green}#1#/#2#{}几率生成一张{C:attention}愚者{}牌或{C:poke_item}弯曲的汤匙{}",
                 }
             },
             j_poke_mega_alakazam = {
@@ -1375,7 +1375,7 @@ return {
                 text = {
                     "{C:attention}+#3#{} 消耗品栏位",
                     "每张持有的{C:attention}消耗品{}给予{X:mult,C:white}X#1#{} 倍率",
-                    "{C:item}弯曲的汤匙{}给予{X:mult,C:white}X#2#{} 倍率",
+                    "{C:poke_item}弯曲的汤匙{}给予{X:mult,C:white}X#2#{} 倍率",
                 }
             },
             j_poke_machop = {
@@ -1544,7 +1544,7 @@ return {
                 name = "三合一磁怪",
                 text = {
                     "每张计分的{C:attention}钢铁牌{}给予{X:mult,C:white}X#1#{}倍率",
-                    "每张相邻的{X:metal,C:white}钢{}属性小丑牌",
+                    "每张相邻的{X:poke_metal,C:white}钢{}属性小丑牌",
                     "会额外给予{X:mult,C:white}X#2#{}倍率",
                     "{C:inactive}（目前为{X:mult,C:white}X#3#{}{C:inactive}倍率）{}",
                     "{C:inactive,s:0.8}（使用{C:attention,s:0.8}雷之石{}{C:inactive,s:0.8}牌进化）",
@@ -1553,7 +1553,7 @@ return {
             j_poke_farfetchd = {
                 name = '大葱鸭',
                 text = {
-                    "此牌附带{C:item}大葱{}",
+                    "此牌附带{C:poke_item}大葱{}",
                     "使用{C:attention}消耗品{}时，有",
                     "{C:green}#2#/#3#{}的几率获得 {C:money}$#1#",
                     "使用{C:attention}大葱{}时必定获得金钱",
@@ -1674,7 +1674,7 @@ return {
                     "当一张{C:attention}非石头{}牌",
                     "被摧毁时，向{C:attention}牌组{}",
                     "加入一张{C:attention}石头{}牌",
-                    "{C:inactive,s:0.8}(附上{C:metal,s:0.8}钢{}{C:inactive,s:0.8}贴纸后进化)",
+                    "{C:inactive,s:0.8}(附上{C:poke_metal,s:0.8}钢{}{C:inactive,s:0.8}贴纸后进化)",
                 }
             },
             j_poke_drowzee = {
@@ -1751,7 +1751,7 @@ return {
             j_poke_cubone = {
                 name = '卡拉卡拉',
                 text = {
-                    "此牌附带{C:item}粗骨头{}",
+                    "此牌附带{C:poke_item}粗骨头{}",
                     "每张持有的消耗牌",
                     "给予{C:mult}+#1#{}倍率",
                     "{C:inactive,s:0.8}（{C:attention,s:0.8}粗骨头{}{C:inactive,s:0.8}牌当作双倍）{}",
@@ -1880,7 +1880,7 @@ return {
                     "每张计分的{C:attention}6{}会给此牌{C:mult}+#2#{}倍率",
                     "如果手牌中有{C:attention}K{}，效果翻倍",
                     "{C:inactive}（目前为{C:mult}+#1#{C:inactive}倍率）",
-                    "{C:inactive,s:0.8}（附上{C:dragon,s:0.8}龙{}{C:inactive,s:0.8}贴纸后进化）{}",
+                    "{C:inactive,s:0.8}（附上{C:poke_dragon,s:0.8}龙{}{C:inactive,s:0.8}贴纸后进化）{}",
                 }
             },
             j_poke_goldeen = {
@@ -1927,7 +1927,7 @@ return {
                     "如果被摧毁的小丑牌是{C:red}稀有{}或以上",
                     "新增{C:attention}闪箔{}，{C:attention}全息{}或{C:attention}多彩{}版本",
                     "{C:inactive}（目前为{C:mult}+#1#{C:inactive} 倍率）",
-                    "{C:inactive,s:0.8}（附上{C:metal,s:0.8}钢{}{C:inactive,s:0.8}贴纸或使用{C:attention,s:0.8}硬石头{C:inactive,s:0.8}后进化）",
+                    "{C:inactive,s:0.8}（附上{C:poke_metal,s:0.8}钢{}{C:inactive,s:0.8}贴纸或使用{C:attention,s:0.8}硬石头{C:inactive,s:0.8}后进化）",
                 }
             },
             j_poke_jynx = {
@@ -2027,7 +2027,7 @@ return {
                 text = {
                     "{C:attention}右不稳定{}",
                     "商店结束时，{C:attention}变为{}最左侧的小丑牌",
-                    "并附带{C:attention}易腐{}和{X:colorless,C:white}无色{}属性贴纸",
+                    "并附带{C:attention}易腐{}和{X:poke_colorless,C:white}无色{}属性贴纸",
                     "{C:inactive,s:0.8}（自身除外）",
                 }
             },
@@ -2066,9 +2066,9 @@ return {
             j_poke_porygon = {
                 name = '多边兽',
                 text = {
-                    "{C:pink}+1{}能量上限",
+                    "{C:poke_pink}+1{}能量上限",
                     "每次打开{C:attention}补充包{}时",
-                    "产生一张{C:pink}能量{}牌",
+                    "产生一张{C:poke_pink}能量{}牌",
                     "{C:inactive,s:0.8}（使用{} {C:attention,s:0.8}升级数据{}{C:inactive,s:0.8}牌进化）",
                 }
             },
@@ -2078,7 +2078,7 @@ return {
                     "{C:attention}远古#1#{}",
                     "{X:attention,C:white}1+{} : 产生一张{C:tarot}塔罗牌{}",
                     "{X:attention,C:white}2+{} : 获得 {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : 产生一张{C:item}道具{}牌 {C:inactive,s:0.7}(触发 {C:attention,s:0.7}#3#{C:inactive,s:0.7} 次后进化)",
+                    "{X:attention,C:white}3+{} : 产生一张{C:poke_item}道具{}牌 {C:inactive,s:0.7}(触发 {C:attention,s:0.7}#3#{C:inactive,s:0.7} 次后进化)",
                     "{C:inactive,s:0.8}（必须有空位）",
                 }
             },
@@ -2088,7 +2088,7 @@ return {
                     "{C:attention}远古#1#{}",
                     "{X:attention,C:white}1+{} : 产生一张{C:tarot}塔罗牌{}",
                     "{X:attention,C:white}2+{} : 获得 {C:money}$#2#{}",
-                    "{X:attention,C:white}3+{} : 产生一张{C:item}道具{}牌",
+                    "{X:attention,C:white}3+{} : 产生一张{C:poke_item}道具{}牌",
                     "{X:attention,C:white}4+{} : 产生一个{C:attention}标签{} {C:inactive,s:0.8}(每轮一次) {C:inactive}#3#{}",
                     "{C:inactive,s:0.8}（必须有空位）",
                 }
@@ -2138,7 +2138,7 @@ return {
             j_poke_snorlax = {
                 name = '卡比兽',
                 text = {
-                    "此牌附带{C:item}吃剩的东西{}",
+                    "此牌附带{C:poke_item}吃剩的东西{}",
                     "回合结束时，每张你拥有的{C:attention}吃剩的东西{}",
                     "会给此牌{X:mult,C:white}X#1#{}倍率",
                     "{C:inactive}（目前为{X:mult,C:white} X#2# {}{C:inactive}倍率）",
@@ -2197,7 +2197,7 @@ return {
                 text = {
                     "击败{C:attention}Boss盲注{}后，生成一张",
                     "最左侧{C:attention}小丑牌{}的{C:dark_edition}多彩{}{C:attention}复制品{}",
-                    "并为{C:attention}复制品{}{C:pink}注入能量{}",
+                    "并为{C:attention}复制品{}{C:poke_pink}注入能量{}",
                     "然后摧毁最左侧的{C:attention}小丑牌{}",
                     "{br:3}ERROR - CONTACT STEAK",
                     "每张{C:dark_edition}多彩{}版本的小丑牌给予{X:mult,C:white} X#1# {}倍率",
@@ -2214,18 +2214,18 @@ return {
                 name = "超级超梦Y",
                 text = {
                     "在商店结束时，为最左侧的",
-                    "小丑牌提供{C:attention}两次{} {C:pink}能量注入{}",
+                    "小丑牌提供{C:attention}两次{} {C:poke_pink}能量注入{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "击败{C:attention}Boss盲注{}时，",
-                    "{C:pink}+1{} 能量上限",
-                    "{C:inactive}（不能为自身{C:pink}注入能量{C:inactive}）",
+                    "{C:poke_pink}+1{} 能量上限",
+                    "{C:inactive}（不能为自身{C:poke_pink}注入能量{C:inactive}）",
                 }
             },
             j_poke_mew = {
                 name = '梦幻',
                 text = {
                     "离开商店后，产生一张随机的",
-                    "{C:dark_edition}负片{}{C:tarot}塔罗{}，{C:spectral}幻灵{}或{C:item}道具{}牌",
+                    "{C:dark_edition}负片{}{C:tarot}塔罗{}，{C:spectral}幻灵{}或{C:poke_item}道具{}牌",
                     "有{C:green}#1#%{}的几率产生一张随机的{C:dark_edition}负片{}小丑牌{C:attention}作为替代{}",
                     "{br:3}ERROR - CONTACT STEAK",
                     "{C:inactive,s:0.8}（几率不能提升）{}",
@@ -2401,8 +2401,8 @@ return {
                     "若打出的牌包含{C:attention}对子{}",
                     "给予{C:chips}+#1#{}筹码和{C:money}$#2#{}",
                     "{br:3}ERROR - CONTACT STEAK",
-                    "每张{X:water,C:white}水{}属性小丑牌会增加{C:chips}+#3#{}到获得的筹码",
-                    "每张{X:lightning,C:black}电{}属性小丑牌会增加{C:money}$#4#{}到获得的金钱",
+                    "每张{X:poke_water,C:white}水{}属性小丑牌会增加{C:chips}+#3#{}到获得的筹码",
+                    "每张{X:poke_lightning,C:black}电{}属性小丑牌会增加{C:money}$#4#{}到获得的金钱",
                     "{C:inactive}(当前{C:chips}+#6#{C:inactive}筹码及{C:money}$#5#{C:inactive})",
                 }
             },
@@ -2530,9 +2530,9 @@ return {
             j_poke_weird_tree = {
                 name = "奇怪的树",
                 text = {
-                    "{C:attention}属性变换: {X:grass,C:white}草{}",
+                    "{C:attention}属性变换: {X:poke_grass,C:white}草{}",
                     "回合结束时，若此小丑牌不是",
-                    "{X:grass,C:white}草{}属性或你拥有{X:water,C:white}水{}属性",
+                    "{X:poke_grass,C:white}草{}属性或你拥有{X:poke_water,C:white}水{}属性",
                     "小丑牌，则{C:}变形{}",
                 }
             },
@@ -2550,7 +2550,7 @@ return {
                 name = '蚊香蛙皇',
                 text = {
                     "重新触发第一张计分的{V:1}#2#{}，",
-                    "再按你拥有的每张{X:water,C:white}水{}属性",
+                    "再按你拥有的每张{X:poke_water,C:white}水{}属性",
                     "小丑牌额外重新触发一次，",
                     "计分后花色循环变化",
                     "{C:inactive,s:0.8}(#3#, #4#, #5#, #6#)",
@@ -2660,7 +2660,7 @@ return {
             j_poke_murkrow = {
               name = "黑暗鸦",
               text = {
-                "每持有{X:dark,C:white}恶{}属性小丑牌，获得{X:mult,C:white} X#1# {} 倍率",
+                "每持有{X:poke_dark,C:white}恶{}属性小丑牌，获得{X:mult,C:white} X#1# {} 倍率",
                 "{C:inactive}(当前{X:mult,C:white} X#2#{C:inactive} 倍率)",
                 "{C:inactive,s:0.8}(使用{C:attention,s:0.8}暗之石{C:inactive,s:0.8}后进化)",
               }
@@ -2787,7 +2787,7 @@ return {
             j_poke_qwilfish = {
                 name = '千针鱼',
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "当一张{C:attention}强化{}牌",
                     "被摧毁时，获得 {C:chips}+#2#{} 筹码",
                     "{C:inactive}(当前{C:chips}+#3#{C:inactive} 筹码)",
@@ -2820,8 +2820,8 @@ return {
                 text = {
                     "选择{C:attention}盲注{}时，",
                     "摧毁最左侧的{C:attention}消耗品{}",
-                    "并生成一张{C:item}树果汁{}",
-                    "{C:inactive}(不能摧毁{C:item}树果汁{C:inactive})",
+                    "并生成一张{C:poke_item}树果汁{}",
+                    "{C:inactive}(不能摧毁{C:poke_item}树果汁{C:inactive})",
                 }
             },
             j_poke_sneasel = {
@@ -2845,7 +2845,7 @@ return {
               name = "圈圈熊",
               text = {
                 "每跳过一个{C:attention}补充包{}",
-                "获得 {C:mult}+#2#{} 倍率并生成一张{C:item}道具{}牌",
+                "获得 {C:mult}+#2#{} 倍率并生成一张{C:poke_item}道具{}牌",
                 "{C:inactive,s:0.8}(必须有空位)",
                 "{C:inactive}(当前 {C:mult}+#1#{C:inactive} 倍率)",
                 "{C:inactive,s:0.8}(使用{C:attention,s:0.8}月之石{C:inactive,s:0.8}后进化)",
@@ -2915,9 +2915,9 @@ return {
               name = '太阳珊瑚',
               text = {
                 "选择{C:attention}盲注{}时，",
-                "每拥有一张{X:water,C:white}水{}属性小丑牌",
+                "每拥有一张{X:poke_water,C:white}水{}属性小丑牌",
                 "获得{C:mult}+#1#{}倍率，",
-                "然后生成一张{C:attention}基础{} {X:water,C:white}水{}属性小丑牌",
+                "然后生成一张{C:attention}基础{} {X:poke_water,C:white}水{}属性小丑牌",
                 "{C:inactive,s:0.8}(必须有空间)",
                 "{C:inactive}(当前 {C:mult}+#2#{C:inactive} 倍率)",
               }
@@ -2958,7 +2958,7 @@ return {
             j_poke_skarmory = {
                 name = '盔甲鸟',
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "手牌中每有一张{C:attention}陷阱牌{}或{C:attention}钢铁牌{}",
                     "提供 {X:mult,C:white}X#2#{} 倍率",
                     "{C:inactive}(当前{X:mult,C:white}X#3#{C:inactive} 倍率)",
@@ -2995,10 +2995,10 @@ return {
             j_poke_porygon2 = {
                 name = '多边兽Ⅱ',
                 text = {
-                    "{C:pink}+2{}能量上限",
+                    "{C:poke_pink}+2{}能量上限",
                     "每次打开{C:attention}补充包{}时",
-                    "产生一张与最左边的小丑牌的{C:pink}属性{}",
-                    "相同的{C:pink}能量{}牌",
+                    "产生一张与最左边的小丑牌的{C:poke_pink}属性{}",
+                    "相同的{C:poke_pink}能量{}牌",
                     "{C:inactive,s:0.8}（使用{}{C:attention,s:0.8}可疑补丁{}{C:inactive,s:0.8}牌进化）",
                 }
             },
@@ -3097,7 +3097,7 @@ return {
             j_poke_miltank = {
                 name = "大奶罐",
                 text = {
-                    "每持有{X:colorless,C:white}无色{}属性小丑牌，",
+                    "每持有{X:poke_colorless,C:white}无色{}属性小丑牌，",
                     "在回合结束时获得{C:money}$#1#{}",
                     "{C:inactive}(当前{C:money}$#2#{C:inactive}){}"
                 }
@@ -3220,7 +3220,7 @@ return {
                     "{C:attention}+#3#{}手牌上限, {C:attention}性格: {C:inactive}({C:attention}#6#, #7#, #8#{C:inactive}){}",
                     "每张打出的{C:attention}性格{}牌获得{C:money}$#1#{}",
                     "计分时，每拥有一张{C:attention}其他{}",
-                    "{X:grass,C:white}草{}属性小丑牌，额外获得{C:money}$#5#{}",
+                    "{X:poke_grass,C:white}草{}属性小丑牌，额外获得{C:money}$#5#{}",
                     "{C:inactive}（目前为{C:money}$#4#{C:inactive}）{}",
                 }
             },
@@ -3251,7 +3251,7 @@ return {
                     "{br:2}ERROR - CONTACT STEAK",
                     "若本回合已弃掉",
                     "{C:attention}#4# {C:inactive}[#5#] {C:attention}张性格{}牌，",
-                    "每张{X:fire,C:white}火{}或{X:fighting,C:white}斗{}属性小丑牌",
+                    "每张{X:poke_fire,C:white}火{}或{X:poke_fighting,C:white}斗{}属性小丑牌",
                     "给予{X:mult,C:white} X#2# {}倍率",
                 }
             },
@@ -3281,7 +3281,7 @@ return {
                     "计分时给予{C:chips}+#1#{}筹码",
                     "{br:2}ERROR - CONTACT STEAK",
                     "若牌型含有{C:attention}#3#张性格{}牌，",
-                    "每有{C:attention}2{}张{X:water,C:white}水{}或{X:earth,C:white}地面{}属性小丑牌，",
+                    "每有{C:attention}2{}张{X:poke_water,C:white}水{}或{X:poke_earth,C:white}地面{}属性小丑牌，",
                     "生成一张{C:tarot}塔罗{}牌{C:inactive}(必须有空位){}",
                 }
             },
@@ -3300,7 +3300,7 @@ return {
                 "每当一张{C:attention}游戏牌{}被摧毁时",
                 "获得 {C:mult}+#2#{} 倍率",
                 "{br:2}ERROR - CONTACT STEAK",
-                "每拥有一张{X:dark,C:white}恶{}属性小丑牌，",
+                "每拥有一张{X:poke_dark,C:white}恶{}属性小丑牌，",
                 "额外增加 {C:mult}+#3#{} 倍率",
                 "{C:inactive}(当前 {C:mult}+#1#{C:inactive} 倍率)",
               }
@@ -3309,7 +3309,7 @@ return {
               name = "蛇纹熊",
               text = {
                 "出牌时，有 {C:green}#1#/#2#{} 的概率",
-                "生成一张{C:attention}捡拾{}类{C:item}道具{}牌",
+                "生成一张{C:attention}捡拾{}类{C:poke_item}道具{}牌",
                 "{C:inactive}(必须有空位)",
                 "{C:inactive,s:0.8}(在{C:attention}#3#{C:inactive,s:0.8}回合后进化)",
               }
@@ -3318,7 +3318,7 @@ return {
               name = "直冲熊",
               text = {
                 "出牌时，有 {C:green}#1#/#2#{} 的概率",
-                "生成一张{C:attention}捡拾{}类{C:item}道具{}牌",
+                "生成一张{C:attention}捡拾{}类{C:poke_item}道具{}牌",
                 "若打出的牌包含",
                 "{C:attention}顺子{}，则必定生成",
                 "{C:inactive}(必须有空位)",
@@ -3404,14 +3404,14 @@ return {
                 "获得{C:money}$#1#{}，",
                 "点数每回合变化",
                 "{br:2}ERROR - CONTACT STEAK",
-                "每拥有一张{X:water,C:white}水{}属性小丑牌",
+                "每拥有一张{X:poke_water,C:white}水{}属性小丑牌",
                 "额外获得{C:money}$#2#{}",
               }
             },
             j_poke_ralts = {
               name = "拉鲁拉丝",
               text = {
-                "每张{C:pink}能量注入{}的小丑牌",
+                "每张{C:poke_pink}能量注入{}的小丑牌",
                 "和{C:attention}持有{}的{C:planet}星球{}牌给予{C:mult}+#1#{}倍率",
                 "{C:inactive}(当前为{C:mult}+#3#{C:inactive}倍率)",
                 "{C:inactive,s:0.8}(在{C:attention,s:0.8}#2#{C:inactive,s:0.8}回合后进化)",
@@ -3420,7 +3420,7 @@ return {
             j_poke_kirlia = {
               name = "奇鲁莉安",
               text = {
-                "每张{C:pink}能量注入{}的小丑牌",
+                "每张{C:poke_pink}能量注入{}的小丑牌",
                 "和{C:attention}持有{}的{C:planet}星球{}牌给予{C:mult}+#1#{}倍率",
                 "{C:inactive}(当前为{C:mult}+#2#{C:inactive}倍率)",
                 "{C:inactive,s:0.8}(使用{C:attention,s:0.8}#3#张{C:planet,s:0.8}星球{C:inactive,s:0.8}牌后进化)",
@@ -3432,7 +3432,7 @@ return {
               text = {
                 "{C:attention}持有{}{C:spectral}黑洞{}",
                 "{br:2}ERROR - CONTACT STEAK",
-                "每张{C:pink}能量注入{}的小丑牌",
+                "每张{C:poke_pink}能量注入{}的小丑牌",
                 "和每个等级{C:attention}#3#+{}牌型给予{X:mult,C:white}X#1#{}倍率",
                 "{C:inactive}(当前为{X:mult,C:white}X#2#{C:inactive}倍率)",
               }
@@ -3504,8 +3504,8 @@ return {
                   "每防止一次获得{X:mult,C:white}X#2#{}倍率",
                   "{C:inactive}(当前为{X:mult,C:white}X#1#{C:inactive}倍率)",
                   "{br:2.5}ERROR - CONTACT STEAK",
-                  "若商店结束时你有{X:fire,C:white}火{}、{X:dark,C:white}恶{}、",
-                  "{X:earth,C:white}地面{}或{X:psychic,C:white}超能力{}属性小丑牌，",
+                  "若商店结束时你有{X:poke_fire,C:white}火{}、{X:poke_dark,C:white}恶{}、",
+                  "{X:poke_earth,C:white}地面{}或{X:poke_psychic,C:white}超能力{}属性小丑牌，",
                   "{S:1.1,C:red,E:2}自毁{}",
                   "{C:inactive}(不包括脱壳忍者){}",
                 }
@@ -3522,7 +3522,7 @@ return {
                 name = "铁掌力士",
                 text = {
                   "选择{C:attention}盲注{}时，",
-                  "每张{X:fighting,C:white}格斗{}属性小丑牌",
+                  "每张{X:poke_fighting,C:white}格斗{}属性小丑牌",
                   "获得{C:chips}+#1#{}出牌次数",
                 }
             },
@@ -3557,7 +3557,7 @@ return {
                 text = {
                   "复制右侧{B:1,V:2}#1#{}",
                   "小丑牌的能力，",
-                  "并附带{C:pink}+#2#{}能量",
+                  "并附带{C:poke_pink}+#2#{}能量",
                   "{C:inactive,s:0.8}(属性每回合变化){}",
                 }
             },
@@ -3610,7 +3610,7 @@ return {
                 "使用{C:planet}星球{}牌时",
                 "获得{C:chips}+#2#{}筹码",
                 "{br:2}ERROR - CONTACT STEAK",
-                "若你有另一张{X:grass,C:white}草{}属性小丑牌，",
+                "若你有另一张{X:poke_grass,C:white}草{}属性小丑牌，",
                 "同时获得{X:mult,C:white}X#4#{}倍率",
                 "{C:inactive}(当前为{C:chips}+#1#{C:inactive}筹码，{X:mult,C:white}X#3#{C:inactive}倍率)",
               }
@@ -3619,7 +3619,7 @@ return {
               name = "甜甜萤",
               text = {
                 "选择{C:attention}盲注{}时，",
-                "每张{X:grass,C:white}草{}属性小丑牌",
+                "每张{X:poke_grass,C:white}草{}属性小丑牌",
                 "生成一张{C:planet}星球{}牌",
                 "{C:inactive}(必须有空位){}",
               }
@@ -3705,7 +3705,7 @@ return {
             j_poke_cacnea = {
               name = "刺球仙人掌",
               text = {
-                "{C:hazard}+#1#{}陷阱层数",
+                "{C:poke_hazard}+#1#{}陷阱层数",
                 "有牌被摧毁时",
                 "获得{C:money}$#2#{}",
                 "{C:inactive}(在{C:attention}#3#{C:inactive}回合后进化)",
@@ -3714,7 +3714,7 @@ return {
             j_poke_cacturne = {
               name = "梦歌仙人掌",
               text = {
-                "{C:hazard}+#1#{}陷阱层数",
+                "{C:poke_hazard}+#1#{}陷阱层数",
                 "有牌被摧毁时",
                 "获得{C:money}$#2#{}",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -3737,7 +3737,7 @@ return {
                 "获得{C:chips}+#2#{}筹码，且有",
                 "{C:green}#4#/#5#{}概率也获得{C:money}$#3#{}",
                 "{br:2}ERROR - CONTACT STEAK",
-                "若你有另一张{X:dragon,C:white}龙{}属性",
+                "若你有另一张{X:poke_dragon,C:white}龙{}属性",
                 "小丑牌则必定触发",
                 "{C:inactive}(当前为{C:chips}+#1#{C:inactive}筹码)",
               }
@@ -3928,7 +3928,7 @@ return {
                 "获得{C:attention}+#1#{}手牌上限",
                 "{br:2}ERROR - CONTACT STEAK",
                 "打开{C:attention}补充包{}期间售出",
-                "{C:tarot}塔罗{}或{C:item}道具{}牌时，",
+                "{C:tarot}塔罗{}或{C:poke_item}道具{}牌时，",
                 "获得{X:mult,C:white}X#2#{}倍率并摧毁",
                 "一张随机{C:attention}手中{}牌",
                 "{C:inactive}(当前为{X:mult,C:white}X#3#{C:inactive}倍率)",
@@ -3941,7 +3941,7 @@ return {
                 "获得{C:attention}+#1#{}手牌上限",
                 "{br:2}ERROR - CONTACT STEAK",
                 "打开{C:attention}补充包{}期间使用",
-                "{C:tarot}塔罗{}或{C:item}道具{}牌时，",
+                "{C:tarot}塔罗{}或{C:poke_item}道具{}牌时，",
                 "获得{X:mult,C:white}X#2#{}倍率",
                 "{C:inactive}(当前为{X:mult,C:white}X#3#{C:inactive}倍率)",
               }
@@ -4079,7 +4079,7 @@ return {
                 name = '基拉祈',
                 text = {
                     "复制右侧{C:attention}小丑牌{}的能力",
-                    "如同其拥有额外的{C:pink}能量注入{}",
+                    "如同其拥有额外的{C:poke_pink}能量注入{}",
                 }
             },
             j_poke_jirachi_fixer = {
@@ -4167,7 +4167,7 @@ return {
                 text = {
                     "{C:attention}幼年{}，{X:mult,C:white}X#1#{}倍率",
                     "回合结束时，生成一张",
-                    "{C:dark_edition}负片{}{C:item}奇迹种子{}复制品",
+                    "{C:dark_edition}负片{}{C:poke_item}奇迹种子{}复制品",
                     "{C:inactive,s:0.8}(在{C:attention,s:0.8}#2#{C:inactive,s:0.8}回合后进化)",
                 }
             },
@@ -4252,7 +4252,7 @@ return {
             j_poke_honchkrow = {
                 name = "乌鸦头头",
                 text = {
-                    "每张{X:dark,C:white}恶{}属性小丑牌提供{X:mult,C:white}X#1#{} 倍率",
+                    "每张{X:poke_dark,C:white}恶{}属性小丑牌提供{X:mult,C:white}X#1#{} 倍率",
                 }
             },
             j_poke_chingling = {
@@ -4297,7 +4297,7 @@ return {
                 text = {
                     "{C:attention}幼年{}, {X:mult,C:white} X#1# {} 倍率",
                     "回合结束时，生成一张",
-                    "{C:dark_edition}负片{}{C:item}道具牌{}",
+                    "{C:dark_edition}负片{}{C:poke_item}道具牌{}",
                     "{C:inactive,s:0.8}(在{C:attention,s:0.8}#2#{C:inactive,s:0.8}回合后进化)",
                 }
             },
@@ -4348,7 +4348,7 @@ return {
                 name = '自爆磁怪',
                 text = {
                     "打出的{C:attention}钢铁牌{}获得 {X:mult,C:white}X#1#{} 倍率",
-                    "每拥有一张{X:metal,C:white}钢{}属性小丑牌",
+                    "每拥有一张{X:poke_metal,C:white}钢{}属性小丑牌",
                     "额外提供 {X:mult,C:white}X#2#{} 倍率",
                     "{C:inactive}(当前 {X:mult,C:white}X#3#{C:inactive} 倍率){}",
                 }
@@ -4370,7 +4370,7 @@ return {
                     "可永久获得{C:chips}+#1#{}筹码",
                     "并重新触发",
                     "{br:3}ERROR - CONTACT STEAK",
-                    "每拥有 {C:attention}3{} 张{X:earth,C:white}地面{}属性小丑牌，",
+                    "每拥有 {C:attention}3{} 张{X:poke_earth,C:white}地面{}属性小丑牌，",
                     "{C:attention}石头牌{}额外重新触发一次",
                     "{C:inactive}(当前重新触发 #2# 次)",
                 }
@@ -4466,11 +4466,11 @@ return {
             j_poke_porygonz = {
                 name = '多边兽Ｚ',
                 text = {
-                    "{C:pink}+3{}能量上限",
-                    "每张在此{C:attention}比赛{}中使用的{C:pink}能量{}牌会给予{X:mult,C:white} X#2# {}倍率",
+                    "{C:poke_pink}+3{}能量上限",
+                    "每张在此{C:attention}比赛{}中使用的{C:poke_pink}能量{}牌会给予{X:mult,C:white} X#2# {}倍率",
                     "{br:2}text needs to be here to work",
-                    "当你使用{C:pink}能量{}牌时",
-                    "产生一张{C:pink}能量{}牌",
+                    "当你使用{C:poke_pink}能量{}牌时",
+                    "产生一张{C:poke_pink}能量{}牌",
                     "{C:inactive}（必须有空位）",
                     "{C:inactive}（目前为{X:mult,C:white} X#1# {}{C:inactive}倍率）",
                 }
@@ -4511,7 +4511,7 @@ return {
                     "最多可欠债{C:mult}-$#1#{}",
                     "{br:2.5}ERROR - CONTACT STEAK",
                     "若出牌时处于欠债状态，",
-                    "生成一张{C:item}道具{}卡牌",
+                    "生成一张{C:poke_item}道具{}卡牌",
                     "{C:inactive,s:0.8}(必须有空间)",
                 }
             },
@@ -4519,7 +4519,7 @@ return {
                 name = "洛托姆",
                 text = {
                   "打开任意{C:attention}补充包{}时，",
-                  "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                  "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                   "{C:inactive}(必须有空位){}",
                   "{C:attention}补充包{}价格降低 {C:money}$1{}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4530,7 +4530,7 @@ return {
                 name = "加热洛托姆",
                 text = {
                   "打开任意{C:attention}补充包{}时，",
-                  "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                  "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                   "{C:inactive}(必须有空位){}",
                   "若首次弃牌",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4543,7 +4543,7 @@ return {
                 name = "清洗洛托姆",
                 text = {
                   "打开任意{C:attention}补充包{}时，",
-                  "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                  "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                   "{C:inactive}(必须有空位){}",
                   "每打出一张计分的{C:attention}强化牌{}，",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4555,7 +4555,7 @@ return {
               name = "结冰洛托姆",
               text = {
                 "打开任意{C:attention}补充包{}时，",
-                "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                 "{C:inactive}(必须有空位){}",
                 "选择盲注时，生成一张",
                 "{br:2}ERROR - CONTACT STEAK",
@@ -4568,7 +4568,7 @@ return {
                 name = "旋转洛托姆",
                 text = {
                   "打开任意{C:attention}补充包{}时，",
-                  "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                  "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                   "{C:inactive}(必须有空位){}",
                   "选择盲注时，",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4581,7 +4581,7 @@ return {
                 name = "切割洛托姆",
                 text = {
                   "打开任意{C:attention}补充包{}时，",
-                  "有{C:green}#1#/#2#{}的几率生成一张{C:item}道具{}牌",
+                  "有{C:green}#1#/#2#{}的几率生成一张{C:poke_item}道具{}牌",
                   "{C:inactive}(必须有空位){}",
                   "回合结束时，{C:attention}降低{}",
                   "{br:2}ERROR - CONTACT STEAK",
@@ -4673,7 +4673,7 @@ return {
                 name = "梦梦蚀",
                 text = {
                   "选择{C:attention}盲注{}时，本回合",
-                  "每张{X:psychic,C:white}超能力{}属性小丑牌给予{C:purple}+#2#预见{}",
+                  "每张{X:poke_psychic,C:white}超能力{}属性小丑牌给予{C:purple}+#2#预见{}",
                   "{br:3}ERROR - CONTACT STEAK",
                   "每张{C:attention}强化的预见{}牌",
                   "给予{X:mult,C:white}X#1#{}倍率",
@@ -4683,7 +4683,7 @@ return {
             j_poke_roggenrola = {
                 name = "石丸子",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "手牌中每有一张{C:attention}无点数{}的牌",
                     "提供 {C:mult}+#2#{} 倍率",
                     "{C:inactive,s:0.8}(触发{C:attention,s:0.8}#3#{C:inactive,s:0.8}次后进化)",
@@ -4692,7 +4692,7 @@ return {
             j_poke_boldore = {
                 name = "地幔岩",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "手牌中每有一张{C:attention}无点数{}的牌",
                     "提供 {C:mult}+#2#{} 倍率",
                     "{C:inactive,s:0.8}(使用{C:attention,s:0.8}联系绳{C:inactive,s:0.8}后进化)",
@@ -4701,7 +4701,7 @@ return {
             j_poke_gigalith = {
                 name = "庞岩怪",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "手牌中每有一张{C:attention}无点数{}的牌",
                     "提供 {C:mult}+#2#{} 倍率并重新触发",
                 }
@@ -4839,7 +4839,7 @@ return {
             j_poke_ferroseed = {
                 name = "种子铁球",
                 text = {
-                    "{C:hazard}+#2#{}陷阱层数",
+                    "{C:poke_hazard}+#2#{}陷阱层数",
                     "{C:attention}百搭{}牌和{C:attention}陷阱{}牌",
                     "同时也是{C:attention}钢铁{}牌",
                     "{C:inactive,s:0.8}(在{C:attention,s:0.8}#1#{C:inactive,s:0.8}回合后进化)",
@@ -4848,7 +4848,7 @@ return {
             j_poke_ferrothorn = {
               name = "坚果哑铃",
               text = {
-                    "{C:hazard}+#1#{}陷阱层数",
+                    "{C:poke_hazard}+#1#{}陷阱层数",
                     "{C:attention}百搭{}牌和{C:attention}陷阱{}牌",
                     "同时也是{C:attention}钢铁{}牌",
                     "{br:2}ERROR - CONTACT STEAK",
@@ -4915,7 +4915,7 @@ return {
             j_poke_golett = {
                 name = "泥偶小人",
                 text = {
-                  "{C:hazard}+#1#{}陷阱层数",
+                  "{C:poke_hazard}+#1#{}陷阱层数",
                   "手牌{C:attention}中{}有{C:green}#4#/#5#{}的概率",
                   "提供{X:mult,C:white}X#2#{}倍率",
                   "{C:attention}陷阱牌{}必定触发",
@@ -4925,7 +4925,7 @@ return {
             j_poke_golurk = {
                 name = "泥偶巨人",
                 text = {
-                  "{C:hazard}+#1#{}陷阱层数",
+                  "{C:poke_hazard}+#1#{}陷阱层数",
                   "手牌{C:attention}中{}有{C:green}#3#/#4#{}的概率",
                   "提供{X:mult,C:white}X#2#{}倍率",
                   "{C:attention}陷阱牌{}必定触发",
@@ -5007,7 +5007,7 @@ return {
                     "若出牌包含{C:attention}同花{}，获得{C:chips}+#1#{} 筹码",
                     "{br:2}ERROR - CONTACT STEAK",
                     "若还包含{C:attention}国王{}或{C:attention}皇后{}，",
-                    "生成一张{C:pink}能量{}卡牌",
+                    "生成一张{C:poke_pink}能量{}卡牌",
                 }
             },
             j_poke_sylveon = {
@@ -5063,7 +5063,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "每使用一张{C:spectral}幻灵牌{}，",
                   "获得{C:money}$#3#{}，并为{C:attention}最左侧{}的小丑牌",
-                  "贴上{X:psychic,C:white}超能力{}属性贴纸",
+                  "贴上{X:poke_psychic,C:white}超能力{}属性贴纸",
                 }
             },
             j_poke_gourgeist_average = {
@@ -5075,7 +5075,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "每使用一张{C:spectral}幻灵牌{}，",
                   "获得{C:money}$#3#{}，并为{C:attention}最左侧{}的小丑牌",
-                  "贴上{X:psychic,C:white}超能力{}属性贴纸",
+                  "贴上{X:poke_psychic,C:white}超能力{}属性贴纸",
                 }
             },
             j_poke_gourgeist_large = {
@@ -5087,7 +5087,7 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "每使用一张{C:spectral}幻灵牌{}，",
                   "获得{C:money}$#3#{}，并为{C:attention}最左侧{}的小丑牌",
-                  "贴上{X:psychic,C:white}超能力{}属性贴纸",
+                  "贴上{X:poke_psychic,C:white}超能力{}属性贴纸",
                 }
             },
             j_poke_gourgeist_super = {
@@ -5099,14 +5099,14 @@ return {
                   "{br:2}ERROR - CONTACT STEAK",
                   "每使用一张{C:spectral}幻灵牌{}，",
                   "获得{C:money}$#3#{}，并为{C:attention}最左侧{}的小丑牌",
-                  "贴上{X:psychic,C:white}超能力{}属性贴纸",
+                  "贴上{X:poke_psychic,C:white}超能力{}属性贴纸",
                 }
             },
             j_poke_grubbin = {
                 name = '强颚鸡母虫',
                 text = {
                     "{C:mult}+#1#{}倍率",
-                    "如果你有{X:lightning, C:black}电{}属性的小丑牌",
+                    "如果你有{X:poke_lightning, C:black}电{}属性的小丑牌",
                     "此牌给予的倍率会增加{C:attention}三倍{}",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}个回合后进化）",
                 }
@@ -5114,7 +5114,7 @@ return {
             j_poke_charjabug = {
                 name = '虫电宝',
                 text = {
-                    "每张你拥有的{X:lightning, C:black}电{}属性小丑牌",
+                    "每张你拥有的{X:poke_lightning, C:black}电{}属性小丑牌",
                     "会给予{C:mult}+#1#{}倍率",
                     "{C:inactive}（目前为{C:mult}+#2#{C:inactive}倍率）",
                     "{C:inactive,s:0.8}（使用{} {C:attention,s:0.8}雷之石{}{C:inactive,s:0.8}牌进化）",
@@ -5124,7 +5124,7 @@ return {
                 name = '锹农炮虫',
                 text = {
                     "{C:mult}+#3#{}倍率",
-                    "每张其他你拥有的{X:lightning, C:black}电{}属性小丑牌",
+                    "每张其他你拥有的{X:poke_lightning, C:black}电{}属性小丑牌",
                     "会给予{X:mult,C:white} X#1# {}倍率",
                     "{C:inactive}（目前为{X:mult,C:white} X#2# {}{C:inactive}倍率）",
                 }
@@ -5308,7 +5308,7 @@ return {
                 "每跳过一个{C:attention}补充包{}，",
                 "获得 {C:mult}+#2#{} 倍率并生成一张",
                 "带有{C:dark_edition}闪箔{}、{C:dark_edition}全息{}或",
-                "{C:dark_edition}多彩{}版本的{C:item}道具{}牌",
+                "{C:dark_edition}多彩{}版本的{C:poke_item}道具{}牌",
                 "{C:inactive,s:0.8}(必须有空位)",
                 "{C:inactive}(当前 {C:mult}+#1#{C:inactive} 倍率)",
               }
@@ -5316,14 +5316,14 @@ return {
             j_poke_tarountula = {
                 name = "团珠蛛",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数，{C:attention}+#3#{}手牌上限",
+                    "{C:poke_hazard}+#1#{}陷阱层数，{C:attention}+#3#{}手牌上限",
                     "{C:inactive,s:0.8}(在{C:attention,s:0.8}#2#{C:inactive,s:0.8}回合后进化)",
                 }
             },
             j_poke_spidops = {
                 name = "操陷蛛",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数，{C:attention}+#2#{}手牌上限",
+                    "{C:poke_hazard}+#1#{}陷阱层数，{C:attention}+#2#{}手牌上限",
                     "为加入牌组的每第{C:attention}#3#{}张",
                     "{C:attention}游戏牌{C:inactive}[#4#]{}添加随机{C:attention}蜡封{}",
                 }
@@ -5336,7 +5336,7 @@ return {
                     "每次触发后，所需的{C:attention}点数{}增加",
                     "{C:inactive,s:0.8}(达到最高点数后会循环回最低点数)",
                     "{C:inactive}(当前 {C:chips}+#1#{C:inactive} 筹码)",
-                    "{C:inactive,s:0.8}(当你拥有{X:fire,C:white,s:0.8}火{}属性小丑牌时进化)",
+                    "{C:inactive,s:0.8}(当你拥有{X:poke_fire,C:white,s:0.8}火{}属性小丑牌时进化)",
                 }
             },
             j_poke_dachsbun = {
@@ -5345,7 +5345,7 @@ return {
                     "如果打出的牌包含{C:attention}#3#{}，此牌获得{C:chips}+#2#{}筹码",
                     "所需的{C:attention}卡牌点数{}会在每次触发时提升一点",
                     "{br:4}ERROR - CONTACT STEAK",
-                    "每张{X:fire,C:white}火{}属性小丑牌会增加{C:chips}+2{}到获得的筹码",
+                    "每张{X:poke_fire,C:white}火{}属性小丑牌会增加{C:chips}+2{}到获得的筹码",
                     "{C:inactive,s:0.8}（如果是A，那就会变回2）",
                     "{C:inactive}（目前有{C:chips}+#1#{C:inactive}筹码）",
                 }
@@ -5372,8 +5372,8 @@ return {
                 "回合结束时，为{C:attention}每张{}小丑牌",
                 "和{C:attention}消耗牌{}增加{C:money}$#1#{}出售价值",
                 "{br:2.5}ERROR - CONTACT STEAK",
-                "对{X:grass,C:white}草{}属性小丑牌和",
-                "{X:grass,C:white}草{}属性{C:pink}能量{}增加{C:attention}双倍{}",
+                "对{X:poke_grass,C:white}草{}属性小丑牌和",
+                "{X:poke_grass,C:white}草{}属性{C:poke_pink}能量{}增加{C:attention}双倍{}",
               }
             },
             j_poke_charcadet = {
@@ -5426,7 +5426,7 @@ return {
             j_poke_rellor = {
                 name = "虫滚泥",
                 text = {
-                    "本局每使用一张{C:item}道具{}牌，",
+                    "本局每使用一张{C:poke_item}道具{}牌，",
                     "给予{C:mult}+#1#{}倍率",
                     "{C:inactive}(当前为{C:mult}+#2#{C:inactive}倍率)",
                     "{C:inactive,s:0.8}(使用{C:attention,s:0.8}#3#{C:inactive,s:0.8}张道具后进化)",
@@ -5435,11 +5435,11 @@ return {
             j_poke_rabsca = {
                 name = "虫甲圣",
                 text = {
-                "使用{C:item}道具{}牌时，",
+                "使用{C:poke_item}道具{}牌时，",
                 "有{C:green}#3#/#4#{}概率生成一张{C:tarot}塔罗{}牌",
                 "{C:inactive}(必须有空位){}",
                 "{br:2}ERROR - CONTACT STEAK",
-                    "本局每使用一张{C:item}道具{}牌，",
+                    "本局每使用一张{C:poke_item}道具{}牌，",
                     "给予{C:mult}+#1#{}倍率",
                     "{C:inactive}(当前为{C:mult}+#2#{C:inactive}倍率)",
                 }
@@ -5584,7 +5584,7 @@ return {
                 name = '洛托姆图鉴',
                 text = {
                     "{C:attention}补充包{}价格降低，数值等于",
-                    "你拥有的小丑牌中不同{C:pink}属性{}的数量",
+                    "你拥有的小丑牌中不同{C:poke_pink}属性{}的数量",
                     "{C:inactive}(当前降低 {C:money}$#1#{C:inactive})",
                 }
             },
@@ -5610,7 +5610,7 @@ return {
                 name = "饭团",
                 text = {
                     "选择盲注后",
-                    "产生一张{X:colorless,C:white}无色{}{C:pink}能量{}牌",
+                    "产生一张{X:poke_colorless,C:white}无色{}{C:poke_pink}能量{}牌",
                     "{C:inactive}（剩余{C:attention}#1#{}{C:inactive}个回合）{}",
                 }
             },
@@ -5641,7 +5641,7 @@ return {
                     "{C:attention}属性变换{}",
                     "{br:2}ERROR - CONTACT STEAK",
                     "当选择盲注时，",
-                    "将最左侧小丑牌的{C:pink}类型{}转换为最右侧小丑牌的{C:pink}类型{}",
+                    "将最左侧小丑牌的{C:poke_pink}类型{}转换为最右侧小丑牌的{C:poke_pink}类型{}",
                     "{C:inactive}({C:attention}#1#{C:inactive} 回合剩余){}",
                 }
             },
@@ -5708,7 +5708,7 @@ return {
                 text = {
                     "在{C:attention}#1#{}回合后孵化为",
                     "一只{C:attention}基础{}或{C:attention}幼年{}小丑牌，",
-                    "若适用，附带{C:pink}能量注入{}",
+                    "若适用，附带{C:poke_pink}能量注入{}",
                 }
             },
             j_poke_daycare = {
@@ -5732,7 +5732,7 @@ return {
                 name = '十亿头狮子',
                 text = {
                     "当选择盲注时，",
-                    "销毁每张持有的{C:pink}类型{}小丑牌，",
+                    "销毁每张持有的{C:poke_pink}类型{}小丑牌，",
                     "然后每张销毁的小丑牌提供{X:mult,C:white}X#2#{} 倍率",
                     "{S:1.1,C:red,E:2}狮子耗尽时自毁{}",
                     "{C:inactive}(当前{X:mult,C:white}X#1#{C:inactive} 倍率，{C:attention}#3#{C:inactive}头狮子)",
@@ -5741,7 +5741,7 @@ return {
             j_poke_spiclops = {
                 name = "Spiclops",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数，{C:attention}+#2#{}手牌上限",
+                    "{C:poke_hazard}+#1#{}陷阱层数，{C:attention}+#2#{}手牌上限",
                     "为加入牌组的每第{C:attention}#3#{}张",
                     "{C:attention}游戏牌{C:inactive}[#4#]{}添加随机{C:attention}蜡封{}",
                     "选择{C:attention}盲注{}时，",
@@ -5818,10 +5818,10 @@ return {
             sleeve_poke_obituarysleeve_alt = {
                 name = "讣闻牌套",
                 text = {
-                    "{C:pink}粉红蜡封{}触发后有{C:green}#1#/#2#{}概率",
+                    "{C:poke_pink}粉红蜡封{}触发后有{C:green}#1#/#2#{}概率",
                     "被移除",
                     "小丑牌被售出或摧毁时，",
-                    "生成一张对应属性的{C:dark_edition}负片{}{C:pink}能量{}",
+                    "生成一张对应属性的{C:dark_edition}负片{}{C:poke_pink}能量{}",
                 },
             },
             sleeve_poke_revenantsleeve = {
@@ -5834,7 +5834,7 @@ return {
               name = "亡魂牌套",
               text = {
                   "{C:blue}+#1#{}消耗牌槽位",
-                  "{C:pink}口袋包{}不会",
+                  "{C:poke_pink}口袋包{}不会",
                   "出现在商店中",
               },
             },
@@ -5842,15 +5842,15 @@ return {
                 name = "发亮牌套",
                 text = {
                     "所有小丑牌生成时附有",
-                    "随机的{C:pink}属性{}贴纸",
-                    "并经过一次{C:pink}能量注入{}",
+                    "随机的{C:poke_pink}属性{}贴纸",
+                    "并经过一次{C:poke_pink}能量注入{}",
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "发亮牌套",
                 text = {
                     "重掷有{C:green}#1#/#2#{}概率",
-                    "生成一个{C:item}太晶珠{}",
+                    "生成一个{C:poke_item}太晶珠{}",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -5859,14 +5859,14 @@ return {
                     "开局时获得",
                     "{C:tarot,T:v_crystal_ball}#1#{}优惠券",
                     "和{C:attention}2{}张",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{}",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{}",
                 }
             },
             sleeve_poke_telekineticsleeve_alt = {
                 name = "念动力牌套",
                 text = {
                     "{C:attention}消耗牌{}区域中的",
-                    "{C:item,T:c_poke_twisted_spoon}#2#{}每张给予",
+                    "{C:poke_item,T:c_poke_twisted_spoon}#2#{}每张给予",
                     "{C:blue}+1{}消耗牌槽位",
                 }
             },
@@ -5876,15 +5876,15 @@ return {
                     "开局时获得",
                     "{C:tarot,T:v_poke_energysearch}#1#{}优惠券",
                     "和一张",
-                    "{C:pink,T:c_poke_double_rainbow_energy}#2#{}",
+                    "{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{}",
                 }
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "增幅牌套",
                 text = {
                     "开局时获得一张{C:dark_edition}负片{}",
-                    "{C:attention,T:j_poke_jelly_donut}#1#{}，而不是{C:pink,T:c_poke_double_rainbow_energy}#2#{}",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{}不再对非无色属性",
+                    "{C:attention,T:j_poke_jelly_donut}#1#{}，而不是{C:poke_pink,T:c_poke_double_rainbow_energy}#2#{}",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{}不再对非无色属性",
                     "小丑牌效果减半",
                 }
             },
@@ -5953,7 +5953,7 @@ return {
             sleeve_poke_diceysleeve = {
                 name = "碎屑牌套",
                 text = {
-                    "{C:hazard}+#1#{}陷阱层数和上限，{C:attention}+#1#{}手牌上限",
+                    "{C:poke_hazard}+#1#{}陷阱层数和上限，{C:attention}+#1#{}手牌上限",
                     "每回合结束时：",
                     "牌组中每张{C:attention}陷阱{}牌",
                     "获得{C:money}$#4#{}",
@@ -5989,7 +5989,7 @@ return {
                 text = {
                     "把选择的或最左边的",
                     "宝可梦进化到最高{C:attention}阶段{}",
-                    "并为其{C:pink}注入能量{}",
+                    "并为其{C:poke_pink}注入能量{}",
                 },
             },
             c_poke_megastone = {
@@ -6006,23 +6006,23 @@ return {
             c_poke_obituary = {
                 name = "讣告",
                 text = {
-                    "新增{C:pink}粉红{}蜡封",
+                    "新增{C:poke_pink}粉红{}蜡封",
                     "到选择的{C:attention}1{}张手牌中",
                 }
             },
             c_poke_nightmare = {
                 name = "梦魇",
                 text = {
-                    "摧毁一只选定的带{C:pink}属性{}的小丑牌，",
+                    "摧毁一只选定的带{C:poke_pink}属性{}的小丑牌，",
                     "并生成 {C:attention}2{} 张该小丑牌属性的",
-                    "{C:dark_edition}负片{}版本{C:pink}能量{}牌",
-                    "{C:inactive}(无属性小丑牌给予{X:colorless,C:white}无色{C:inactive})",
+                    "{C:dark_edition}负片{}版本{C:poke_pink}能量{}牌",
+                    "{C:inactive}(无属性小丑牌给予{X:poke_colorless,C:white}无色{C:inactive})",
                 },
             },
             c_poke_revenant = {
                 name = "亡魂",
                 text = {
-                    "新增 {C:item}白银{} 蜡封",
+                    "新增 {C:poke_item}白银{} 蜡封",
                     "到选择的 {C:attention}1{} 张手牌中",
                 }
             },
@@ -6030,7 +6030,7 @@ return {
                 name = "双彩虹能量",
                 text = {
                     "为最左边或选定的任意",
-                    "{C:pink}属性{}小丑牌{C:pink}注{C:red}入{C:attention}两{C:green}次{C:blue}能{C:purple}量{}",
+                    "{C:poke_pink}属性{}小丑牌{C:poke_pink}注{C:red}入{C:attention}两{C:green}次{C:blue}能{C:purple}量{}",
                     "本轮无法获得利息",
                     "{C:inactive}(每张小丑牌最多强化 {C:attention}#1#{C:inactive} 次)",
                 },
@@ -6095,7 +6095,7 @@ return {
             tag_poke_pocket_tag = {
                 name = "口袋标签",
                 text = {
-                    "获得一个免费的{C:pink}超级口袋包{}",
+                    "获得一个免费的{C:poke_pink}超级口袋包{}",
                     "{C:attention}第5底注{}及以后有{C:green}#1#%{}几率",
                     "含有{C:attention}超级石{}",
                     "{C:inactive,s:0.8}(几率不能提升){}",
@@ -6106,7 +6106,7 @@ return {
                 text = {
                     "下个在商店中的基础版本",
                     "小丑牌是免费的",
-                    "并变为{C:colorless}异色{}",
+                    "并变为{C:poke_colorless}异色{}",
                 },
             },
             tag_poke_stage_one_tag = {
@@ -6120,7 +6120,7 @@ return {
                 name = "狩猎标签",
                 text = {
                     "商店中有一个免费的",
-                    "{C:safari}狩猎{}宝可梦小丑牌",
+                    "{C:poke_safari}狩猎{}宝可梦小丑牌",
                 },
             },
             tag_poke_starter_tag = {
@@ -6158,13 +6158,13 @@ return {
             v_poke_energysearch = {
                 name = "能量搜索",
                 text = {
-                    "{C:pink}+2{}能量上限",
+                    "{C:poke_pink}+2{}能量上限",
                 },
             },
             v_poke_energyresearch = {
                 name = "能量研究",
                 text = {
-                    "{C:pink}+3{}能量上限",
+                    "{C:poke_pink}+3{}能量上限",
                 },
             },
             v_poke_goodrod = {
@@ -6177,7 +6177,7 @@ return {
             v_poke_superrod = {
                 name = "厉害钓竿",
                 text = {
-                    "你可以{C:pink}保留{}",
+                    "你可以{C:poke_pink}保留{}",
                     "所有{C:attention}消耗品{}包里的牌",
                 },
             },
@@ -6187,73 +6187,73 @@ return {
             Grass = {
                 name = "属性",
                 text = {
-                  "{X:grass,C:white}草{}",
+                  "{X:poke_grass,C:white}草{}",
                 }
             },
             Fire = {
                 name = "属性",
                 text = {
-                  "{X:fire,C:white}火{}",
+                  "{X:poke_fire,C:white}火{}",
                 }
             },
             Water = {
                 name = "属性",
                 text = {
-                  "{X:water,C:white}水{}",
+                  "{X:poke_water,C:white}水{}",
                 }
             },
             Lightning = {
                 name = "属性",
                 text = {
-                  "{X:lightning,C:black}电{}",
+                  "{X:poke_lightning,C:black}电{}",
                 }
             },
             Psychic = {
                 name = "属性",
                 text = {
-                  "{X:psychic,C:white}超能力{}",
+                  "{X:poke_psychic,C:white}超能力{}",
                 }
             },
             Fighting = {
                 name = "属性",
                 text = {
-                  "{X:fighting,C:white}格斗{}",
+                  "{X:poke_fighting,C:white}格斗{}",
                 }
             },
             Colorless = {
                 name = "属性",
                 text = {
-                  "{X:colorless,C:white}无色{}",
+                  "{X:poke_colorless,C:white}无色{}",
                 }
             },
             Dark = {
                 name = "属性",
                 text = {
-                  "{X:dark,C:white}恶{}",
+                  "{X:poke_dark,C:white}恶{}",
                 }
             },
             Metal = {
                 name = "属性",
                 text = {
-                  "{X:metal,C:white}钢{}",
+                  "{X:poke_metal,C:white}钢{}",
                 }
             },
             Fairy = {
                 name = "属性",
                 text = {
-                  "{X:fairy,C:white}妖精{}",
+                  "{X:poke_fairy,C:white}妖精{}",
                 }
             },
             Dragon = {
                 name = "属性",
                 text = {
-                  "{X:dragon,C:white}龙{}",
+                  "{X:poke_dragon,C:white}龙{}",
                 }
             },
             Earth = {
                 name = "属性",
                 text = {
-                  "{X:earth,C:white}地面{}",
+                  "{X:poke_earth,C:white}地面{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
@@ -6261,7 +6261,7 @@ return {
             Bird = {
                 name = "属性",
                 text = {
-                  "{X:bird,C:white}鸟{}",
+                  "{X:poke_bird,C:white}鸟{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -6503,7 +6503,7 @@ return {
                 name = "礼物",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}道具{} {C:attention}牌",
+                    "{C:green}30%{} - {C:poke_item}道具{} {C:attention}牌",
                     "{C:green}20%{} - {C:attention}优惠券标签",
                     "{C:green}15%{} - {C:dark_edition}多彩{} {C:attention}礼品卡",
                 }
@@ -6520,9 +6520,9 @@ return {
             dril_treasure = {
                 name = "宝物",
                 text = {
-                    "{C:green}30%{} - {C:attention}进化{C:item}之石   ",
+                    "{C:green}30%{} - {C:attention}进化{C:poke_item}之石   ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}2颗进化{C:item}之石",
+                    "{C:green}20%{} - {C:attention}2颗进化{C:poke_item}之石",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}5%{} - {C:money}$20{}             ",
                 }
@@ -6530,9 +6530,9 @@ return {
             exdril_treasure = {
                 name = "宝物",
                 text = {
-                    "{C:green}30%{} - {C:attention}进化{C:item}之石   ",
+                    "{C:green}30%{} - {C:attention}进化{C:poke_item}之石   ",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}2颗进化{C:item}之石",
+                    "{C:green}20%{} - {C:attention}2颗进化{C:poke_item}之石",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}4%{} - {C:money}$20{}             ",
                     "{C:green}1%{} - {C:attention}超级石     ",
@@ -6541,10 +6541,10 @@ return {
             pickup = {
               name = "捡拾",
               text = {
-                "{C:green}34%{} - {C:item}道具{}",
-                "{C:green}25%{} - {C:item}进化道具",
-                "{C:green}20%{} - {C:item}吃剩的东西",
-                "{C:green}20%{} - {C:item}弯曲的汤匙",
+                "{C:green}34%{} - {C:poke_item}道具{}",
+                "{C:green}25%{} - {C:poke_item}进化道具",
+                "{C:green}20%{} - {C:poke_item}吃剩的东西",
+                "{C:green}20%{} - {C:poke_item}弯曲的汤匙",
                 "{C:green}1%{} - {C:spectral}蜕变",
               }
             },
@@ -6604,14 +6604,14 @@ return {
             eeveelution = {
                 name = "进化形态",
                 text = {
-                    "{C:attention}水之石{} - {X:water,C:white}水伊布{}",
-                    "{C:attention}雷之石{} - {X:lightning,C:black}雷伊布{}",
-                    "{C:attention}火之石{} - {X:fire,C:white}火伊布{}",
-                    "{C:attention}日之石{} - {X:psychic,C:white}太阳伊布{}",
-                    "{C:attention}月之石{} - {X:dark,C:white}月亮伊布{}",
-                    "{C:attention}叶之石{} - {X:grass,C:white}叶伊布{}",
-                    "{C:attention}冰之石{} - {X:water,C:white}冰伊布{}",
-                    "{C:attention}光之石{} - {X:fairy,C:white}仙子伊布{}",
+                    "{C:attention}水之石{} - {X:poke_water,C:white}水伊布{}",
+                    "{C:attention}雷之石{} - {X:poke_lightning,C:black}雷伊布{}",
+                    "{C:attention}火之石{} - {X:poke_fire,C:white}火伊布{}",
+                    "{C:attention}日之石{} - {X:poke_psychic,C:white}太阳伊布{}",
+                    "{C:attention}月之石{} - {X:poke_dark,C:white}月亮伊布{}",
+                    "{C:attention}叶之石{} - {X:poke_grass,C:white}叶伊布{}",
+                    "{C:attention}冰之石{} - {X:poke_water,C:white}冰伊布{}",
+                    "{C:attention}光之石{} - {X:poke_fairy,C:white}仙子伊布{}",
                 }
             },
             poke_egg_tip = {
@@ -6671,13 +6671,13 @@ return {
               name = "无限能量",
               text = {
                 "你可以对小丑牌使用",
-                "任意次数的{C:pink}能量{}牌",
+                "任意次数的{C:poke_pink}能量{}牌",
               }
             },
             precise_energy_tooltip = {
                 name = "精准能量计量",
                 text = {
-                    "{s:0.8}在应用{C:pink,s:0.8}能量{}加成时，对所有数值使用{C:attention,s:0.8}小数{}",
+                    "{s:0.8}在应用{C:poke_pink,s:0.8}能量{}加成时，对所有数值使用{C:attention,s:0.8}小数{}",
                     "{s:0.8}{C:attention,s:0.8}关闭{}此选项时，将发生以下情况:{}",
                     "{C:attention}1. {X:mult,C:white,s:0.8}X{} {s:0.8}倍率 - 使用小数",
                     "{C:attention}2. {s:0.8}+ {C:mult,s:0.8}倍率{}和{C:chips,s:0.8}筹码{} - 向上取整为整数",
@@ -6862,7 +6862,7 @@ return {
             allowpokeballs_tooltip = {
               name = "允许精灵球",
               text = {
-                "允许精灵球{C:item}道具{}出现",
+                "允许精灵球{C:poke_item}道具{}出现",
               }
             },
             pokemaster_tooltip = {
@@ -6920,7 +6920,7 @@ return {
                 text = {
                     "如果此牌在{C:attention}第一次出牌{}时计分，",
                     "产生一张与你拥有的某个小丑牌",
-                    "{C:attention}属性{}相同的{C:pink}能量{}牌",
+                    "{C:attention}属性{}相同的{C:poke_pink}能量{}牌",
                     "{C:inactive}（必须有空位）{}",
                 },
             },
@@ -6930,7 +6930,7 @@ return {
             poke_silver_seal = {
                 name = "白银蜡封",
                 text = {
-                    "生成一张{C:item}道具牌{}，",
+                    "生成一张{C:poke_item}道具牌{}，",
                     "如果在计分时仍{C:attention}在手中{}，则被{C:attention}弃掉{}",
                 }
             },
@@ -6946,73 +6946,73 @@ return {
             grass_sticker = {
                 name = "Type",
                 text = {
-                    "{X:grass,C:white}Grass{}"
+                    "{X:poke_grass,C:white}Grass{}"
                 }
             },
             fire_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fire,C:white}Fire{}"
+                    "{X:poke_fire,C:white}Fire{}"
                 }
             },
             water_sticker = {
                 name = "Type",
                 text = {
-                    "{X:water,C:white}Water{}"
+                    "{X:poke_water,C:white}Water{}"
                 }
             },
             lightning_sticker = {
                 name = "Type",
                 text = {
-                    "{X:lightning,C:white}Lightning{}"
+                    "{X:poke_lightning,C:white}Lightning{}"
                 }
             },
             psychic_sticker = {
                 name = "Type",
                 text = {
-                    "{X:psychic,C:white}Psychic{}"
+                    "{X:poke_psychic,C:white}Psychic{}"
                 }
             },
             fighting_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fighting,C:white}Fighting{}"
+                    "{X:poke_fighting,C:white}Fighting{}"
                 }
             },
             colorless_sticker = {
                 name = "Type",
                 text = {
-                    "{X:colorless,C:white}Colorless{}"
+                    "{X:poke_colorless,C:white}Colorless{}"
                 }
             },
             dark_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dark,C:white}Dark{}"
+                    "{X:poke_dark,C:white}Dark{}"
                 }
             },
             metal_sticker = {
                 name = "Type",
                 text = {
-                    "{X:metal,C:white}Metal{}"
+                    "{X:poke_metal,C:white}Metal{}"
                 }
             },
             fairy_sticker = {
                 name = "Type",
                 text = {
-                    "{X:fairy,C:white}Fairy{}"
+                    "{X:poke_fairy,C:white}Fairy{}"
                 }
             },
             dragon_sticker = {
                 name = "Type",
                 text = {
-                    "{X:dragon,C:white}Dragon{}"
+                    "{X:poke_dragon,C:white}Dragon{}"
                 }
             },
             earth_sticker = {
                 name = "Type",
                 text = {
-                    "{X:earth,C:white}Earth{}"
+                    "{X:poke_earth,C:white}Earth{}"
                 }
             },
             --]]
@@ -7039,57 +7039,57 @@ return {
             p_poke_pokepack_normal_1 = {
                 name = "口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "特大口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "超级口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "特大口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "超级口袋包",
                 text = {
-                    "从{C:attention}#2#{}张{C:item}道具{}牌",
-                    "和{C:attention}#3#{}张{C:pink}能量{}牌中选择{C:attention}#1#{}张",
+                    "从{C:attention}#2#{}张{C:poke_item}道具{}牌",
+                    "和{C:attention}#3#{}张{C:poke_pink}能量{}牌中选择{C:attention}#1#{}张",
                 },
             },
             p_poke_pokepack_wish_pack = {
@@ -7464,7 +7464,7 @@ return {
            ch_c_poke_add_joker_slots = {"打败Boss盲注后，{C:attention}+1{}小丑牌槽位{C:inactive}（最多5个）"},
            ch_c_poke_nuzlocke = {"每个底注的第一个商店必定有{C:attention}小丑包"},
            ch_c_apply_randomizer = {"宝可梦小丑牌会进化成随机宝可梦小丑牌"},
-           ch_c_no_energy = {"{C:pink}能量{}牌不再出现在{C:attention}商店{}中"},
+           ch_c_no_energy = {"{C:poke_pink}能量{}牌不再出现在{C:attention}商店{}中"},
            ch_c_poke_mystery_dungeon = {"开局时拥有一张{C:attention}永恒{}小丑牌"},
            ch_c_poke_mystery_dungeon2 = {"应用一个随机宝可牌牌组效果"},
            ch_c_poke_mystery_dungeon3 = {"每天在{C:attention}"..tostring(os.date("%I:%M %p", 0)).."{}重置"},

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -39,7 +39,7 @@ return {
                 text = {
                     "開始遊戲時獲得",
                     "{C:tarot,T:v_crystal_ball}#1#{}兌換券",
-                    "及{C:attention}兩張{}{C:item,T:c_poke_twisted_spoon}#2#",
+                    "及{C:attention}兩張{}{C:poke_item,T:c_poke_twisted_spoon}#2#",
                 } 
             },
             --Fun fact: this and luminious deck had their descriptions mixed up
@@ -59,8 +59,8 @@ return {
                 name = "發亮牌組",
                 text = {
                     "所有小丑牌帶有",
-                    "隨機的{C:pink}屬性{}貼紙",
-                    "及{C:attention}+1{}{C:pink}能量{}"
+                    "隨機的{C:poke_pink}屬性{}貼紙",
+                    "及{C:attention}+1{}{C:poke_pink}能量{}"
                 }
             },
             b_poke_ampeddeck = {
@@ -68,7 +68,7 @@ return {
                 text = {
                     "開始遊戲時獲得",
                     "{C:tarot,T:v_poke_energysearch}#1#{}兌換券",
-                    "及一張{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "及一張{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             b_poke_futuredeck = {
@@ -105,7 +105,7 @@ return {
             b_poke_diceydeck = {
                 name = "碎石牌組",
                 text = {
-                    "陷阱層級及上限{C:hazard}+#1#{}，手牌數量{C:attention}+#1#{}",
+                    "陷阱層級及上限{C:poke_hazard}+#1#{}，手牌數量{C:attention}+#1#{}",
                     "回合結束時：",
                     "每張在{C:attention}完整牌組{}中的{C:attention}陷阱{}",
                     "會給予{C:money}$#4#{}",
@@ -312,16 +312,16 @@ return {
                 name = "太晶珠",
                 text = {
                     "{C:attention}屬性變更：{}{B:1,V:2}#1#{}",
-                    "{C:inactive,s:0.8}（{C:pink,s:0.8}屬性{C:inactive,s:0.8}會在棄掉手牌時變更）{}",
+                    "{C:inactive,s:0.8}（{C:poke_pink,s:0.8}屬性{C:inactive,s:0.8}會在棄掉手牌時變更）{}",
                     "{br:2}此為分隔線",
                     "如果選擇或最左邊的小丑牌",
-                    "已經是{B:1,V:2}#1#{}{C:pink}屬性{}，對那張小丑牌增加一級{C:pink}能量{}",
+                    "已經是{B:1,V:2}#1#{}{C:poke_pink}屬性{}，對那張小丑牌增加一級{C:poke_pink}能量{}",
                 },
             },
             c_poke_metalcoat = {
                 name = "金屬膜",
                 text = {
-                    "{C:attention}屬性變更：{}{X:metal,C:white}鋼{}",
+                    "{C:attention}屬性變更：{}{X:poke_metal,C:white}鋼{}",
                     "{br:2}此為分隔線",
                     "產生一張",
                     "與選擇的{C:attention}1張{}卡牌的牌級相同的{C:attention}鋼鐵牌{}",
@@ -330,10 +330,10 @@ return {
             c_poke_dragonscale = {
                 name = "龍之鱗片",
                 text = {
-                    "{C:attention}屬性變更：{}{X:dragon,C:white}龍{}",
+                    "{C:attention}屬性變更：{}{X:poke_dragon,C:white}龍{}",
                     "{br:2}此為分隔線",
                     "產生最多{C:attention}3{}張隨機的",
-                    "{C:item}物品牌{}或{C:pink}能量牌{}",
+                    "{C:poke_item}物品牌{}或{C:poke_pink}能量牌{}",
                     "{C:inactive}（必須有空位）{}"
                 },
             },
@@ -390,8 +390,8 @@ return {
                 name = "彎曲的湯匙",
                 text = {
                     "產生這局遊戲中最近使用的",
-                    "{C:item}物品{}牌或{C:pink}能量{}牌",
-                    "{s:0.8,C:item}彎曲的湯匙，可重用物品及樹果汁{s:0.8}除外"
+                    "{C:poke_item}物品{}牌或{C:poke_pink}能量{}牌",
+                    "{s:0.8,C:poke_item}彎曲的湯匙，可重用物品及樹果汁{s:0.8}除外"
                 }
             },
             c_poke_prismscale = {
@@ -431,7 +431,7 @@ return {
                     "{C:attention}進化牌{}",
                     "{br:2}此為分隔線",
                     "加強{C:attention}1{}張選擇的卡牌至{C:attention}石頭牌{}",
-                    "每張你持有的{X:earth,C:white}地面{}屬性的小丑牌",
+                    "每張你持有的{X:poke_earth,C:white}地面{}屬性的小丑牌",
                     "會對那張牌給予{C:chips}+#2#{}額外籌碼",
                 }
             },
@@ -462,8 +462,8 @@ return {
             c_poke_berry_juice_energy = {
                 name = "能量樹果汁",
                 text = {
-                    "對最左邊或選擇的任意{C:pink}屬性{}的小丑牌",
-                    "增加一級{C:pink}能量{}",
+                    "對最左邊或選擇的任意{C:poke_pink}屬性{}的小丑牌",
+                    "增加一級{C:poke_pink}能量{}",
                     "{C:inactive}（每個小丑牌可增加能量{C:attention}#1#{C:inactive}次）",
                 },
             },
@@ -485,7 +485,7 @@ return {
             c_poke_berry_juice_item = {
                 name = "物品樹果汁",
                 text = {
-                    "產生一張{C:item}彎曲的湯匙{}牌",
+                    "產生一張{C:poke_item}彎曲的湯匙{}牌",
                     "有{C:green}#1#/#2#{}的機率",
                     "產生{C:attention}額外{}一張",
                     "{C:inactive}（必須有空位）{}"
@@ -502,7 +502,7 @@ return {
                 name = "神秘樹果汁",
                 text = {
                     "產生一張",
-                    "隨機的{C:item}樹果汁{}牌"
+                    "隨機的{C:poke_item}樹果汁{}牌"
                 }
             },
             c_poke_oven = {
@@ -561,15 +561,15 @@ return {
             c_poke_grass_energy = {
                 name = "草能量",
                 text = {
-                    "對最左邊或選擇的{X:grass,C:white}草{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_grass,C:white}草{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fire_energy = {
                 name = "火能量",
                 text = {
-                    "對最左邊或選擇的{X:fire,C:white}火{}屬性小丑牌的",
+                    "對最左邊或選擇的{X:poke_fire,C:white}火{}屬性小丑牌的",
                     "{C:attention}加分{}及{C:money}金錢{}數值",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
@@ -577,40 +577,40 @@ return {
             c_poke_water_energy = {
                 name = "水能量",
                 text = {
-                    "對最左邊或選擇的{X:water,C:white}水{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_water,C:white}水{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_lightning_energy = {
                 name = "電能量",
                 text = {
-                    "對最左邊或選擇的{X:lightning,C:black}電{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_lightning,C:black}電{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_psychic_energy = {
                 name = "超能量",
                 text = {
-                    "對最左邊或選擇的{X:psychic,C:white}超能力{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_psychic,C:white}超能力{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fighting_energy = {
                 name = "鬥能量",
                 text = {
-                    "對最左邊或選擇的{X:fighting,C:white}格鬥{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_fighting,C:white}格鬥{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_colorless_energy = {
                 name = "無色能量",
                 text = {
-                    "對最左邊或選擇的{X:colorless,C:white}一般{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_colorless,C:white}一般{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "對非{C:attention}一般{}屬性小丑牌的增強效果減半",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
@@ -618,8 +618,8 @@ return {
             c_poke_darkness_energy = {
                 name = "惡能量",
                 text = {
-                    "對最左邊或選擇的{X:dark,C:white}惡{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_dark,C:white}惡{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -627,15 +627,15 @@ return {
                 name = "鋼能量",
                 text = {
                     "對最左邊或選擇的{X:Metal,C:white}鋼{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_fairy_energy = {
                 name = "妖能量",
                 text = {
-                    "對最左邊或選擇的{X:fairy,C:white}妖精{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_fairy,C:white}妖精{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -643,16 +643,16 @@ return {
             c_poke_dragon_energy = {
                 name = "龍能量",
                 text = {
-                    "對最左邊或選擇的{X:dragon,C:white}龍{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_dragon,C:white}龍{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
             c_poke_earth_energy = {
                 name = "地能量",
                 text = {
-                    "對最左邊或選擇的{X:earth,C:white}地面{}屬性小丑牌",
-                    "增加{C:pink}能量{}，如果可適用",
+                    "對最左邊或選擇的{X:poke_earth,C:white}地面{}屬性小丑牌",
+                    "增加{C:poke_pink}能量{}，如果可適用",
                     "{C:inactive}(每張小丑牌可增強{C:attention}#1#{}{C:inactive}次)",
                 },
             },
@@ -1304,7 +1304,7 @@ return {
                 text = {
                     "如果打出的{C:attention}牌型{}",
                     "已經在這個回合打出的話",
-                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:item}物品{}牌",
+                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:poke_item}物品{}牌",
                     "{C:inactive}（在{C:attention}#3#{}{C:inactive}個回合後進化）"
                 } 
             },
@@ -1313,7 +1313,7 @@ return {
                 text = {
                     "如果打出的{C:attention}牌型{}",
                     "已經在這個回合打出的話",
-                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:item}彎曲的湯匙{}牌",
+                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:poke_item}彎曲的湯匙{}牌",
                     "{C:inactive}（使用{}{C:attention}聯繫繩{}{C:inactive}後進化）"
                 } 
             },
@@ -1323,7 +1323,7 @@ return {
                     "消耗牌欄位{C:attention}+#3#{}",
                     "如果打出的{C:attention}牌型{}",
                     "已經在這個回合打出的話",
-                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:item}彎曲的湯匙{}牌"
+                    "將有{C:green}#1#/#2#{}的機率產生一張{C:attention}愚者{}牌或{C:poke_item}彎曲的湯匙{}牌"
                 } 
             },
             j_poke_mega_alakazam = {
@@ -1331,7 +1331,7 @@ return {
                 text = {
                     "消耗牌欄位{C:attention}+#3#{}",
                     "每張持有的{C:attention}消耗牌{}會給予{X:mult,C:white}X#1#{}倍數",
-                    "{C:item}彎曲的湯匙{}會給予{X:mult,C:white}X#2#{}倍數",
+                    "{C:poke_item}彎曲的湯匙{}會給予{X:mult,C:white}X#2#{}倍數",
                 } 
             },
             j_poke_machop = {
@@ -1492,7 +1492,7 @@ return {
                 text = {
                     "每張打出的{C:attention}鋼鐵{}牌",
                     "會在得分時給予{X:red,C:white}X#1#{}倍數",
-                    "每張在這張牌旁邊的{X:metal,C:white}鋼{}屬性小丑牌",
+                    "每張在這張牌旁邊的{X:poke_metal,C:white}鋼{}屬性小丑牌",
                     "會對加成增加{X:red,C:white}X#2#{}倍數",
                     "{C:inactive}（目前將給予{X:red,C:white}X#3#{}{C:inactive}倍數）{}",
                     "{C:inactive,s:0.8}（使用{C:attention,s:0.8}雷之石{}{C:inactive,s:0.8}後進化）"
@@ -1619,7 +1619,7 @@ return {
                 text = {
                     "當有{C:attention}非石頭{}牌被摧毀時",
                     "新增一張{C:attention}石頭{}牌到{C:attention}牌組{}中",
-                    "{C:inactive}（附上{C:metal}鋼{}{C:inactive}貼紙後進化）{}"
+                    "{C:inactive}（附上{C:poke_metal}鋼{}{C:inactive}貼紙後進化）{}"
                 } 
             },
             j_poke_drowzee = {
@@ -1820,7 +1820,7 @@ return {
                     "會在得分時給予這張小丑牌{C:mult}+#2#{}倍數",
                     "如果手牌中持有{C:attention}K{}，加成效果翻倍",
                     "{C:inactive}（目前將給予{C:mult}+#1#{C:inactive}倍數）",
-                    "{C:inactive,s:0.8}（附上{C:dragon,s:0.8}龍{}{C:inactive,s:0.8}貼紙後進化）{}"
+                    "{C:inactive,s:0.8}（附上{C:poke_dragon,s:0.8}龍{}{C:inactive,s:0.8}貼紙後進化）{}"
                 } 
             },
             j_poke_goldeen = {
@@ -1866,7 +1866,7 @@ return {
                     "選擇盲注後，摧毀右邊的小丑牌並獲得{C:mult}+#2#{}倍數",
                     "如果被摧毀的小丑牌是{C:red}稀有{}或以上",
                     "新增{C:attention}銀箔{}，{C:attention}全息{}或{C:attention}彩色{}版本",
-                    "{C:inactive}（附上{C:metal}鋼{}{C:inactive}貼紙或使用{C:attention,s:0.8}硬石頭{C:inactive,s:0.8}牌後進化）{}",
+                    "{C:inactive}（附上{C:poke_metal}鋼{}{C:inactive}貼紙或使用{C:attention,s:0.8}硬石頭{C:inactive,s:0.8}牌後進化）{}",
                     "{C:inactive}（目前將給予{C:mult}+#1#{C:inactive} 倍數）"
                 } 
             },
@@ -1968,7 +1968,7 @@ return {
                     "{C:attention}右邊揮發{}",
                     "離開商店後",
                     "這張小丑牌會{C:attention}變為{}最左邊的小丑牌",
-                    "並對自身附上{C:attention}有限期{}及{C:colorless}一般{}屬性的貼紙",
+                    "並對自身附上{C:attention}有限期{}及{C:poke_colorless}一般{}屬性的貼紙",
                     "{C:inactive,s:0.8}（不能變為百變怪）",
                 } 
             },
@@ -2007,9 +2007,9 @@ return {
             j_poke_porygon = {
                 name = '多邊獸',
                 text = {
-                    "能量上限{C:pink}+1{}",
+                    "能量上限{C:poke_pink}+1{}",
                     "每次打開{C:attention}擴充包{}時",
-                    "產生一張{C:pink}能量{}牌",
+                    "產生一張{C:poke_pink}能量{}牌",
                     "{C:inactive}（使用{} {C:attention}升級資料{}{C:inactive}後進化）"
                 } 
             },
@@ -2019,7 +2019,7 @@ return {
                     "{C:attention}原始的#1#{}",
                     "{C:attention}一張{}：產生一張隨機的{C:attention}塔羅{}牌",
                     "{C:attention}兩張{}：獲得{C:money}$#2#{}",
-                    "{C:attention}三張或以上{}：產生一張隨機的{C:item}物品牌{}{C:inactive,s:0.8}（觸發{C:attention,s:0.8}#3#{C:inactive,s:0.8}次後進化）",
+                    "{C:attention}三張或以上{}：產生一張隨機的{C:poke_item}物品牌{}{C:inactive,s:0.8}（觸發{C:attention,s:0.8}#3#{C:inactive,s:0.8}次後進化）",
                     "{C:inactive}（必須有空位）",
                 } 
             },
@@ -2029,7 +2029,7 @@ return {
                     "{C:attention}原始的#1#{}",
                     "{C:attention}一張{}：產生一張隨機的{C:attention}塔羅{}牌",
                     "{C:attention}兩張{}：獲得{C:money}$#2#{}",
-                    "{C:attention}三張{}：產生一張隨機的{C:item}物品牌{}",
+                    "{C:attention}三張{}：產生一張隨機的{C:poke_item}物品牌{}",
                     "{C:attention}四張或以上{}：每個回合只限一次，產生一個{C:attention}標籤{}",
                     "{C:inactive}（必須有空位）",
                 } 
@@ -2135,7 +2135,7 @@ return {
                 name = '超夢',
                 text = {
                     "離開商店後，{C:attention}複製及摧毀{}最左邊的{C:attention}小丑牌{}",
-                    "副本帶有{C:dark_edition}彩色{}版本及{C:attention}+1{}{C:pink}能量{}",
+                    "副本帶有{C:dark_edition}彩色{}版本及{C:attention}+1{}{C:poke_pink}能量{}",
                     "每張{C:dark_edition}彩色{}版本的小丑牌給予{X:mult,C:white} X#1# {}倍數",
                     "{C:inactive}（不能摧毀自身）",
                 } 
@@ -2150,17 +2150,17 @@ return {
                 name = "超級超夢 Y",
                 text = {
                     "離開商店後",
-                    "對最左邊的小丑牌給予{C:attention}+2{}{C:pink}能量{}",
+                    "對最左邊的小丑牌給予{C:attention}+2{}{C:poke_pink}能量{}",
                     "{br:2}此為分隔線",
                     "擊敗{C:attention}首領盲注{}後",
-                    "能量上限{C:pink}+1{}",
+                    "能量上限{C:poke_pink}+1{}",
                 } 
             },
             j_poke_mew = {
                 name = '夢幻',
                 text = {
                     "離開商店後，產生一張隨機的",
-                    "{C:dark_edition}負片{}{C:attention}塔羅{}，{C:spectral}幻靈{}或{C:item}物品{}牌",
+                    "{C:dark_edition}負片{}{C:attention}塔羅{}，{C:spectral}幻靈{}或{C:poke_item}物品{}牌",
                     "有機率產生一張隨機的{C:dark_edition}負片{}小丑牌",
                 } 
             },
@@ -2341,8 +2341,8 @@ return {
                   "如果得分的手牌包含{C:attention}對子",
                   "將給予{C:chips}+#1#{}籌碼並獲得{C:money}$#2#{}",
                   "{br:3}此為分隔線",
-                  "每張{X:water,C:white}水{}屬性的小丑牌會額外給予{C:chips}+#3#{}籌碼",
-                  "每張{X:lightning,C:black}雷{}屬性的小丑牌會額外給予{C:money}$#4#{}",
+                  "每張{X:poke_water,C:white}水{}屬性的小丑牌會額外給予{C:chips}+#3#{}籌碼",
+                  "每張{X:poke_lightning,C:black}雷{}屬性的小丑牌會額外給予{C:money}$#4#{}",
                   "{C:inactive}（目前將給予{C:chips}+#6#{C:inactive}籌碼及{C:money}$#5#{C:inactive}）"
                 }
             },
@@ -2466,9 +2466,9 @@ return {
             j_poke_weird_tree = {
                 name = "奇怪的樹",
                 text = {
-                  "{C:attention}屬性轉換：{X:grass,C:white}草{}",
-                  "如果這張卡牌不是{X:grass,C:white}草{}屬性",
-                  "或你持有{X:water,C:white}水{}屬性的小丑牌",
+                  "{C:attention}屬性轉換：{X:poke_grass,C:white}草{}",
+                  "如果這張卡牌不是{X:poke_grass,C:white}草{}屬性",
+                  "或你持有{X:poke_water,C:white}水{}屬性的小丑牌",
                   "這張卡牌會在回合結束後{C:}變形{}",
                 }
             },
@@ -2487,7 +2487,7 @@ return {
                     "每張打出的{V:1}#2#{}花色的卡牌",
                     "會在得分時給予{C:mult}+#1#{}倍數",
                     "{br:5}此為分隔線",
-                    "那些牌會依{X:water,C:white}水屬性{}",
+                    "那些牌會依{X:poke_water,C:white}水屬性{}",
                     "的小丑牌的數量而額外觸發",
                     "{C:inactive,s:0.8}（{C:attention,s:0.8}#7#{}{C:inactive,s:0.8}次的額外觸發數量會平均分配到每張的得分牌）{}",
                     "花色在出牌後按次序地變更{C:inactive,s:0.8}(#3#, #4#, #5#, #6#){}",
@@ -2597,7 +2597,7 @@ return {
             j_poke_murkrow = {
                 name = "黑暗鴉",
                 text = {
-                  "每張持有的{X:dark,C:white}惡{}屬性的小丑牌",
+                  "每張持有的{X:poke_dark,C:white}惡{}屬性的小丑牌",
                   "會給予{X:red,C:white}X#1#{}倍數",
                   "{C:inactive}（目前將給予{X:red,C:white} X#2#{C:inactive}倍數）",
                   "{C:inactive,s:0.8}（使用{C:attention,s:0.8}暗之石{C:inactive,s:0.8}後進化）"
@@ -2726,7 +2726,7 @@ return {
             j_poke_qwilfish = {
                 name = '千針魚',
                 text = {
-                    "陷阱層級{C:hazard}+#1#",
+                    "陷阱層級{C:poke_hazard}+#1#",
                     "當有{C:attention}加強牌{}被摧毀時",
                     "這張小丑牌會獲得{C:chips}+#2#{}籌碼",
                     "{C:inactive}（目前將給予{C:chips}+#3#{C:inactive}籌碼）",
@@ -2756,8 +2756,8 @@ return {
                 name = "壺壺",
                 text = {
                   "選擇{C:attention}盲注{}後，摧毀最左邊的{C:attention}消耗牌{}",
-                  "並產生一張{C:item}樹果汁{}牌",
-                  "{C:inactive}（不能摧毀{C:item}樹果汁{C:inactive}牌）"
+                  "並產生一張{C:poke_item}樹果汁{}牌",
+                  "{C:inactive}（不能摧毀{C:poke_item}樹果汁{C:inactive}牌）"
                 }
             },
             j_poke_sneasel = {
@@ -2782,7 +2782,7 @@ return {
               text = {
                 "當有{C:attention}擴充包{}被跳過時",
                 "這張小丑牌將獲得{C:mult}+#2#{}倍數",
-                "並產生一張隨機的{C:item}物品牌{}",
+                "並產生一張隨機的{C:poke_item}物品牌{}",
                 "{C:inactive,s:0.8}（必須有空位）",
                 "{C:inactive}（目前將給予{C:mult}+#1#{C:inactive}倍數）",
                 "{C:inactive,s:0.8}（使用{C:attention,s:0.8}月之石{C:inactive,s:0.8}後進化）",
@@ -2849,9 +2849,9 @@ return {
                 name = '太陽珊瑚',
                 text = {
                     "選擇{C:attention}盲注{}後",
-                    "每張你持有的{X:water,C:white}水{}屬性小丑牌",
+                    "每張你持有的{X:poke_water,C:white}水{}屬性小丑牌",
                     "會給予這張小丑牌{C:mult}+#1#{}倍數",
-                    "然後產生一張{C:attention}基礎{}的{X:water,C:white}水{}屬性小丑牌",
+                    "然後產生一張{C:attention}基礎{}的{X:poke_water,C:white}水{}屬性小丑牌",
                     "{C:inactive,s:0.8}（必須有空位）",
                     "{C:inactive}（目前將給予{C:mult}+#2#{C:inactive}倍數）",
                 }
@@ -2892,7 +2892,7 @@ return {
             j_poke_skarmory = {
                 name = '盔甲鳥',
                 text = {
-                    "陷阱層級{C:hazard}+#1#{}，陷阱層級上限{C:earth}+#4#{}",
+                    "陷阱層級{C:poke_hazard}+#1#{}，陷阱層級上限{C:poke_earth}+#4#{}",
                     "每張在{C:attention}手中{}的{C:attention}陷阱牌{}或{C:attention}鋼鐵牌{}",
                     "會給予{X:mult,C:white}X#2#{}倍數",
                     "{C:inactive}（目前將給予{X:mult,C:white}X#3#{C:inactive}倍數）",
@@ -2928,10 +2928,10 @@ return {
             j_poke_porygon2 = {
                 name = '多邊獸Ⅱ',
                 text = {
-                    "能量上限{C:pink}+2{}",
+                    "能量上限{C:poke_pink}+2{}",
                     "每次打開{C:attention}擴充包{}時",
-                    "產生一張與最左邊的小丑牌的{C:pink}屬性{}",
-                    "相同的{C:pink}能量{}牌",
+                    "產生一張與最左邊的小丑牌的{C:poke_pink}屬性{}",
+                    "相同的{C:poke_pink}能量{}牌",
                     "{C:inactive}（使用{}{C:attention}可疑修正檔{}{C:inactive}後進化）"
                 } 
             },
@@ -3032,7 +3032,7 @@ return {
                 name = "大奶罐",
                 text = {
                   "回合結束時",
-                  "每張持有的{C:colorless}一般{}小丑牌",
+                  "每張持有的{C:poke_colorless}一般{}小丑牌",
                   "會給予{C:money}$#1#{}", 
                   "{C:inactive}（目前將給予{C:money}$#2#{C:inactive}）{}"
                 }
@@ -3153,7 +3153,7 @@ return {
                     "手牌數量{C:attention}+#3#{}，{C:attention}偏好：{C:inactive}（{C:attention}#6#，#7#，#8#{C:inactive}）{}",
                     "每張打出的{C:attention}偏好{}卡牌",
                     "在得分時獲得{C:money}$#1#{}",
-                    "每張{X:grass,C:white}草{}屬性小丑牌會對以上的加成增加{C:money}$#5#{}",
+                    "每張{X:poke_grass,C:white}草{}屬性小丑牌會對以上的加成增加{C:money}$#5#{}",
                     "{C:inactive}（目前將給予{C:money}$#4#{}{C:inactive}）{}"
                 } 
             },
@@ -3183,7 +3183,7 @@ return {
                     "在得分時給予{C:mult}+#1#{}倍數",
                     "{br:2}此為分隔線",
                     "如果你在這個回合中棄掉{C:attention}#4# {C:inactive}[#5#]張{C:attention}偏好{}卡牌",
-                    "每張{X:fire,C:white}火{}或{X:fighting,C:white}鬥{}屬性的小丑牌會給予{X:mult,C:white} X#2# {}倍數",
+                    "每張{X:poke_fire,C:white}火{}或{X:poke_fighting,C:white}鬥{}屬性的小丑牌會給予{X:mult,C:white} X#2# {}倍數",
                 } 
             },
             j_poke_mudkip = {
@@ -3212,7 +3212,7 @@ return {
                     "在得分時給予{C:chips}+#1#{}籌碼",
                     "{br:2}此為分隔線",
                     "如果打出的牌型包含{C:attention}#3#張偏好{}卡牌",
-                    "你持有的每{C:attention}2{}張{X:water,C:white}水{}或{X:earth,C:white}地{}屬性的小丑牌",
+                    "你持有的每{C:attention}2{}張{X:poke_water,C:white}水{}或{X:poke_earth,C:white}地{}屬性的小丑牌",
                     "會產生一張{C:tarot}塔羅{}牌",
                     "{C:inactive}（必須有空位）{}"
                 } 
@@ -3232,7 +3232,7 @@ return {
                 "每張卡牌被{C:attention}摧毀{}時",
                 "這張小丑牌將獲得{C:mult}+#2#{}倍數",
                 "{br:2}此為分隔線",
-                "每張持有的{X:dark,C:white}惡{}屬性小丑牌",
+                "每張持有的{X:poke_dark,C:white}惡{}屬性小丑牌",
                 "會對獲得的倍數提升{C:mult}+#3#{}",
                 "{C:inactive}（目前將給予{C:mult}+#1#{C:inactive}倍數）",
               }
@@ -3241,7 +3241,7 @@ return {
               name = "蛇紋熊",
               text = {
                 "打出手牌時，有{C:green}#1#/#2#{}的機率",
-                "產生一張隨機的{C:attention}撿拾的{}{C:item}物品{}",
+                "產生一張隨機的{C:attention}撿拾的{}{C:poke_item}物品{}",
                 "{C:inactive}（必須有空位）",
                 "{C:inactive,s:0.8}（在{C:attention}#3#{C:inactive,s:0.8}個回合後進化）",
               }
@@ -3250,7 +3250,7 @@ return {
               name = "直衝熊",
               text = {
                 "打出手牌時，有{C:green}#1#/#2#{}的機率",
-                "產生一張隨機的{C:attention}撿拾的{}{C:item}物品{}",
+                "產生一張隨機的{C:attention}撿拾的{}{C:poke_item}物品{}",
                 "如果打出的手牌包含{C:attention}順子{}",
                 "以上的機率會必定觸發",
                 "{C:inactive}（必須有空位）"
@@ -3332,14 +3332,14 @@ return {
                 "每張棄掉的{C:attention}#3#{}會給予{C:money}$#1#{}",
                 "牌級在每個回合變更",
                 "{br:2}此為分隔線",
-                "每張你持有的{X:water,C:white}水{}屬性小丑牌",
+                "每張你持有的{X:poke_water,C:white}水{}屬性小丑牌",
                 "會對以上加成增加{C:money}$#2#{}",
               }
             }, 
             j_poke_ralts = {
               name = "拉魯拉絲",
               text = {
-                "每張有{C:pink}能量加成{}的小丑牌",
+                "每張有{C:poke_pink}能量加成{}的小丑牌",
                 "及{C:attention}持有{}的{C:planet}行星{}牌會給予{C:mult}+#1#{}倍數",
                 "{C:inactive}（目前將給予{C:mult}+#3#{C:inactive}倍數）",
                 "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}個回合後進化）",
@@ -3348,7 +3348,7 @@ return {
             j_poke_kirlia = {
               name = "奇魯莉安",
               text = {
-                "每張有{C:pink}能量加成{}的小丑牌",
+                "每張有{C:poke_pink}能量加成{}的小丑牌",
                 "及{C:attention}持有{}的{C:planet}行星{}牌會給予{C:mult}+#1#{}倍數",
                 "{C:inactive}（目前將給予{C:mult}+#3#{C:inactive}倍數）",
                 "{C:inactive,s:0.8}（在使用{C:attention,s:0.8}#4#{}{C:inactive,s:0.8}張{C:planet,s:0.8}行星{C:inactive,s:0.8}牌後進化）",
@@ -3360,7 +3360,7 @@ return {
               text = {
                 "{C:attention}持有{}{C:spectral}黑洞{}牌",
                 "{br:2}此為分隔線",
-                "每張有{C:pink}能量加成{}的小丑牌及{C:attention}#4#{}級或以上的牌型",
+                "每張有{C:poke_pink}能量加成{}的小丑牌及{C:attention}#4#{}級或以上的牌型",
                 "會給予{X:mult,C:white}X#1#{}倍數",
                 "{C:inactive}（目前將給予{X:mult,C:white} X#3#{C:inactive}倍數）",
               }
@@ -3433,8 +3433,8 @@ return {
                   "並在每次防止時獲得{X:mult,C:white}X#2#{}倍數",
                   "{C:inactive}（目前將給予{X:mult,C:white}X#1#{C:inactive}倍數）",
                   "{br:2.5}此為分隔線",
-                  "離開{C:attention}商店{}時，如果你有{X:fire,C:white}火{}，{X:dark,C:white}惡{}",
-                  "{X:earth,C:white}地{}或{X:psychic,C:white}超能力{}小丑牌",
+                  "離開{C:attention}商店{}時，如果你有{X:poke_fire,C:white}火{}，{X:poke_dark,C:white}惡{}",
+                  "{X:poke_earth,C:white}地{}或{X:poke_psychic,C:white}超能力{}小丑牌",
                   "這張小丑牌會{S:1.1,C:red,E:2}自我毀滅{}",
                   "{C:inactive}（脫殼忍者除外）{}"
                 }
@@ -3451,7 +3451,7 @@ return {
                 name = "鐵掌力士",
                 text = {
                   "選擇{C:attention}盲注{}後",
-                  "每個你持有的{X:fighting,C:white}鬥{}屬性小丑牌",
+                  "每個你持有的{X:poke_fighting,C:white}鬥{}屬性小丑牌",
                   "會給予{C:chips}+#1#{}出牌次數",
                 }
             },
@@ -3484,7 +3484,7 @@ return {
                 name = "優雅貓",
                 text = {
                   "複製右邊{B:1,V:2}#1#{}屬性小丑牌的能力",
-                  "其能力會以附加{C:pink}+#2#{}能量的形式觸發",
+                  "其能力會以附加{C:poke_pink}+#2#{}能量的形式觸發",
                   "{C:inactive,s:0.8}（屬性會在每個回合變更）{}",
                 }
             },
@@ -3557,7 +3557,7 @@ return {
                 "當你使用{C:planet}行星{}牌時",
                 "這張小丑牌將獲得{C:chips}+#2#{}籌碼",
                 "{br:2}此為分隔線",
-                "如果你持有其他{X:grass,C:white}草{}屬性的小丑牌",
+                "如果你持有其他{X:poke_grass,C:white}草{}屬性的小丑牌",
                 "這張小丑牌也會獲得{X:mult,C:white} X#4# {}倍數",
                 "{C:inactive}（目前將給予{C:chips}+#1#{C:inactive}籌碼，{X:mult,C:white} X#3# {C:inactive}倍數）"
               }
@@ -3566,7 +3566,7 @@ return {
               name = "甜甜螢",
               text = {
                 "選擇{C:attention}盲注{}後",
-                "每張你持有的{X:grass,C:white}草{}屬性的小丑牌",
+                "每張你持有的{X:poke_grass,C:white}草{}屬性的小丑牌",
                 "會產生一張{C:planet}行星{}牌",
                 "{C:inactive}（必須有空位）{}",
               }
@@ -3650,7 +3650,7 @@ return {
             j_poke_cacnea = {
               name = "刺球仙人掌",
               text = {
-                "陷阱層級{C:hazard}+#1#{}",
+                "陷阱層級{C:poke_hazard}+#1#{}",
                 "當有卡牌被摧毀時",
                 "將獲得{C:money}$#2#{}",
                 "{C:inactive}（在{C:attention}#3#{C:inactive}個回合後進化）",
@@ -3659,7 +3659,7 @@ return {
             j_poke_cacturne = {
               name = "夢歌仙人掌",
               text = {
-                "陷阱層級{C:hazard}+#1#{}",
+                "陷阱層級{C:poke_hazard}+#1#{}",
                 "當有卡牌被摧毀時",
                 "將獲得{C:money}$#2#{}",
                 "{br:2}此為分隔線",
@@ -3681,7 +3681,7 @@ return {
                 "當你在{C:attention}盲注{}中抽出{C:attention}9{}時",
                 "這張小丑牌將獲得{C:chips}+#2#{}籌碼並給予{C:money}$#3#{}",
                 "{br:2}此為分隔線",
-                "如果你持有其他的{X:dragon,C:white}龍{}屬性小丑牌",
+                "如果你持有其他的{X:poke_dragon,C:white}龍{}屬性小丑牌",
                 "這張小丑牌將額外獲得{C:chips}+#4#{}籌碼",
                 "並額外給予{C:money}$#5#{}",
                 "{C:inactive}（目前將給予{C:chips}+#1#{C:inactive}籌碼）",
@@ -3866,7 +3866,7 @@ return {
                 "手牌數量{C:attention}+#1#{}",
                 "{br:2}此為分隔線",
                 "在打開{C:attention}擴充包{}時",
-                "如果有{C:tarot}塔羅{}或{C:item}物品{}牌{C:attention}被賣出{}",
+                "如果有{C:tarot}塔羅{}或{C:poke_item}物品{}牌{C:attention}被賣出{}",
                 "這張小丑牌會獲得{X:mult,C:white}X#2#{}倍數",
                 "並摧毀{C:attention}在手中{}隨機的卡牌",
                 "{C:inactive}（目前將給予{X:mult,C:white} X#3# {C:inactive}倍數）"
@@ -3879,7 +3879,7 @@ return {
                 "手牌數量{C:attention}+#1#{}",
                 "{br:2}此為分隔線",
                 "在打開{C:attention}擴充包{}時",
-                "如果有{C:tarot}塔羅{}或{C:item}物品{}牌{C:attention}被使用{}",
+                "如果有{C:tarot}塔羅{}或{C:poke_item}物品{}牌{C:attention}被使用{}",
                 "這張小丑牌會獲得{X:mult,C:white}X#2#{}倍數",
                 "{C:inactive}（目前將給予{X:mult,C:white} X#3# {C:inactive}倍數）"
               }
@@ -4013,7 +4013,7 @@ return {
                 name = '基拉祈',
                 text = {
                     "如果你持有",
-                    "{C:attention}#1#{}張或以上{C:pink}有能量{}的小丑牌",
+                    "{C:attention}#1#{}張或以上{C:poke_pink}有能量{}的小丑牌",
                     "複製右邊{C:attention}小丑牌{}的能力",
                     "{C:inactive}（目前有{C:attention}#2#{C:inactive}/#1#）{}"
                 }
@@ -4023,7 +4023,7 @@ return {
                 text = {
                     "如果{C:attention}第一次棄牌{}只有{C:attention}1{}張牌",
                     "{C:attention}摧毀{}那張牌",
-                    "並產生{C:tarot}死神{}，{C:spectral}神秘生物{}或{C:item}金屬膜{}",
+                    "並產生{C:tarot}死神{}，{C:spectral}神秘生物{}或{C:poke_item}金屬膜{}",
                     "{C:inactive}（必須有空位）",
                 }
             },
@@ -4099,7 +4099,7 @@ return {
                 text = {
                     "{C:attention}嬰兒{}，倍數{X:mult,C:white} X#1# {}",
                     "回合結束後，產生一張",
-                    "{C:dark_edition}負片{}{C:item}奇跡種子{}",
+                    "{C:dark_edition}負片{}{C:poke_item}奇跡種子{}",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}個回合後進化）",
                 }
             },
@@ -4178,7 +4178,7 @@ return {
             j_poke_honchkrow = {
                 name = "烏鴉頭頭",
                 text = {
-                  "每張{X:dark,C:white}惡{}屬性的小丑牌會給予{X:red,C:white}X#1#{}倍數",
+                  "每張{X:poke_dark,C:white}惡{}屬性的小丑牌會給予{X:red,C:white}X#1#{}倍數",
                 }
             },
             j_poke_chingling = {
@@ -4221,7 +4221,7 @@ return {
                 text = {
                     "{C:attention}嬰兒{}，倍數{X:red,C:white} X#1# {}",
                     "回合結束後，產生一張隨機的",
-                    "{C:dark_edition}負片{}{C:item}物品牌{}",
+                    "{C:dark_edition}負片{}{C:poke_item}物品牌{}",
                     "{C:inactive}（你沒看錯，這會{C:attention}減低{C:inactive}你的倍數）",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}個回合後進化）",
                 }
@@ -4274,7 +4274,7 @@ return {
                 text = {
                     "每張得分的{C:attention}鋼鐵牌{}",
                     "會給予{X:red,C:white}X#1#{}倍數",
-                    "每張在旁邊的{X:metal,C:white}鋼{}屬性小丑牌",
+                    "每張在旁邊的{X:poke_metal,C:white}鋼{}屬性小丑牌",
                     "會給予{X:red,C:white}X#2#{}倍數"
                 } 
             },
@@ -4291,7 +4291,7 @@ return {
                     "每張得分的{C:attention}石頭牌{}",
                     "可永久獲得{C:chips}+#1#{}籌碼並額外觸發一次",
                     "{br:3}此為分隔線",
-                    "每{C:attention}3{}張{X:earth,C:white}地{}屬性小丑牌",
+                    "每{C:attention}3{}張{X:poke_earth,C:white}地{}屬性小丑牌",
                     "會對{C:attention}石頭牌{}額外觸發一次",
                     "{C:inactive}（目前會額外觸發#2#次）"
                 } 
@@ -4381,11 +4381,11 @@ return {
             j_poke_porygonz = {
                 name = '多邊獸Ｚ',
                 text = {
-                    "能量上限{C:pink}+3{}",
-                    "每張在本局{C:attention}遊戲{}中使用的{C:pink}能量{}牌會給予{X:red,C:white} X#2# {}倍數",
+                    "能量上限{C:poke_pink}+3{}",
+                    "每張在本局{C:attention}遊戲{}中使用的{C:poke_pink}能量{}牌會給予{X:red,C:white} X#2# {}倍數",
                     "{br:2}此為分隔線",
-                    "當你使用{C:pink}能量牌{}時",
-                    "產生一張隨機的{C:pink}能量牌",
+                    "當你使用{C:poke_pink}能量牌{}時",
+                    "產生一張隨機的{C:poke_pink}能量牌",
                     "{C:inactive}（必須有空位）",
                     "{C:inactive}（目前將給予{X:red,C:white} X#1# {}{C:inactive}倍數）"
                 } 
@@ -4425,7 +4425,7 @@ return {
                   "可負債至{C:mult}-$#1#{}",
                   "{br:2.5}此為分隔線",
                   "如果在負債中打出手牌",
-                  "產生一張{C:item}物品牌{}",
+                  "產生一張{C:poke_item}物品牌{}",
                   "{C:inactive,s:0.8}（必須有空位）",
                 }
             },
@@ -4434,7 +4434,7 @@ return {
                 text = {
                   "打開任何{C:attention}擴充包{}時",
                   "會有{C:green}#1#/#2#{}的機率",
-                  "產生一張隨機的{C:item}物品牌{}",
+                  "產生一張隨機的{C:poke_item}物品牌{}",
                   "{C:inactive}（必須有空位）{}",
                   "{br:2}此為分隔線",
                   "{C:attention}擴充包{}的價格降低{C:money}$1{}",
@@ -4446,7 +4446,7 @@ return {
                 text = {
                   "打開任何{C:attention}擴充包{}時",
                   "會有{C:green}#1#/#2#{}的機率",
-                  "產生一張隨機的{C:item}物品牌{}",
+                  "產生一張隨機的{C:poke_item}物品牌{}",
                   "{C:inactive}（必須有空位）{}",
                   "{br:2}此為分隔線",
                   "如果第一次棄牌",
@@ -4460,7 +4460,7 @@ return {
                 text = {
                   "打開任何{C:attention}擴充包{}時",
                   "會有{C:green}#1#/#2#{}的機率",
-                  "產生一張隨機的{C:item}物品牌{}",
+                  "產生一張隨機的{C:poke_item}物品牌{}",
                   "{C:inactive}（必須有空位）{}",
                   "{br:2}此為分隔線",
                   "每張打出的{C:attention}加強牌{}",
@@ -4474,7 +4474,7 @@ return {
               text = {
                 "打開任何{C:attention}擴充包{}時",
                 "會有{C:green}#1#/#2#{}的機率",
-                "產生一張隨機的{C:item}物品牌{}",
+                "產生一張隨機的{C:poke_item}物品牌{}",
                 "{C:inactive}（必須有空位）{}",
                 "{br:2}此為分隔線",
                 "選擇盲注後",
@@ -4488,7 +4488,7 @@ return {
                 text = {
                   "打開任何{C:attention}擴充包{}時",
                 "會有{C:green}#1#/#2#{}的機率",
-                "產生一張隨機的{C:item}物品牌{}",
+                "產生一張隨機的{C:poke_item}物品牌{}",
                 "{C:inactive}（必須有空位）{}",
                 "{br:2}此為分隔線",
                   "選擇盲注後",
@@ -4502,7 +4502,7 @@ return {
                 text = {
                   "打開任何{C:attention}擴充包{}時",
                   "會有{C:green}#1#/#2#{}的機率",
-                  "產生一張隨機的{C:item}物品牌{}",
+                  "產生一張隨機的{C:poke_item}物品牌{}",
                   "{C:inactive}（必須有空位）{}",
                   "{br:2}此為分隔線",
                   "回合結束時",
@@ -4595,7 +4595,7 @@ return {
                 name = "夢夢蝕",
                 text = {
                   "選擇{C:attention}盲注{}後",
-                  "每張你持有的{X:psychic,C:white}超能力{}屬性的卡牌",
+                  "每張你持有的{X:poke_psychic,C:white}超能力{}屬性的卡牌",
                   "會對這個回合給予{C:purple}+#2#張卡牌預視{}",
                   "{br:3}此為分隔線",
                   "每張{C:attention}預視的加強{}卡牌",
@@ -4606,7 +4606,7 @@ return {
             j_poke_roggenrola = {
                 name = "石丸子",
                 text = {
-                    "陷阱層級{C:hazard}+#1#",
+                    "陷阱層級{C:poke_hazard}+#1#",
                     "每張在{C:attention}手中{}的{C:attention}無牌級的卡牌{}",
                     "會給予{C:mult}+#2#{}倍數",
                     "{C:inactive,s:0.8}（在觸發{C:attention,s:0.8}#3#{C:inactive,s:0.8}次後進化）",
@@ -4615,7 +4615,7 @@ return {
             j_poke_boldore = {
                 name = "地幔岩",
                 text = {
-                    "陷阱層級{C:hazard}+#1#",
+                    "陷阱層級{C:poke_hazard}+#1#",
                     "每張在{C:attention}手中{}的{C:attention}無牌級的卡牌{}",
                     "會給予{C:mult}+#2#{}倍數",
                     "{C:inactive,s:0.8}（使用{C:attention,s:0.8}聯繫繩{C:inactive,s:0.8}後進化）"
@@ -4624,7 +4624,7 @@ return {
             j_poke_gigalith = {
                 name = "龐岩怪",
                 text = {
-                    "陷阱層級{C:hazard}+#1#",
+                    "陷阱層級{C:poke_hazard}+#1#",
                     "每張在{C:attention}手中{}的{C:attention}無牌級的卡牌{}",
                     "會給予{C:mult}+#2#{}倍數並額外觸發一次",
                 }
@@ -4762,7 +4762,7 @@ return {
             j_poke_ferroseed = {
                 name = "種子鐵球",
                 text = {
-                  "陷阱層級{C:hazard}+#2#",
+                  "陷阱層級{C:poke_hazard}+#2#",
                   "{C:attention}萬能{}牌及{C:attention}陷阱{}牌",
                   "也會視為{C:attention}鋼鐵{}牌",
                   "{C:inactive,s:0.8}（在{C:attention,s:0.8}#1#{C:inactive,s:0.8}個回合後進化）",
@@ -4771,7 +4771,7 @@ return {
             j_poke_ferrothorn = {
               name = "堅果啞鈴",
               text = {
-                "陷阱層級{C:hazard}+#1#",
+                "陷阱層級{C:poke_hazard}+#1#",
                 "{C:attention}萬能{}牌及{C:attention}陷阱{}牌",
                 "也會視為{C:attention}鋼鐵{}牌",
                 "{br:2}此為分隔線",
@@ -4832,7 +4832,7 @@ return {
             j_poke_golett = {
                 name = "泥偶小人",
                 text = {
-                  "陷阱層級{C:hazard}+#1#",
+                  "陷阱層級{C:poke_hazard}+#1#",
                   "在{C:attention}手中{}的卡牌",
                   "會有{C:green}#4#/#5#{}的機率給予{X:mult,C:white}X#2#{}倍數",
                   "{C:attention}陷阱牌{}會一定觸發以上效果",
@@ -4842,7 +4842,7 @@ return {
             j_poke_golurk = {
                 name = "泥偶巨人",
                 text = {
-                  "陷阱層級{C:hazard}+#1#",
+                  "陷阱層級{C:poke_hazard}+#1#",
                   "在{C:attention}手中{}的卡牌",
                   "會有{C:green}#3#/#4#{}的機率給予{X:mult,C:white}X#2#{}倍數",
                   "{C:attention}陷阱牌{}會一定觸發以上效果",
@@ -4929,7 +4929,7 @@ return {
                     "如果打出的牌型包含{C:attention}同花{}，{C:chips}+#1#{}籌碼",
                     "{br:2}此為分隔線",
                     "如果同時包含{C:attention}K{}或{C:attention}Q{}",
-                    "產生一張{C:pink}能量牌{}",
+                    "產生一張{C:poke_pink}能量牌{}",
                 } 
             },
             j_poke_sylveon = {
@@ -4984,7 +4984,7 @@ return {
                   "{C:inactive}（必須有空位）",
                   "{br:2}此為分隔線",
                   "使用{C:spectral}幻靈{}牌時，將獲得{C:money}$#3#{}",
-                  "並對最左邊的{C:attention}小丑牌{}附上{X:psychic,C:white}超能力{}貼紙",
+                  "並對最左邊的{C:attention}小丑牌{}附上{X:poke_psychic,C:white}超能力{}貼紙",
                 }
             },
             j_poke_gourgeist_average = {
@@ -4995,7 +4995,7 @@ return {
                   "{C:inactive}（必須有空位）",
                   "{br:2}此為分隔線",
                   "使用{C:spectral}幻靈{}牌時，將獲得{C:money}$#3#{}",
-                  "並對最左邊的{C:attention}小丑牌{}附上{X:psychic,C:white}超能力{}貼紙",
+                  "並對最左邊的{C:attention}小丑牌{}附上{X:poke_psychic,C:white}超能力{}貼紙",
                 }
             },
             j_poke_gourgeist_large = {
@@ -5006,7 +5006,7 @@ return {
                   "{C:inactive}（必須有空位）",
                   "{br:2}此為分隔線",
                   "使用{C:spectral}幻靈{}牌時，將獲得{C:money}$#3#{}",
-                  "並對最左邊的{C:attention}小丑牌{}附上{X:psychic,C:white}超能力{}貼紙",
+                  "並對最左邊的{C:attention}小丑牌{}附上{X:poke_psychic,C:white}超能力{}貼紙",
                 }
             },
             j_poke_gourgeist_super = {
@@ -5017,14 +5017,14 @@ return {
                   "{C:inactive}（必須有空位）",
                   "{br:2}此為分隔線",
                   "使用{C:spectral}幻靈{}牌時，將獲得{C:money}$#3#{}",
-                  "並對最左邊的{C:attention}小丑牌{}附上{X:psychic,C:white}超能力{}貼紙",
+                  "並對最左邊的{C:attention}小丑牌{}附上{X:poke_psychic,C:white}超能力{}貼紙",
                 }
             },
             j_poke_grubbin = {
                 name = '強顎雞母蟲',
                 text = {
                     "倍數{C:mult}+#1#{}",
-                    "如果你有{X:lightning, C:black}電{}屬性的小丑牌",
+                    "如果你有{X:poke_lightning, C:black}電{}屬性的小丑牌",
                     "此牌給予的倍數會增加{C:attention}三倍{}",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}個回合後進化）",
                 }  
@@ -5032,7 +5032,7 @@ return {
             j_poke_charjabug = {
                 name = '蟲電寶',
                 text = {
-                    "每張你持有的{X:lightning, C:black}電{}屬性小丑牌",
+                    "每張你持有的{X:poke_lightning, C:black}電{}屬性小丑牌",
                     "會給予{C:mult}+#1#{}倍數{C:inactive}（包括自身）{}",
                      "{C:inactive}（目前將給予{C:mult}#2#{C:inactive}倍數）",
                     "{C:inactive}（使用{} {C:attention}雷之石{}{C:inactive}後進化）"
@@ -5042,7 +5042,7 @@ return {
                 name = '鍬農炮蟲',
                 text = {
                     "倍數{C:mult}+#3#{}",
-                    "每張其他你持有的{X:lightning, C:black}雷{}屬性小丑牌",
+                    "每張其他你持有的{X:poke_lightning, C:black}雷{}屬性小丑牌",
                     "會給予{X:red,C:white} X#1# {}倍數",
                      "{C:inactive}（目前將給予{X:red,C:white} X#2# {}{C:inactive}倍數）",
                 }  
@@ -5175,7 +5175,7 @@ return {
             j_poke_hisuian_qwilfish = {
                 name = "千針魚（洗翠的樣子）",
                 text = {
-                    "{C:earth}+#1#張陷阱牌{C:inactive}（每#2#張牌增加一張）",
+                    "{C:poke_earth}+#1#張陷阱牌{C:inactive}（每#2#張牌增加一張）",
                     "每次抽出{C:attention}陷阱牌{}時",
                     "這張小丑牌會獲得{C:chips}+#3#{}籌碼",
                     "{C:inactive}（在 {C:chips}+#4#{C:inactive} / +#5# 籌碼時進化）",
@@ -5184,7 +5184,7 @@ return {
             j_poke_overqwil = {
                 name = "萬針魚",
                 text = {
-                    "{C:earth}+#1#張陷阱牌{C:inactive}（每#2#張牌增加一張）",
+                    "{C:poke_earth}+#1#張陷阱牌{C:inactive}（每#2#張牌增加一張）",
                     "每次抽出{C:attention}陷阱牌{}時",
                     "這張小丑牌會獲得{C:chips}+#3#{}籌碼",
                     "{br:3}此為分隔線",
@@ -5195,11 +5195,11 @@ return {
             j_poke_wyrdeer = {
                 name = "詭角鹿",
                 text = {
-                    "{C:earth}+#1#{}張卡牌預視",
+                    "{C:poke_earth}+#1#{}張卡牌預視",
                     "按照{C:attention}預視{}的卡牌中牌級{C:attention}最高{}的卡牌",
                     "向倍數追加其牌級{C:attention}兩倍{}的數量",
                     "{br:3}此為分隔線",
-                    "打出手牌時，這張小丑牌會獲得{C:earth}#2#個預視{}",
+                    "打出手牌時，這張小丑牌會獲得{C:poke_earth}#2#個預視{}",
                     "{C:inactive,s:0.8}（回合結束後重設）",
                     
                 }
@@ -5220,7 +5220,7 @@ return {
               text = {
                 "當有{C:attention}擴充包{}被跳過時",
                 "這張小丑牌將獲得{C:mult}+#2#{}倍數",
-                "並產生一張帶有{C:dark_edition}彩色{}版本的隨機{C:item}物品牌{}",
+                "並產生一張帶有{C:dark_edition}彩色{}版本的隨機{C:poke_item}物品牌{}",
                 "{C:inactive,s:0.8}（必須有空位）",
                 "{C:inactive}（目前將給予{C:mult}+#1#{C:inactive}倍數）",
               }
@@ -5228,14 +5228,14 @@ return {
             j_poke_tarountula = {
                 name = "團珠蛛",
                 text = {
-                    "陷阱層級{C:hazard}+#1#{}，手牌數量{C:attention}+#3#{}",
+                    "陷阱層級{C:poke_hazard}+#1#{}，手牌數量{C:attention}+#3#{}",
                     "{C:inactive,s:0.8}（在{C:attention,s:0.8}#2#{C:inactive,s:0.8}個回合後進化）",
                 }
             },
             j_poke_spidops = {
                 name = "操陷蛛",
                 text = {
-                    "陷阱層級{C:hazard}+#1#{}，手牌數量{C:attention}+#2#{}",
+                    "陷阱層級{C:poke_hazard}+#1#{}，手牌數量{C:attention}+#2#{}",
                     "對每{C:attention}#3#{}張加入到牌組中的{C:attention}卡牌{C:inactive}[#4#]{}",
                     "附上隨機的{C:attention}封蠟章{}",
                 }
@@ -5247,7 +5247,7 @@ return {
                   "所需的{C:attention}卡牌牌級{}會在每次觸發時提升一點",
                   "{C:inactive,s:0.8}（如果是A，那就會變回2）",
                   "{C:inactive}（目前將給予{C:chips}+#1#{C:inactive}籌碼）",
-                  "{C:inactive}（在持有{X:fire,C:white}火{}{C:inactive}屬性小丑牌時進化）",
+                  "{C:inactive}（在持有{X:poke_fire,C:white}火{}{C:inactive}屬性小丑牌時進化）",
                 }
             },
             j_poke_dachsbun = {
@@ -5255,7 +5255,7 @@ return {
                 text = {
                   "如果打出的手牌包含{C:attention}#3#{}，此牌獲得{C:chips}+#2#{}籌碼",
                   "所需的{C:attention}卡牌牌級{}會在每次觸發時提升一點",
-                  "每張{X:fire,C:white}火{}屬性小丑牌會增加{C:chips}+1{}到獲得的籌碼",
+                  "每張{X:poke_fire,C:white}火{}屬性小丑牌會增加{C:chips}+1{}到獲得的籌碼",
                   "{C:inactive,s:0.8}（如果是A，那就會變回2）",
                   "{C:inactive}（目前將給予{C:chips}+#1#{C:inactive}籌碼）",
                 }
@@ -5284,8 +5284,8 @@ return {
                 "對{C:attention}所有{}小丑牌及{C:attention}消耗{}牌的出售價",
                 "提升{C:money}$#1#{}",
                 "{br:2.5}此為分隔線",
-                "以上效果對{X:grass,C:white}草{}屬性小丑牌及",
-                "{X:grass,C:white}草{}{C:pink}能量{}{C:attention}加倍{}"
+                "以上效果對{X:poke_grass,C:white}草{}屬性小丑牌及",
+                "{X:poke_grass,C:white}草{}{C:poke_pink}能量{}{C:attention}加倍{}"
               }
             },
             j_poke_charcadet = {
@@ -5338,7 +5338,7 @@ return {
             j_poke_rellor = {
                 name = '蟲滾泥',      
                 text = {
-                    "每張在這局遊戲中使用的{C:item}物品{}牌",
+                    "每張在這局遊戲中使用的{C:poke_item}物品{}牌",
                     "將給予這張小丑牌{C:mult}+#1#{}倍數",
                     "{C:inactive}（目前將給予{C:mult}+#2#{C:inactive}倍數）",
                     "{C:inactive,s:0.8}（在使用{C:attention,s:0.8}#3#{C:inactive,s:0.8}張物品牌後進化）",
@@ -5347,12 +5347,12 @@ return {
 			j_poke_rabsca = {
                 name = '蟲甲聖',      
                 text = {
-                    "當你使用{C:item}物品{}牌時",
+                    "當你使用{C:poke_item}物品{}牌時",
                     "將有{C:green}#3#/#4#{}的機率",
                     "產生一張{C:tarot}塔羅{}牌",
                     "{C:inactive}（必須有空位）{}",
                     "{br:2}此為分隔線",
-                    "每張在這局遊戲中使用的{C:item}物品{}牌",
+                    "每張在這局遊戲中使用的{C:poke_item}物品{}牌",
                     "將給予這張小丑牌{C:mult}+#1#{}倍數",
                     "{C:inactive}（目前將給予{C:mult}+#2#{C:inactive}倍數）",
 				} 
@@ -5498,7 +5498,7 @@ return {
                 name = '洛托姆圖鑑',
                 text = {
                     "在你持有的小丑牌中",
-                    "每個不同的{C:pink}屬性{}會對{C:attention}擴充包{}的價格減少{C:money}$1{}",
+                    "每個不同的{C:poke_pink}屬性{}會對{C:attention}擴充包{}的價格減少{C:money}$1{}",
                     "{C:inactive}（目前會減少{C:money}$#1#{C:inactive}）"
                 } 
             },
@@ -5523,7 +5523,7 @@ return {
                 name = "御握",
                 text = {
                   "選擇盲注後",
-                  "產生一張{C:colorless}無色{}{C:pink}能量{}牌",
+                  "產生一張{C:poke_colorless}無色{}{C:poke_pink}能量{}牌",
                   "{C:inactive}（剩餘{C:attention}#1#{}{C:inactive}個回合）{}"
                 }
             },
@@ -5552,8 +5552,8 @@ return {
                 name = "寶食堂",
                 text = {
                   "選擇盲注時",
-                  "轉換最左邊小丑牌的{C:pink}屬性{}",
-                  "至最右邊小丑牌的{C:pink}屬性{}",
+                  "轉換最左邊小丑牌的{C:poke_pink}屬性{}",
+                  "至最右邊小丑牌的{C:poke_pink}屬性{}",
                   "{C:attention}屬性轉換牌{}",
                   "{C:inactive}（剩餘{C:attention}#1#{C:inactive}個回合）{}"
                 }
@@ -5621,7 +5621,7 @@ return {
                 text = {
                   "在{C:attention}#1#{}個回合後",
                   "會孵化一個{C:attention}基礎{}或{C:attention}嬰兒{}小丑牌",
-                  "如果適用，會對那張牌加上{C:pink}+1{}能量"
+                  "如果適用，會對那張牌加上{C:poke_pink}+1{}能量"
                 }
             },
             j_poke_daycare = {
@@ -5644,7 +5644,7 @@ return {
                 name = '十億隻獅子',
                 text = {
                     "選擇盲注後",
-                    "摧毀每張持有的{C:pink}有屬性{}小丑牌",
+                    "摧毀每張持有的{C:poke_pink}有屬性{}小丑牌",
                     "每張被摧毀的小丑牌會給予這張小丑牌{X:mult,C:white}X#2#{}倍數",
                     "失去所有獅子時會{S:1.1,C:red,E:2}自我毀滅{}",
                     "{C:inactive}（目前將給予{X:mult,C:white}X#1#{C:inactive}倍數，剩餘{C:attention}#3#{C:inactive}隻獅子）"
@@ -5653,7 +5653,7 @@ return {
             j_poke_spiclops = {
                 name = "獨眼陷蛛",
                 text = {
-                    "陷阱層級{C:hazard}+#1#{}，手牌數量{C:attention}+#2#{}",
+                    "陷阱層級{C:poke_hazard}+#1#{}，手牌數量{C:attention}+#2#{}",
                     "對每{C:attention}#3#{}張增至你的牌組的{C:attention}卡牌{C:inactive}[#4#]{}",
                     "附上隨機{C:attention}封蠟章{}",
                     "選擇{C:attention}盲注{}後",
@@ -5716,10 +5716,10 @@ return {
             sleeve_poke_obituarysleeve_alt = {
                 name = "訃聞牌套",
                 text = {
-                    "{C:pink}粉紅封蠟章{}會有{C:green}#1#/#2#{}的機率",
+                    "{C:poke_pink}粉紅封蠟章{}會有{C:green}#1#/#2#{}的機率",
                     "會在出發後移除",
                     "小丑牌會在賣出或摧毀後",
-                    "產生與其屬性相同的{C:dark_edition}負片{C:pink}能量{}牌",
+                    "產生與其屬性相同的{C:dark_edition}負片{C:poke_pink}能量{}牌",
                 },
             },
             sleeve_poke_revenantsleeve = {
@@ -5732,22 +5732,22 @@ return {
               name = "亡靈牌套",
               text = {
                   "消耗牌欄位{C:blue}+#1#{}",
-                  "{C:pink}寶可夢禮包{}不會再出現在商店中",
+                  "{C:poke_pink}寶可夢禮包{}不會再出現在商店中",
               },
             },
             sleeve_poke_luminoussleeve = {
                 name = "發亮牌套",
                 text = {
                     "所有小丑牌在產生時",
-                    "會帶有隨機的{C:pink}屬性{}貼紙",
-                    "並附有一級{C:pink}能量{}",
+                    "會帶有隨機的{C:poke_pink}屬性{}貼紙",
+                    "並附有一級{C:poke_pink}能量{}",
                 },
             },
             sleeve_poke_luminoussleeve_alt = {
                 name = "發亮牌套",
                 text = {
                     "刷新會有{C:green}#1#/#2#{}的機率",
-                    "產生一個{C:item}太晶球",
+                    "產生一個{C:poke_item}太晶球",
                 },
             },
             sleeve_poke_telekineticsleeve = {
@@ -5755,13 +5755,13 @@ return {
                 text = {
                     "開始遊戲時獲得",
                     "{C:tarot,T:v_crystal_ball}#1#{}兌換券",
-                    "及{C:attention}兩張{}{C:item,T:c_poke_twisted_spoon}#2#",
+                    "及{C:attention}兩張{}{C:poke_item,T:c_poke_twisted_spoon}#2#",
                 } 
             },
             sleeve_poke_telekineticsleeve_alt = {
                 name = "念力牌套",
                 text = {
-                    "在{C:attention}消耗牌{}欄位中的{C:item,T:c_poke_twisted_spoon}#2#s{}",
+                    "在{C:attention}消耗牌{}欄位中的{C:poke_item,T:c_poke_twisted_spoon}#2#s{}",
                     "會給予{C:blue}+1{}消耗牌欄位",
                 }
             },
@@ -5770,15 +5770,15 @@ return {
                 text = {
                     "開始遊戲時獲得",
                     "{C:tarot,T:v_poke_energysearch}#1#{}兌換券",
-                    "及一張{C:pink,T:c_poke_double_rainbow_energy}#2#"
+                    "及一張{C:poke_pink,T:c_poke_double_rainbow_energy}#2#"
                 } 
             },
             sleeve_poke_ampedsleeve_alt = {
                 name = "振奮牌套",
                 text = {
-                    "開始遊戲時獲得的{C:pink,T:c_poke_double_rainbow_energy}#2#",
+                    "開始遊戲時獲得的{C:poke_pink,T:c_poke_double_rainbow_energy}#2#",
                     "會以一張{C:dark_edition}負片{C:attention,T:j_poke_jelly_donut}#1#{}取代",
-                    "{C:pink,T:c_poke_colorless_energy}#3#{}",
+                    "{C:poke_pink,T:c_poke_colorless_energy}#3#{}",
                     "不再對非一般屬性的小丑牌增強效果減半",
                 } 
             },
@@ -5844,7 +5844,7 @@ return {
             b_poke_diceysleeve = {
                 name = "碎石牌套",
                 text = {
-                    "陷阱層級及上限{C:hazard}+#1#{}，手牌數量{C:attention}+#1#{}",
+                    "陷阱層級及上限{C:poke_hazard}+#1#{}，手牌數量{C:attention}+#1#{}",
                     "回合結束時：",
                     "每張在{C:attention}完整牌組{}中的{C:attention}陷阱{}",
                     "會給予{C:money}$#4#{}",
@@ -5880,7 +5880,7 @@ return {
                 text = {
                     "把選擇的或最左邊的",
                     "寶可夢進化到最高{C:attention}階段{}",
-                    "並給予{}+1{} {C:pink}能量{}", 
+                    "並給予{}+1{} {C:poke_pink}能量{}", 
                 },
             },
             c_poke_megastone = {
@@ -5897,14 +5897,14 @@ return {
             c_poke_obituary = {
                 name = "訃告",
                 text = {
-                    "新增{C:pink}粉紅{}封蠟章",
+                    "新增{C:poke_pink}粉紅{}封蠟章",
                     "到選擇的{C:attention}1{}張手牌中",
                 }
             },
             c_poke_revenant = {
                 name = "亡靈",
                 text = {
-                    "新增{C:item}銀色{}封蠟章",
+                    "新增{C:poke_item}銀色{}封蠟章",
                     "到選擇的{C:attention}1{}張手牌中",
                 }
             },
@@ -5912,15 +5912,15 @@ return {
                 name = "夢魘",
                 text = {
                     "摧毀最左邊或選擇的寶可夢小丑牌",
-                    "並產生{C:attention}2{}張其{C:pink}屬性{}的{C:dark_edition}負片{}{C:pink}能量{}牌",
-                    "{C:inactive}（無屬性的小丑牌會產生{X:colorless,C:white}一般{C:inactive}能量）"
+                    "並產生{C:attention}2{}張其{C:poke_pink}屬性{}的{C:dark_edition}負片{}{C:poke_pink}能量{}牌",
+                    "{C:inactive}（無屬性的小丑牌會產生{X:poke_colorless,C:white}一般{C:inactive}能量）"
                 },
             },
             c_poke_double_rainbow_energy = {
                 name = "雙虹能量",
                 text = {
-                    "對最左邊或選擇的任意{C:pink}屬性{}的小丑牌",
-                    "{C:red}增{C:attention}加{C:green}兩{C:blue}級{C:pink}能量{}",
+                    "對最左邊或選擇的任意{C:poke_pink}屬性{}的小丑牌",
+                    "{C:red}增{C:attention}加{C:green}兩{C:blue}級{C:poke_pink}能量{}",
                     "使用後將不會獲得本回合的利息",
                     "{C:inactive}（最多對小丑牌增加{C:attention}#1#{C:inactive}級能量）",
                 },
@@ -5986,14 +5986,14 @@ return {
                 name = "寶可夢標籤",
                 text = {
                     "獲得一個免費的",
-                    "{C:pink}超級寶可夢禮包",
+                    "{C:poke_pink}超級寶可夢禮包",
                 }, 
             },
             tag_poke_shiny_tag = {
                 name = "發光標籤",
                 text = {
                     "下個在商店中的小丑牌",
-                    "是免費並帶有{C:colorless}發光{}",
+                    "是免費並帶有{C:poke_colorless}發光{}",
                 }, 
             },
             tag_poke_stage_one_tag = {
@@ -6007,7 +6007,7 @@ return {
                 name = "野生標籤",
                 text = {
                     "下個在商店中",
-                    "有免費的{C:safari}野生{}寶可夢",
+                    "有免費的{C:poke_safari}野生{}寶可夢",
                 }, 
             },
             tag_poke_starter_tag = {
@@ -6046,13 +6046,13 @@ return {
             v_poke_energysearch = {
                 name = "能量分析",
                 text = {
-                    "能量上限{C:pink}+2{}"
+                    "能量上限{C:poke_pink}+2{}"
                 },
             },
             v_poke_energyresearch = {
                 name = "能量研究",
                 text = {
-                    "能量上限{C:pink}+3{}"
+                    "能量上限{C:poke_pink}+3{}"
                 },
             },
             v_poke_goodrod = {
@@ -6066,7 +6066,7 @@ return {
                 name = "厲害釣竿",
                 text = {
                     "您可以把從任何的{C:attention}擴充包{}中的消耗牌",
-                    "{C:pink}儲存{}在欄位中",
+                    "{C:poke_pink}儲存{}在欄位中",
                 },
             },
         },
@@ -6075,80 +6075,80 @@ return {
             Grass = {
                 name = "屬性",
                 text = {
-                  "{X:grass,C:white}草{}",
+                  "{X:poke_grass,C:white}草{}",
                 }
             },
             Fire = {
                 name = "屬性",
                 text = {
-                  "{X:fire,C:white}火{}",
+                  "{X:poke_fire,C:white}火{}",
                 }
             },
             Water = {
                 name = "屬性",
                 text = {
-                  "{X:water,C:white}水{}",
+                  "{X:poke_water,C:white}水{}",
                 }
             },
             Lightning = {
                 name = "屬性",
                 text = {
-                  "{X:lightning,C:black}電{}",
+                  "{X:poke_lightning,C:black}電{}",
                 }
             },
             Psychic = {
                 name = "屬性",
                 text = {
-                  "{X:psychic,C:white}超能力{}",
+                  "{X:poke_psychic,C:white}超能力{}",
                 }
             },
             Fighting = {
                 name = "屬性",
                 text = {
-                  "{X:fighting,C:white}格鬥{}",
+                  "{X:poke_fighting,C:white}格鬥{}",
                 }
             },
             Colorless = {
                 name = "屬性",
                 text = {
-                  "{X:colorless,C:white}一般{}",
+                  "{X:poke_colorless,C:white}一般{}",
                 }
             },
             Dark = {
                 name = "屬性",
                 text = {
-                  "{X:dark,C:white}惡{}",
+                  "{X:poke_dark,C:white}惡{}",
                 }
             },
             Metal = {
                 name = "屬性",
                 text = {
-                  "{X:metal,C:white}鋼{}",
+                  "{X:poke_metal,C:white}鋼{}",
                 }
             },
             Fairy = {
                 name = "屬性",
                 text = {
-                  "{X:fairy,C:white}妖精{}",
+                  "{X:poke_fairy,C:white}妖精{}",
                 }
             },
             Dragon = {
                 name = "屬性",
                 text = {
-                  "{X:dragon,C:white}龍{}",
+                  "{X:poke_dragon,C:white}龍{}",
                 }
             },
             Earth = {
                 name = "屬性",
                 text = {
-                  "{X:earth,C:white}地面{}",
+                  "{X:poke_earth,C:white}地面{}",
                 }
             },
             --Have you Heard? Bird is the wordddd
             Bird = {
                 name = "屬性",
                 text = {
-                  "{X:bird,C:white}鳥{}",
+                  "{X:poke_bird,C:white}鳥{}",
                 }
             },
             --infoqueue used for things like kabuto and omanyte
@@ -6368,7 +6368,7 @@ return {
                 name = "可獲得的禮物",
                 text = {
                     "{C:green}35%{} - {C:money}$8{}",
-                    "{C:green}30%{} - {C:item}物品{}{C:attention}牌",
+                    "{C:green}30%{} - {C:poke_item}物品{}{C:attention}牌",
                     "{C:green}20%{} - {C:attention}兌換券標籤",
                     "{C:green}15%{} - {C:dark_edition}彩色{}{C:attention}禮物卡",
                 }
@@ -6385,9 +6385,9 @@ return {
             dril_treasure = {
                 name = "可獲得的寶藏",
                 text = {
-                    "{C:green}30%{} - {C:attention}進化{C:item}石",
+                    "{C:green}30%{} - {C:attention}進化{C:poke_item}石",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}兩張進化{C:item}石",
+                    "{C:green}20%{} - {C:attention}兩張進化{C:poke_item}石",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}5%{} - {C:money}$20{}             ",
                 }
@@ -6395,9 +6395,9 @@ return {
             exdril_treasure = {
                 name = "可獲得的寶藏",
                 text = {
-                    "{C:green}30%{} - {C:attention}進化{C:item}石",
+                    "{C:green}30%{} - {C:attention}進化{C:poke_item}石",
                     "{C:green}30%{} - {C:money}$5{}               ",
-                    "{C:green}20%{} - {C:attention}兩張進化{C:item}石",
+                    "{C:green}20%{} - {C:attention}兩張進化{C:poke_item}石",
                     "{C:green}15%{} - {C:money}$10{}              ",
                     "{C:green}4%{} - {C:money}$20{}             ",
                     "{C:green}1%{} - {C:attention}超級石",
@@ -6406,10 +6406,10 @@ return {
             pickup = {
               name = "撿拾的物品",
               text = {
-                "{C:green}34%{} - {C:item}物品牌{}",
-                "{C:green}25%{} - {C:item}進化牌",
-                "{C:green}20%{} - {C:item}吃剩的東西",
-                "{C:green}20%{} - {C:item}彎曲的湯匙",
+                "{C:green}34%{} - {C:poke_item}物品牌{}",
+                "{C:green}25%{} - {C:poke_item}進化牌",
+                "{C:green}20%{} - {C:poke_item}吃剩的東西",
+                "{C:green}20%{} - {C:poke_item}彎曲的湯匙",
                 "{C:green}1%{} - {C:dark_edition}蛻變",
               }
             },
@@ -6469,14 +6469,14 @@ return {
             eeveelution = {
                 name = "伊布家族",
                 text = {
-                    "{C:attention}水之石{} - {X:water,C:white}水伊布{}",
-                    "{C:attention}雷之石{} - {X:lightning,C:black}雷伊布{}",
-                    "{C:attention}火之石{} - {X:fire,C:white}火伊布{}",
-                    "{C:attention}日之石{} - {X:psychic,C:white}太陽伊布{}",
-                    "{C:attention}月之石{} - {X:dark,C:white}月亮伊布{}",
-                    "{C:attention}葉之石{} - {X:grass,C:white}葉伊布{}",
-                    "{C:attention}冰之石{} - {X:water,C:white}冰伊布{}",
-                    "{C:attention}光之石{} - {X:fairy,C:white}仙子伊布{}"
+                    "{C:attention}水之石{} - {X:poke_water,C:white}水伊布{}",
+                    "{C:attention}雷之石{} - {X:poke_lightning,C:black}雷伊布{}",
+                    "{C:attention}火之石{} - {X:poke_fire,C:white}火伊布{}",
+                    "{C:attention}日之石{} - {X:poke_psychic,C:white}太陽伊布{}",
+                    "{C:attention}月之石{} - {X:poke_dark,C:white}月亮伊布{}",
+                    "{C:attention}葉之石{} - {X:poke_grass,C:white}葉伊布{}",
+                    "{C:attention}冰之石{} - {X:poke_water,C:white}冰伊布{}",
+                    "{C:attention}光之石{} - {X:poke_fairy,C:white}仙子伊布{}"
                 }
             },
             poke_egg_tip = {
@@ -6535,13 +6535,13 @@ return {
               name = "無限能量",
               text = {
                 "小丑牌不再有",
-                "可用{C:pink}能量{}上限"
+                "可用{C:poke_pink}能量{}上限"
               }
             },
             precise_energy_tooltip = {
                 name = "精準的能量刻度",
                 text = {
-                    "{s:0.8}使用{C:attention,s:0.8}小數{}{s:0.8}來顯示所有的{C:pink,s:0.8}能量{}{s:0.8}加成的數值",
+                    "{s:0.8}使用{C:attention,s:0.8}小數{}{s:0.8}來顯示所有的{C:poke_pink,s:0.8}能量{}{s:0.8}加成的數值",
                     "{C:attention,s:0.8}禁用{}{s:0.8}這個選項會對加成造成以下影響",
                     "{C:attenion}1. {X:mult,C:white,s:0.8}乘成{}{s:0.8}倍數 - 使用小數",
                     "{C:attenion}2. {s:0.8}加成{C:mult,s:0.8}倍數{}{s:0.8}及{C:chips,s:0.8}籌碼{}{s:0.8} - 上取整至整數",
@@ -6670,7 +6670,7 @@ return {
             allowpokeballs_tooltip = {
               name = "允許精靈球",
               text = {
-                "允許精靈球{C:item}物品牌{}出現",
+                "允許精靈球{C:poke_item}物品牌{}出現",
               }
             },
             pokemaster_tooltip = {
@@ -6725,7 +6725,7 @@ return {
                 name = "粉紅封蠟章",
                 text = {
                     "如果此牌在{C:attention}第一次出牌{}時得分",
-                    "產生一張{C:pink}能量{}牌",
+                    "產生一張{C:poke_pink}能量{}牌",
                 },
             },
 
@@ -6733,7 +6733,7 @@ return {
                 name = "銀色封蠟章",
                 text = {
                   "如果這張牌在出牌時{C:attention}在手牌中",
-                  "產生一張{C:item}物品{}牌",
+                  "產生一張{C:poke_item}物品{}牌",
                   "並{C:attention}棄掉{}這張牌"
                 }
             },
@@ -6751,73 +6751,73 @@ return {
             grass_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:grass,C:white}草{}"
+                    "{X:poke_grass,C:white}草{}"
                 } 
             },
             fire_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:fire,C:white}火{}"
+                    "{X:poke_fire,C:white}火{}"
                 } 
             },
             water_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:water,C:white}水{}"
+                    "{X:poke_water,C:white}水{}"
                 } 
             },
             lightning_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:lightning,C:white}電{}"
+                    "{X:poke_lightning,C:white}電{}"
                 } 
             },
             psychic_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:psychic,C:white}超能力{}"
+                    "{X:poke_psychic,C:white}超能力{}"
                 } 
             },
             fighting_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:fighting,C:white}格鬥{}"
+                    "{X:poke_fighting,C:white}格鬥{}"
                 } 
             },
             colorless_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:colorless,C:white}一般{}"
+                    "{X:poke_colorless,C:white}一般{}"
                 } 
             },
             dark_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:dark,C:white}惡{}"
+                    "{X:poke_dark,C:white}惡{}"
                 } 
             },
             metal_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:metal,C:white}鋼{}"
+                    "{X:poke_metal,C:white}鋼{}"
                 } 
             },
             fairy_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:fairy,C:white}妖精{}"
+                    "{X:poke_fairy,C:white}妖精{}"
                 } 
             },
             dragon_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:dragon,C:white}龍{}"
+                    "{X:poke_dragon,C:white}龍{}"
                 } 
             },
             earth_sticker = {
                 name = "屬性",
                 text = {
-                    "{X:earth,C:white}地面{}"
+                    "{X:poke_earth,C:white}地面{}"
                 } 
             },
             --]]
@@ -6842,56 +6842,56 @@ return {
             p_poke_pokepack_normal_1 = {
                 name = "寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_normal_2 = {
                 name = "寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_jumbo_1 = {
                 name = "特大寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_mega_1 = {
                 name = "超級寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_normal_3 = {
                 name = "寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_normal_4 = {
                 name = "寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_jumbo_2 = {
                 name = "特大寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },
             p_poke_pokepack_mega_2 = {
                 name = "超級寶可夢禮包",
                 text = {
-                    "從{C:attention}#2#{}張{C:pink}能量{}或{C:item}物品{}牌中",
+                    "從{C:attention}#2#{}張{C:poke_pink}能量{}或{C:poke_item}物品{}牌中",
                     "選擇{C:attention}#1#{}張"
                 },
             },

--- a/lovely/UI.toml
+++ b/lovely/UI.toml
@@ -3,26 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = 0
 
-
-# Localization color
-[[patches]]
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = "legendary = G.C.RARITY[4],"
-position = "after"
-payload = "poke_safari = G.C.RARITY['poke_safari'], poke_mega = G.C.RARITY['poke_mega'],"
-match_indent = true
-# Localization color
-[[patches]]
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = "legendary = G.C.RARITY[4],"
-position = "after"
-payload = "poke_safari = G.C.RARITY['poke_safari'], poke_mega = G.C.RARITY['poke_mega'],"
-match_indent = true
-
-
-
 # Description functionality, a little hacky but it works
 [[patches]]
 [patches.pattern]

--- a/pokemon/pokejokers_03.lua
+++ b/pokemon/pokejokers_03.lua
@@ -92,7 +92,7 @@ local abra={
             if pseudorandom('abraitem') < .50 then
               set = "poke_item"
               message = "poke_plus_pokeitem"
-              colour = G.ARGS.LOC_COLOURS.item
+              colour = G.C.SECONDARY_SET.poke_item
             else
               set = "Tarot"
               message = "k_plus_tarot"
@@ -144,7 +144,7 @@ local kadabra={
             if pseudorandom('kadabraitem') < .50 then
               set = "poke_item"
               message = "poke_plus_pokeitem"
-              colour = G.ARGS.LOC_COLOURS.item
+              colour = G.C.SECONDARY_SET.poke_item
               conname = "c_poke_twisted_spoon"
             else
               set = "Tarot"
@@ -196,7 +196,7 @@ local alakazam={
             if pseudorandom('alakazam') < .50 then
               set = "poke_item"
               message = "poke_plus_pokeitem"
-              colour = G.ARGS.LOC_COLOURS.item
+              colour = G.C.SECONDARY_SET.poke_item
               conname = "c_poke_twisted_spoon"
             else
               set = "Tarot"

--- a/pokemon/pokejokers_05.lua
+++ b/pokemon/pokejokers_05.lua
@@ -891,7 +891,7 @@ local porygon={
                   G.GAME.consumeable_buffer = 0
               return true
           end)}))
-      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = G.ARGS.LOC_COLOURS["pink"]})
+      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = pokermon.colours.pink})
     end
     return pokermon.item_evo(self, card, context, "j_poke_porygon2")
   end,
@@ -948,7 +948,7 @@ local omanyte={
             local _card = create_card('poke_item', G.consumeables, nil, nil, nil, nil, nil)
             _card:add_to_deck()
             G.consumeables:emplace(_card)
-            card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.item})
+            card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('poke_plus_pokeitem'), colour = G.C.SECONDARY_SET.poke_item})
           end
         end
         
@@ -1004,7 +1004,7 @@ local omastar={
             local _card = create_card('poke_item', G.consumeables, nil, nil, nil, nil, nil)
             _card:add_to_deck()
             G.consumeables:emplace(_card)
-            card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.item})
+            card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('poke_plus_pokeitem'), colour = G.C.SECONDARY_SET.poke_item})
           end
         end
         if card.ability.extra.ancient_count > 3 and not card.ability.extra.tag_created then
@@ -1678,7 +1678,7 @@ local mega_mewtwo_y = {
       end
     end
     if context.end_of_round and not context.individual and not context.repetition and G.GAME.blind.boss then
-      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_future_sight"), colour = G.ARGS.LOC_COLOURS.psychic})
+      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_future_sight"), colour = pokermon.colours.psychic})
       if not G.GAME.poke_energy_plus then
         G.GAME.poke_energy_plus = 1
       else

--- a/pokemon/pokejokers_06.lua
+++ b/pokemon/pokejokers_06.lua
@@ -29,7 +29,7 @@ local mew ={
       else
         --create random consumable and apply negative
         local sets = {{set = "Tarot", message = localize('k_plus_tarot'), colour = G.C.PURPLE}, {set = "Spectral", message = localize('k_plus_spectral'), colour = G.C.SECONDARY_SET.Spectral}, 
-                      {set = "poke_item", message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.pink}}
+                      {set = "poke_item", message = localize('poke_plus_pokeitem'), colour = pokermon.colours.pink}}
         local creation = pseudorandom_element(sets, pseudoseed('mewcreate'))
         
         local consum = SMODS.add_card{set = creation.set, edition = 'e_negative', key_append = 'mew'}

--- a/pokemon/pokejokers_07.lua
+++ b/pokemon/pokejokers_07.lua
@@ -297,7 +297,7 @@ local weird_tree={
   loc_vars = function(self, info_queue, center)
     pokermon.type_tooltip(self, info_queue, center)
     if pokermon_config.detailed_tooltips then
-      info_queue[#info_queue+1] = {set = 'Other', key = 'typechangerpoke', vars = {"Grass Type", colours = {G.ARGS.LOC_COLOURS.grass}}}
+      info_queue[#info_queue+1] = {set = 'Other', key = 'typechangerpoke', vars = {"Grass Type", colours = {pokermon.colours.grass}}}
     end
     return {vars = {}}
   end,

--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -160,7 +160,7 @@ local scizor={
     if context.joker_main and (card.ability.extra.mult > 0 or card.ability.extra.scizor_chips > 0 or card.ability.extra.scizor_Xmult > 1) then
       return {
         message = localize("poke_x_scissor_ex"),
-        colour = G.ARGS.LOC_COLOURS.metal,
+        colour = pokermon.colours.metal,
         mult_mod = card.ability.extra.mult,
         chip_mod = card.ability.extra.scizor_chips,
         Xmult_mod = card.ability.extra.scizor_Xmult
@@ -1284,7 +1284,7 @@ local porygon2={
                   G.GAME.consumeable_buffer = 0
               return true
           end)}))
-      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = G.ARGS.LOC_COLOURS["pink"]})
+      card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = pokermon.colours.pink})
     end
     return pokermon.item_evo(self, card, context, "j_poke_porygonz")
   end,

--- a/pokemon/pokejokers_09.lua
+++ b/pokemon/pokejokers_09.lua
@@ -1252,7 +1252,7 @@ local zigzagoon={
         if SMODS.pseudorandom_probability(card, 'zigzagoon', card.ability.extra.num, card.ability.extra.dem, 'zigzagoon') then
           G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
           return {
-            extra = {focus = card, message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.pink, func = function()
+            extra = {focus = card, message = localize('poke_plus_pokeitem'), colour = pokermon.colours.pink, func = function()
               G.E_MANAGER:add_event(Event({
                 trigger = 'before',
                 delay = 0.0,
@@ -1299,7 +1299,7 @@ local linoone={
         if next(context.poker_hands['Straight']) or SMODS.pseudorandom_probability(card, 'linoone', card.ability.extra.num, card.ability.extra.dem, 'linoone') then
           G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
           return {
-            extra = {focus = card, message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.pink, func = function()
+            extra = {focus = card, message = localize('poke_plus_pokeitem'), colour = pokermon.colours.pink, func = function()
               G.E_MANAGER:add_event(Event({
                 trigger = 'before',
                 delay = 0.0,

--- a/pokemon/pokejokers_10.lua
+++ b/pokemon/pokejokers_10.lua
@@ -900,7 +900,7 @@ local skitty={
     local cattype = G.GAME.current_round.cattype or "Grass"
 
     local highlight_colour = cattype ~= "Lightning" and G.C.WHITE or G.C.BLACK
-    local type_colour = G.ARGS.LOC_COLOURS[string.lower(cattype)]
+    local type_colour = pokermon.colours[string.lower(cattype)]
     local main_end
 
     if card.area and card.area == G.jokers then

--- a/pokemon/pokejokers_11.lua
+++ b/pokemon/pokejokers_11.lua
@@ -9,7 +9,7 @@ local delcatty={
     local cattype = G.GAME.current_round.cattype or "Grass"
 
     local highlight_colour = cattype ~= "Lightning" and G.C.WHITE or G.C.BLACK
-    local type_colour = G.ARGS.LOC_COLOURS[string.lower(cattype)]
+    local type_colour = pokermon.colours[string.lower(cattype)]
     local main_end
 
     if card.area and card.area == G.jokers then
@@ -865,7 +865,7 @@ local spinda={
       if natures > 0 then
         return {
             message = localize('poke_teeter_dance_ex'),
-            colour = G.ARGS.LOC_COLOURS["colorless"]
+            colour = pokermon.colours.colorless
         }
       end
     end

--- a/pokemon/pokejokers_12.lua
+++ b/pokemon/pokejokers_12.lua
@@ -326,7 +326,7 @@ local baltoy={
             colour = G.C.CLEAR,
           },
           nodes = {
-            { n = G.UIT.T, config = { text = '+'..center.ability.extra.hazard_level, colour = G.ARGS.LOC_COLOURS.hazard, scale = 0.32 } },
+            { n = G.UIT.T, config = { text = '+'..center.ability.extra.hazard_level, colour = pokermon.colours.hazard, scale = 0.32 } },
               { n = G.UIT.T, config = { text = ' '..localize('k_poke_hazard_layer'), colour = G.C.UI.TEXT_DARK, scale = 0.32 } },
             }
         },
@@ -422,7 +422,7 @@ local claydol={
             colour = G.C.CLEAR,
           },
           nodes = {
-            { n = G.UIT.T, config = { text = '+'..center.ability.extra.hazard_level, colour = G.ARGS.LOC_COLOURS.hazard, scale = 0.32 } },
+            { n = G.UIT.T, config = { text = '+'..center.ability.extra.hazard_level, colour = pokermon.colours.hazard, scale = 0.32 } },
               { n = G.UIT.T, config = { text = ' '..localize('k_poke_hazard_layer'), colour = G.C.UI.TEXT_DARK, scale = 0.32 } },
             }
         },

--- a/pokemon/pokejokers_13.lua
+++ b/pokemon/pokejokers_13.lua
@@ -1074,7 +1074,7 @@ local jirachi_fixer = {
               local cons = {
                 {set = "Tarot", message = localize('k_plus_tarot'), colour = G.C.PURPLE, key = 'c_death'},
                 {set = "Spectral", message = localize('k_plus_spectral'), colour = G.C.SECONDARY_SET.Spectral, key = 'c_cryptid'},
-                {set = "poke_item", message = localize('poke_plus_pokeitem'), colour = G.ARGS.LOC_COLOURS.item, key = 'c_poke_metalcoat'},
+                {set = "poke_item", message = localize('poke_plus_pokeitem'), colour = G.C.SECONDARY_SET.poke_item, key = 'c_poke_metalcoat'},
                }
               local con = pseudorandom_element(cons, pseudoseed('jirachi_fixer'))
               local added = SMODS.add_card{set = con.set, key = con.key, key_append = 'jirachi_fixer'}

--- a/pokemon/pokejokers_16.lua
+++ b/pokemon/pokejokers_16.lua
@@ -695,7 +695,7 @@ local porygonz={
                   G.GAME.consumeable_buffer = 0
               return true
           end)}))
-      card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = G.ARGS.LOC_COLOURS["pink"]})
+      card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize("poke_plus_energy"), colour = pokermon.colours.pink})
     end
   end,
   add_to_deck = function(self, card, from_debuff)

--- a/pokemon/pokejokers_18.lua
+++ b/pokemon/pokejokers_18.lua
@@ -511,7 +511,7 @@ local drilbur={
       if not context.blueprint and SMODS.has_enhancement(context.destroying_card, 'm_stone') and card.ability.extra.active then
         card.ability.extra.active = false
         card.ability.extra.stones_destroyed = card.ability.extra.stones_destroyed + 1
-        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_drill_ex'), colour = G.ARGS.LOC_COLOURS.earth})
+        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_drill_ex'), colour = pokermon.colours.earth})
         pokermon.create_treasure(card, 'drilbur')
         return true
       end
@@ -558,7 +558,7 @@ local excadrill={
     end
     if context.destroying_card then
       if not context.blueprint and SMODS.has_enhancement(context.destroying_card, 'm_stone') then
-        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_drill_ex'), colour = G.ARGS.LOC_COLOURS.earth})
+        card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_drill_ex'), colour = pokermon.colours.earth})
         pokermon.create_treasure(card, 'excadril', true)
         return true
       end

--- a/pokemon/pokejokers_23.lua
+++ b/pokemon/pokejokers_23.lua
@@ -68,7 +68,7 @@ local pyroar={
           return {
             message = localize{type = 'variable', key = 'a_chips', vars = {card.ability.extra.chips}}, 
             colour = G.C.CHIPS,
-            extra = {focus = card, message = localize('poke_plus_energy'), colour = G.ARGS.LOC_COLOURS.pink, func = function()
+            extra = {focus = card, message = localize('poke_plus_energy'), colour = pokermon.colours.pink, func = function()
               G.E_MANAGER:add_event(Event({
                 trigger = 'before',
                 delay = 0.0,

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -183,7 +183,7 @@ local jelly_donut={
               return true
             end
         })) 
-        card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = "Energy!", colour = G.ARGS.LOC_COLOURS.pink})
+        card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = "Energy!", colour = pokermon.colours.pink})
       else
         card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = "No Room!", colour = G.C.MULT})
       end
@@ -207,7 +207,7 @@ local treasure_eatery={
   config = {extra = {rounds = 4,}},
   loc_vars = function(self, info_queue, center)
     pokermon.type_tooltip(self, info_queue, center)
-    info_queue[#info_queue+1] = {set = 'Other', key = 'typechangerother', vars = {"Type", colours = {G.ARGS.LOC_COLOURS.pink}}}
+    info_queue[#info_queue+1] = {set = 'Other', key = 'typechangerother', vars = {"Type", colours = {pokermon.colours.pink}}}
     return {vars = {center.ability.extra.rounds, }}
   end,
   rarity = 2,

--- a/pokesprites.lua
+++ b/pokesprites.lua
@@ -405,38 +405,39 @@ for i = 1, 5 do
 end
 
 --Custom colors for Types (humplydinkle wuz here)
-local pokecolors = loc_colour
-function loc_colour(_c, _default)
-  if not G.ARGS.LOC_COLOURS then
-    pokecolors()
-  end
-  G.ARGS.LOC_COLOURS["dark"] = HEX("0086a5")
-  G.ARGS.LOC_COLOURS["lightning"] = HEX("f8f800")
-  G.ARGS.LOC_COLOURS["fire"] = HEX("f81020")
-  G.ARGS.LOC_COLOURS["water"] = HEX("38b8f8")
-  G.ARGS.LOC_COLOURS["earth"] = HEX("e97333")
-  G.ARGS.LOC_COLOURS["fairy"] = HEX("ff3db6")
-  G.ARGS.LOC_COLOURS["fighting"] = HEX("b85838")
-  G.ARGS.LOC_COLOURS["colorless"] = HEX("c8c0f8")
-  G.ARGS.LOC_COLOURS["psychic"] = HEX("c135ff")
-  G.ARGS.LOC_COLOURS["metal"] = HEX("888080")
-  G.ARGS.LOC_COLOURS["grass"] = HEX("289830")
-  G.ARGS.LOC_COLOURS["dragon"] = HEX("c8a800")
-  G.ARGS.LOC_COLOURS["bird"] = HEX("F7B58C")
-  G.ARGS.LOC_COLOURS["pink"] = HEX("FF7ABF")
-  G.ARGS.LOC_COLOURS["item"] = HEX("9AA4B7")
-  G.ARGS.LOC_COLOURS["safari"] = HEX("F2C74E")
-  G.ARGS.LOC_COLOURS["pocket"] = HEX("E8C069")
-  G.ARGS.LOC_COLOURS["hazard"] = HEX("BA7333")
-  G.ARGS.LOC_COLOURS["sun"] = HEX("F48E62")
-  G.ARGS.LOC_COLOURS["rain"] = HEX("6169FF")
-  G.ARGS.LOC_COLOURS["sand"] = HEX("E1C019")
-  G.ARGS.LOC_COLOURS["snow"] = HEX("82C8E8")
-  return pokecolors(_c, _default)
-end
+pokermon.colours = {
+  dark = HEX("0086a5"),
+  lightning = HEX("f8f800"),
+  fire = HEX("f81020"),
+  water = HEX("38b8f8"),
+  earth = HEX("e97333"),
+  fairy = HEX("ff3db6"),
+  fighting = HEX("b85838"),
+  colorless = HEX("c8c0f8"),
+  psychic = HEX("c135ff"),
+  metal = HEX("888080"),
+  grass = HEX("289830"),
+  dragon = HEX("c8a800"),
+  bird = HEX("F7B58C"),
+  pink = HEX("FF7ABF"),
+  -- item = HEX("9AA4B7"),
+  -- safari = HEX("F2C74E"),
+  pocket = HEX("E8C069"),
+  hazard = HEX("BA7333"),
+  sun = HEX("F48E62"),
+  rain = HEX("6169FF"),
+  sand = HEX("E1C019"),
+  snow = HEX("82C8E8")
+}
 
---called to ensure crashes don't happen
-loc_colour()
+local loc_colour_ref = loc_colour
+function loc_colour(_c, _default, ...)
+  if type(_c) == 'string' and string.sub(_c, 0, 5) == 'poke_' then
+    local poke_colour = pokermon.colours[string.sub(_c, 6)]
+    if poke_colour then return poke_colour end
+  end
+  return loc_colour_ref(_c, _default, ...)
+end
 
 --Stake textures for Malverk
 if (SMODS.Mods["malverk"] or {}).can_load then

--- a/pokeui.lua
+++ b/pokeui.lua
@@ -703,7 +703,7 @@ function G.UIDEF.use_and_sell_buttons(card)
 end
 G.FUNCS.poke_can_reserve_card = function(e)
     if #G.consumeables.cards < G.consumeables.config.card_limit then 
-        e.config.colour = G.ARGS.LOC_COLOURS.pink
+        e.config.colour = pokermon.colours.pink
         e.config.button = 'poke_reserve_card' 
     else
       e.config.colour = G.C.UI.BACKGROUND_INACTIVE

--- a/seals/seals1.lua
+++ b/seals/seals1.lua
@@ -35,7 +35,7 @@ local pink_seal = {
             return true
           end,
         }))
-        return { message = localize("poke_plus_energy"), colour = G.ARGS.LOC_COLOURS["pink"] }
+        return { message = localize("poke_plus_energy"), colour = pokermon.colours.pink }
       end
 		end
 	end,

--- a/sleeves/sleeve.lua
+++ b/sleeves/sleeve.lua
@@ -412,7 +412,7 @@ local diceysleeve = {
           G.GAME.modifiers.poke_enhance_bonus = 'm_poke_hazard'
           G.GAME.modifiers.poke_money_per_enhancement = self.config.money
           G.GAME.modifiers.poke_enhance_bonus_text = localize('poke_hazards_in_deck')
-          G.GAME.modifiers.poke_enhance_bonus_color = G.ARGS.LOC_COLOURS["hazard"]
+          G.GAME.modifiers.poke_enhance_bonus_color = pokermon.colours.hazard
           return true
         end
       }))

--- a/stickers/stickers.lua
+++ b/stickers/stickers.lua
@@ -12,7 +12,7 @@ for i = 1, #poketype_list do
   local poke_type = string.lower(poketype_list[i])
   local type_sticker = copy_table(type_sticker_template)
   type_sticker.key = poke_type..'_sticker'
-  type_sticker.badge_colour = G.ARGS.LOC_COLOURS[poke_type]
+  type_sticker.badge_colour = pokermon.colours[poke_type]
   type_sticker.pos = {x = i % 10, y = math.floor(i/10) }
   table.insert(type_stickers, type_sticker)
 end

--- a/tags/tags1.lua
+++ b/tags/tags1.lua
@@ -21,7 +21,7 @@ local pocket_tag = {
 			--I'll leave that up to you
       --Oops, meant to change that lol
 			-- -Jevonn
-			tag:yep("+", G.ARGS.LOC_COLOURS.item, function()
+			tag:yep("+", G.C.SECONDARY_SET.poke_item, function()
 				local key = "p_poke_pokepack_mega_"..math.random(1, 2)
 				local card = Card(
 					G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2,
@@ -137,7 +137,7 @@ local safari_tag = {
       }
       create_shop_card_ui(card, 'Joker', context.area)
       card.states.visible = false
-      tag:yep('+', G.ARGS.LOC_COLOURS.safari,function() 
+      tag:yep('+', G.C.RARITY.poke_safari,function() 
           card:start_materialize()
           card.ability.couponed = true
           card:set_cost()


### PR DESCRIPTION
Prefixes Pokermon-specific colours, to ensure we don't run into any collisions. Additionally removes superfluous instances of Item and Safari colours.

Instead of using `G.ARGS.LOC_COLOURS` in the future:
- `G.ARGS.LOC_COLOURS.item` -> `G.C.SECONDARY_SET.poke_item`
- `G.ARGS.LOC_COLOURS.safari` -> `G.C.RARITY.poke_safari`
- `G.ARGS.LOC_COLOURS[ptype]` -> `pokermon.colours[ptype]`

`pokermon.colours` contains all unprefixed colours (except `item` and `safari`)

For colours in localization files, all colours are now prefixed with `poke_` (ex. `{C:pink}` -> `{C:poke_pink}`)

(localization files were edited by mass find and replace using regex)