### PR TITLE
2 Teensy Optimizations for create_consumeable and Pumpkaboo line

### DIFF
--- a/functions/pokedraw.lua
+++ b/functions/pokedraw.lua
@@ -141,3 +141,11 @@ function poke_set_mystery_dungeon_back_sprites()
     handle_mystery_dungeon_sprites(card)
   end
 end
+
+-- Pumpkaboo and Gourgeist small form juice fix
+local juiceupref = Card.juice_up
+function Card:juice_up(scale, rot_amount)
+  juiceupref(self, scale, rot_amount)
+  if not scale then scale = 0.11 end
+  if self.T.scale < 0.9 then self.VT.scale = self.T.scale - 0.6 * scale end
+end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1459,6 +1459,7 @@ pokermon.create_consumeable = function(args, in_event, message_card)
   if type(args) == 'string' then args = { key = args } end
   if not G.GAME.banned_keys[args.key]
       and (#G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit or args.edition == 'e_negative') then
+    args.skip_materialize = true
     local card = SMODS.create_card(args)
     local set = card.ability.set
     local loc_keys = {
@@ -1468,8 +1469,8 @@ pokermon.create_consumeable = function(args, in_event, message_card)
       ['poke_item'] = 'poke_plus_pokeitem',
       ['poke_energy'] = 'poke_plus_pokeitem',
     }
+    card.states.visible = nil
     if in_event then
-      card.states.visible = nil
       G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
       G.E_MANAGER:add_event(Event({
         func = (function()
@@ -1481,6 +1482,7 @@ pokermon.create_consumeable = function(args, in_event, message_card)
       }))
     else
       SMODS.add_to_deck(card, args)
+      card:start_materialize()
     end
     SMODS.calculate_effect({
       message = loc_keys[set] and localize(loc_keys[set]) or "+1 " .. card.ability.set,


### PR DESCRIPTION
create_consumable fix is preventing the card spawning noise from stacking on itself (not super noticeable until you start having game states running at 4fps but was still something of note)

pumpkaboo and gourgeist in small form kinda freak out when you hover over them? and it's my fault because of how I did the sticker fix, so I made a little hook to fix the problem