### PR TITLE
depleted fix for ranks not in pool / non-default ranks

### DIFF
--- a/jokerdisplay/definitions3.lua
+++ b/jokerdisplay/definitions3.lua
@@ -1846,14 +1846,15 @@ jd_def["j_poke_relicanth"] = {
       local depleted_count = 0
     
       for _, rank in pairs(SMODS.Ranks) do
-        if rank.in_pool and not rank:in_pool({}) then goto continue end
-        local is_rank = function(deck_card)
-          return deck_card:get_id() == rank.id
+        if rank.in_pool and not rank:in_pool({}) then
+        else
+          local is_rank = function(deck_card)
+            return deck_card:get_id() == rank.id
+          end
+          if pokermon.get_depleted(is_rank) then
+            depleted_count = depleted_count + 1
+          end
         end
-        if pokermon.get_depleted(is_rank) then
-          depleted_count = depleted_count + 1
-        end
-        ::continue::
       end
       Xmult = 1 + card.ability.extra.Xmult_mod * depleted_count
     end

--- a/jokerdisplay/definitions3.lua
+++ b/jokerdisplay/definitions3.lua
@@ -1845,18 +1845,15 @@ jd_def["j_poke_relicanth"] = {
     if four_count >= 4 then
       local depleted_count = 0
     
-      for k, v in pairs(SMODS.Ranks) do
+      for _, rank in pairs(SMODS.Ranks) do
+        if rank.in_pool and not rank:in_pool({}) then goto continue end
         local is_rank = function(deck_card)
-          if deck_card:get_id() == v.id then
-            return true
-          else
-            return false
-          end
+          return deck_card:get_id() == rank.id
         end
-        
         if pokermon.get_depleted(is_rank) then
           depleted_count = depleted_count + 1
         end
+        ::continue::
       end
       Xmult = 1 + card.ability.extra.Xmult_mod * depleted_count
     end

--- a/pokemon/pokejokers_13.lua
+++ b/pokemon/pokejokers_13.lua
@@ -284,14 +284,15 @@ local relicanth={
     local depleted_count = 0
     
     for _, rank in pairs(SMODS.Ranks) do
-      if rank.in_pool and not rank:in_pool({}) then goto continue end
-      local is_rank = function(deck_card)
-        return deck_card:get_id() == rank.id
+      if rank.in_pool and not rank:in_pool({}) then
+      else
+        local is_rank = function(deck_card)
+          return deck_card:get_id() == rank.id
+        end
+        if pokermon.get_depleted(is_rank) then
+          depleted_count = depleted_count + 1
+        end
       end
-      if pokermon.get_depleted(is_rank) then
-        depleted_count = depleted_count + 1
-      end
-      ::continue::
     end
     return {vars = {localize(abbr.rank, 'ranks'), abbr.chips, abbr.money_mod, abbr.Xmult_mod, math.max(1, 1 + abbr.Xmult_mod * depleted_count)}}
   end,
@@ -334,14 +335,15 @@ local relicanth={
       local depleted_count = 0
     
       for _, rank in pairs(SMODS.Ranks) do
-        if rank.in_pool and not rank:in_pool({}) then goto continue end
-        local is_rank = function(deck_card)
-          return deck_card:get_id() == rank.id
+        if rank.in_pool and not rank:in_pool({}) then
+        else
+          local is_rank = function(deck_card)
+            return deck_card:get_id() == rank.id
+          end
+          if pokermon.get_depleted(is_rank) then
+            depleted_count = depleted_count + 1
+          end
         end
-        if pokermon.get_depleted(is_rank) then
-          depleted_count = depleted_count + 1
-        end
-        ::continue::
       end
       
       if depleted_count > 0 then

--- a/pokemon/pokejokers_13.lua
+++ b/pokemon/pokejokers_13.lua
@@ -283,18 +283,15 @@ local relicanth={
     local abbr = center.ability.extra
     local depleted_count = 0
     
-    for k, v in pairs(SMODS.Ranks) do
+    for _, rank in pairs(SMODS.Ranks) do
+      if rank.in_pool and not rank:in_pool({}) then goto continue end
       local is_rank = function(deck_card)
-        if deck_card:get_id() == v.id then
-          return true
-        else
-          return false
-        end
+        return deck_card:get_id() == rank.id
       end
-      
       if pokermon.get_depleted(is_rank) then
         depleted_count = depleted_count + 1
       end
+      ::continue::
     end
     return {vars = {localize(abbr.rank, 'ranks'), abbr.chips, abbr.money_mod, abbr.Xmult_mod, math.max(1, 1 + abbr.Xmult_mod * depleted_count)}}
   end,
@@ -336,18 +333,15 @@ local relicanth={
     if context.joker_main and card.ability.extra.ancient_count > 3 then
       local depleted_count = 0
     
-      for k, v in pairs(SMODS.Ranks) do
+      for _, rank in pairs(SMODS.Ranks) do
+        if rank.in_pool and not rank:in_pool({}) then goto continue end
         local is_rank = function(deck_card)
-          if deck_card:get_id() == v.id then
-            return true
-          else
-            return false
-          end
+          return deck_card:get_id() == rank.id
         end
-        
         if pokermon.get_depleted(is_rank) then
           depleted_count = depleted_count + 1
         end
+        ::continue::
       end
       
       if depleted_count > 0 then


### PR DESCRIPTION
This is mostly for fan-addon reasons - currently with the way deplete and pokermon.get_depleted work (which is really just relicanth atp), ranks that don't *start* in your deck count toward the depleted count because there are zero of them in deck by default, so this is just a bandage fix for that