### PR TITLE
move pool toggles into `context.modify_weights`

### DIFF
--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1489,3 +1489,28 @@ pokermon.create_consumeable = function(args, in_event, message_card)
     }, message_card or card)
   end
 end
+
+pokermon.remove_from_pool = function(center)
+  local config = pokermon_config or {}
+
+  if center.set == 'Joker' then
+    if not center.stage then return config.pokemon_only end
+
+    return (not config.hazards_on and center.hazard_poke)
+        or not pokermon.get_gen_allowed(center)
+        or pokermon.family_present(center)
+  end
+
+  return false
+end
+
+pokermon.modify_pool = function(pool)
+  for k, v in pairs(pool) do
+    if type(k) == 'string' then
+      local center = G.P_CENTERS[k]
+      if center and pokermon.remove_from_pool(center) then
+        v.weight = 0
+      end
+    end
+  end
+end

--- a/lovely/gameplay_functions.toml
+++ b/lovely/gameplay_functions.toml
@@ -182,21 +182,6 @@ match_indent = true
 ### Game Modifiers
 
 
-# Pokemon only functionality
-[[patches]]
-[patches.pattern]
-target = "functions/common_events.lua"
-pattern = "if v.yes_pool_flag and not G.GAME.pool_flags[v.yes_pool_flag] then add = nil end"
-position = "after"
-payload = '''
-if v.set == 'Joker' and not v.stage and pokermon_config and pokermon_config.pokemon_only then add = nil end
-if v.set == 'Joker' and v.stage and not pokermon.get_gen_allowed(v) then add = nil end
-if v.set == 'Joker' and v.stage and pokermon_config and not pokermon_config.hazards_on and v.hazard_poke then add = nil end
-if add and v.set == 'Joker' and v.stage and pokermon.family_present(v) then add = nil end
-'''
-match_indent = true
-
-
 # Enhance bonus
 [[patches]]
 [patches.pattern]

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -6,7 +6,7 @@ if SMODS.current_mod then
 end
 
 pokermon = { energy = {}, ui = {}, sprites = {} }
-SMODS.current_mod.optional_features = { quantum_enhancements = true }
+SMODS.current_mod.optional_features = { quantum_enhancements = true, object_weights = true }
 
 --Undiscovered sprites, mostly for testing some localization things since the game crashes without them
 --This can probably have a better integration or just be removed altogether since everything is discovered anyways
@@ -346,6 +346,10 @@ function SMODS.current_mod.calculate(self, context)
         joker.ability.fainted = nil
       end
     end
+  end
+
+  if context.modify_weights then
+    pokermon.modify_pool(context.pool)
   end
 end
 


### PR DESCRIPTION
Using the new SMODS feature of object weights, this simply moves our pool functions out of patches and into context calls.

Ideally shouldn't change any regular functionality, but does give us 2 small benefits:
- pool toggles will now also apply to joker generation using attributes
- we can now use `weight` to make certain consumables/jokers/enhancements/etc more or less likely to appear (base weight is 10)