### PR TITLE
Use poll_evo_item function for pickup keys

### DIFF
--- a/boosters/packs1.lua
+++ b/boosters/packs1.lua
@@ -19,38 +19,9 @@ local create_energy = function(self, card)
   return create_card("poke_energy", G.pack_cards, nil, nil, true, true, nil, nil)
 end
 
-local poll_evo_item = function(seed)
-  local evo_item_key_set = {}
-  for _, v in pairs(G.jokers.cards) do
-    if v.config.center.item_req then
-      local item_req = type(v.config.center.item_req) == 'table'
-          and pseudorandom_element(v.config.center.item_req, pseudoseed(seed))
-          or v.config.center.item_req
-
-      local prefix = pokermon.has(native_evo_items, item_req)
-          and 'poke'
-          or v.config.center.poke_custom_prefix
-
-      local item_key = 'c_' .. prefix .. '_' .. item_req
-
-      evo_item_key_set[item_key] = true
-    end
-  end
-  local evo_item_key_list = {}
-  for key, _ in pairs(evo_item_key_set) do
-    if G.P_CENTERS[key] and not G.GAME.used_jokers[key] and not G.GAME.banned_keys[key] and (not (type(G.P_CENTERS[key].in_pool) == 'function') or G.P_CENTERS[key]:in_pool()) then
-      evo_item_key_list[#evo_item_key_list+1] = key
-    end
-  end
-  if #evo_item_key_list > 1 then
-    return pseudorandom_element(evo_item_key_list, pseudoseed(seed))
-  end
-  return evo_item_key_list[1]
-end
-
 local create_item = function(seed)
   if pseudorandom(pseudoseed(seed .. '_evo_item')) > .92 then
-    local evo_item_key = poll_evo_item('match')
+    local evo_item_key = pokermon.poll_evo_item('match')
     if evo_item_key then
       return SMODS.create_card { key = evo_item_key, area = G.pack_cards, skip_materialize = true }
     end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1179,34 +1179,48 @@ pokermon.fossil_generate_ui = function(self, info_queue, card, desc_nodes, speci
 end
 
 pokermon.generate_pickup_item_key = function(seed)
-  local item_key = 'c_poke_transformation'
+  local item_key
   local item_chance = pseudorandom(seed)
+
   if item_chance < .34 then item_key = nil
-  elseif item_chance < .59 then item_key = 'evo'
+  elseif item_chance < .59 then item_key = pokermon.poll_evo_item(seed)
   elseif item_chance < .79 then item_key = 'c_poke_leftovers'
   elseif item_chance < .99 then item_key = 'c_poke_twisted_spoon'
+  else item_key = 'c_poke_transformation'
   end
-  
-  if item_key == "evo" then
-    local evo_item_keys = {}
-    for k, v in pairs(G.jokers.cards) do
-      if v.config.center.item_req then
-        if type(v.config.center.item_req) == "table" then
-          item_key = "c_poke_"..pseudorandom_element(v.config.center.item_req, pseudoseed(seed))
-        else
-          item_key = "c_poke_"..v.config.center.item_req
-        end
-        table.insert(evo_item_keys, item_key)
-      end
-    end
-    if #evo_item_keys > 0 then
-      item_key = pseudorandom_element(evo_item_keys, pseudoseed(seed))
-    else
-      item_key = nil
-    end
-  end
-  
+
   return item_key
+end
+
+pokermon.poll_evo_item = function(seed)
+  local evo_item_key_set = {}
+  for _, v in pairs(G.jokers.cards) do
+    if v.config.center.item_req then
+      local item_req = type(v.config.center.item_req) == 'table'
+          and pseudorandom_element(v.config.center.item_req, pseudoseed(seed))
+          or v.config.center.item_req
+
+      local prefix = pokermon.has(POKE_NATIVE_EVO_ITEMS, item_req)
+          and 'poke'
+          or v.config.center.poke_custom_prefix
+
+      local item_key = 'c_' .. prefix .. '_' .. item_req
+
+      evo_item_key_set[item_key] = true
+    end
+  end
+
+  local evo_item_key_list = {}
+  for key, _ in pairs(evo_item_key_set) do
+    if G.P_CENTERS[key] and not G.GAME.used_jokers[key] and not G.GAME.banned_keys[key]
+        and (not type(G.P_CENTERS[key].in_pool) == 'function' or G.P_CENTERS[key]:in_pool()) then
+      evo_item_key_list[#evo_item_key_list+1] = key
+    end
+  end
+  if #evo_item_key_list > 1 then
+    return pseudorandom_element(evo_item_key_list, pseudoseed(seed))
+  end
+  return evo_item_key_list[1]
 end
 
 pokermon.set_sprites = function(self, card, front)


### PR DESCRIPTION
Super niche PR, Linoone (and other pickup jokers) can crash if they attempt to generate an evo item from a fan addition without the "poke" prefix. Fortunately there's a handy poll_evo_item function already in use for pocket packs that doesn't have this issue, so i moved that function and applied it in both places.