### PR TITLE
Refactor Gimmighoul

### DIFF
--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -140,25 +140,28 @@ pokermon.add_playing_card = function(t, no_joker_effect)
   return playing_card
 end
 
-pokermon.add_shop_card = function(add_card, card)
-    if G.GAME.shop.joker_max == 1 then
-      G.shop_jokers.config.card_limit = G.GAME.shop.joker_max + 1
-      G.shop_jokers.T.w = math.min((G.GAME.shop.joker_max + 1)*1.02*G.CARD_W,4.08*G.CARD_W)
-      G.shop:recalculate()
+pokermon.add_shop_card = function(add_card, card, is_free)
+  if G.GAME.shop.joker_max == 1 then
+    G.shop_jokers.config.card_limit = G.GAME.shop.joker_max + 1
+    G.shop_jokers.T.w = math.min((G.GAME.shop.joker_max + 1) * 1.02 * G.CARD_W, 4.08 * G.CARD_W)
+    G.shop:recalculate()
+  end
+  add_card.states.visible = false
+  G.shop_jokers:emplace(add_card)
+  if is_free then
+    add_card.ability.couponed = true
+  end
+  add_card:start_materialize()
+  add_card:set_cost()
+  create_shop_card_ui(add_card)
+
+  if (SMODS.Mods["Talisman"] or {}).can_load then
+    if Talisman.config_file.disable_anims then
+      add_card.states.visible = true
     end
-    add_card.states.visible = false
-    G.shop_jokers:emplace(add_card)
-    add_card:start_materialize()
-    add_card:set_cost()
-    create_shop_card_ui(add_card)
-    
-    if (SMODS.Mods["Talisman"] or {}).can_load then
-      if Talisman.config_file.disable_anims then 
-        add_card.states.visible = true
-      end
-    end
-    card:juice_up()
-    card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_plus_shop'), colour = G.C.GREEN})
+  end
+  card:juice_up()
+  card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('poke_plus_shop'), colour = G.C.GREEN})
 end
 
 pokermon.remove_card = function(target, card, trigger)

--- a/pokemon/pokejokers_03.lua
+++ b/pokemon/pokejokers_03.lua
@@ -836,8 +836,7 @@ local slowpoke={
       if SMODS.pseudorandom_probability(card, 'slowpoke', card.ability.extra.num, card.ability.extra.dem, 'slowpoke') then
         local temp_card = {set = "Joker", area = G.shop_jokers, key = "j_poke_shell"}
         local add_card = SMODS.create_card(temp_card)
-        pokermon.add_shop_card(add_card, card)
-        add_card.cost = 0
+        pokermon.add_shop_card(add_card, card, true)
       end
     end
     local evo = pokermon.item_evo(self, card, context, "j_poke_slowking")

--- a/pokemon/pokejokers_34.lua
+++ b/pokemon/pokejokers_34.lua
@@ -10,7 +10,7 @@
 local gimmighoul={
   name = "gimmighoul",
   pos = {x = 12, y = 6},
-  config = {extra = {money = 3, money_goal = 999, money_seen = 0, previous_money = 0}},
+  config = {extra = {money = 3, money_goal = 999, money_seen = 0}},
   loc_vars = function(self, info_queue, center)
     pokermon.type_tooltip(self, info_queue, center)
     if pokermon_config.detailed_tooltips then
@@ -30,61 +30,28 @@ local gimmighoul={
   eternal_compat = true,
   calculate = function(self, card, context)
     if context.individual and not context.end_of_round and context.cardarea == G.play and SMODS.has_enhancement(context.other_card, 'm_gold') then
-      G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + card.ability.extra.money
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                G.GAME.dollar_buffer = 0
-                return true
-            end
-        }))
       local earned = pokermon.ease_poke_dollars(card, "gimmi", card.ability.extra.money, true)
+      G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + earned
       return {
         dollars = earned,
-        card = card
+        func = function()
+          G.E_MANAGER:add_event(Event({
+            func = function()
+              G.GAME.dollar_buffer = 0
+              return true
+            end
+          }))
+        end
       }
     end
     if context.skipping_booster and G.shop_jokers and G.shop_jokers.cards then
-        local temp_card = {set = "Joker", area = G.shop_jokers, key = "j_poke_gimmighoulr"}
-        local new_card = SMODS.create_card(temp_card)
-        local edition = {negative = true}
-        new_card:set_edition(edition, true)
-        pokermon.add_shop_card(new_card, card)
-        new_card.cost = 0
+      local new_card = SMODS.create_card({set = "Joker", key = "j_poke_gimmighoulr", edition = 'e_negative'})
+      pokermon.add_shop_card(new_card, card, true)
+    end
+    if context.money_altered then
+      card.ability.extra.money_seen = card.ability.extra.money_seen + math.abs(context.amount)
     end
     return pokermon.scaling_evo(self, card, context, "j_poke_gholdengo", card.ability.extra.money_seen, card.ability.extra.money_goal)
-  end,
-  set_ability = function(self, card, initial, delay_sprites)
-    if initial and G.STAGE == G.STAGES.RUN then
-      card.ability.extra.previous_money = G.GAME.dollars
-    end
-  end,
-  update = function(self, card, dt)
-    if G.STAGE == G.STAGES.RUN then
-      if not card.ability.extra.previous_money then card.ability.extra.previous_money = 0 end
-      if (SMODS.Mods["Talisman"] or {}).can_load then
-        local money_diff = math.abs(to_number(G.GAME.dollars) - to_number(card.ability.extra.previous_money))
-        if to_big(money_diff) > to_big(0) then
-          card.ability.extra.money_seen = card.ability.extra.money_seen + money_diff
-          card.ability.extra.previous_money = G.GAME.dollars
-        end
-        if to_big(card.ability.extra.money_seen) >= to_big(card.ability.extra.money_goal) and not card.ability.extra.juiced then
-          card.ability.extra.juiced = true
-          local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-          juice_card_until(card, eval, true)
-        end
-      else
-        local money_diff = math.abs(G.GAME.dollars - card.ability.extra.previous_money)
-        if money_diff > 0 then
-          card.ability.extra.money_seen = card.ability.extra.money_seen + money_diff
-          card.ability.extra.previous_money = G.GAME.dollars
-        end
-        if card.ability.extra.money_seen >= card.ability.extra.money_goal and not card.ability.extra.juiced then
-          card.ability.extra.juiced = true
-          local eval = function(card) return not card.REMOVED and not G.RESET_JIGGLES end
-          juice_card_until(card, eval, true)
-        end
-      end
-    end
   end,
   attributes = {"enhancements", "economy", "condition_evo"},
 }


### PR DESCRIPTION
Refactors Gimmighoul and adds a parameter to `pokermon.add_shop_card` to make the resulting card free

This version retains the behaviour of Gimmighoul counting both earning and spending money. Let me know if we should take this opportunity to make it just earning instead


Given that [Talisman has been frozen](https://github.com/SpectralPack/Talisman) a little under a month ago, I've only tested this with its replacement Amulet