### PR TITLE
Using SMODS.find_card instead of find_joker where applicable

### DIFF
--- a/consumables/03_mart_items.lua
+++ b/consumables/03_mart_items.lua
@@ -836,7 +836,7 @@ local upgrade = {
     end
   end,
   in_pool = function(self)
-    return not next(find_joker("porygon2"))
+    return not next(SMODS.find_card("j_poke_porygon2"))
   end
 }
 

--- a/consumables/05_mart_specific.lua
+++ b/consumables/05_mart_specific.lua
@@ -108,7 +108,7 @@ local dubious_disc = {
     end
   end,
   in_pool = function(self)
-    return next(find_joker("porygon2"))
+    return next(SMODS.find_card("j_poke_porygon2"))
   end
 }
 

--- a/functions/debufffunctions.lua
+++ b/functions/debufffunctions.lua
@@ -8,8 +8,8 @@ SMODS.current_mod.set_debuff = function(card)
 
    -- prevent debuffs
    if card.ability.name == "gholdengo" then return 'prevent_debuff' end
-   if SMODS.has_enhancement(card, 'm_wild') and next(find_joker("tangrowth")) then return 'prevent_debuff' end
-   if card:get_id() == 10 and next(find_joker("tentacruel")) then return 'prevent_debuff' end
+   if SMODS.has_enhancement(card, 'm_wild') and next(SMODS.find_card("j_poke_tangrowth")) then return 'prevent_debuff' end
+   if card:get_id() == 10 and next(SMODS.find_card("j_poke_tentacruel")) then return 'prevent_debuff' end
 
    return false
 end

--- a/functions/pokefamily.lua
+++ b/functions/pokefamily.lua
@@ -280,7 +280,7 @@ end
 
 --- Returns whether any cards present share a family with the provided center
 pokermon.family_present = function(center)
-  if next(find_joker("Showman")) or next(find_joker("pokedex")) then return false end
+  if SMODS.showman() or next(SMODS.find_card("j_poke_pokedex")) then return false end
   local family_list = pokermon.get_family_list(center.name)
   local prefix = center.poke_custom_prefix or 'poke'
   for _, fam in pairs(family_list) do

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -262,7 +262,7 @@ end
 
 pokermon.can_evolve = function(self, card, context, forced_key, ignore_step, allow_level)
   if not G.P_CENTERS[forced_key] then return false end
-  if next(find_joker("everstone")) and not allow_level then return false end
+  if next(SMODS.find_card("j_poke_everstone")) and not allow_level then return false end
   if (context.evolution or ignore_step) and not context.blueprint and not card.gone then
     return true
   else
@@ -292,7 +292,7 @@ pokermon.level_evo = function(self, card, context, forced_key)
     end
     if pokermon.can_evolve(self, card, context, forced_key, true) and card.ability.extra.rounds <= 1 and not card.ability.extra.juiced then
       card.ability.extra.juiced = true
-      local eval = function(card) return card.ability.extra.rounds and card.ability.extra.rounds <= 1 and not next(find_joker("everstone")) and card.ability.extra.juiced end
+      local eval = function(card) return card.ability.extra.rounds and card.ability.extra.rounds <= 1 and not next(SMODS.find_card("j_poke_everstone")) and card.ability.extra.juiced end
       juice_card_until(card, eval, true)
     end
 end

--- a/pokemon/pokejokers_05.lua
+++ b/pokemon/pokejokers_05.lua
@@ -662,7 +662,6 @@ local ditto={
         end
       end
     end
-    if next(find_joker("Showman")) then return true end
     return true
   end,
   attributes = {"joker", "volatile"},


### PR DESCRIPTION
Some of this might conflict with mael's earlier PR since they were meant to address the same thing initially, but it also replaces instances of find_joker with SMODS.find_card