### PR TITLE
Attribute stages n types

### DIFF
--- a/consumables/00_mart_balls.lua
+++ b/consumables/00_mart_balls.lua
@@ -18,7 +18,7 @@ local pokeball = {
     pokermon.set_spoon_item(card)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        SMODS.add_card({ set = 'Joker', attributes = {'stage_basic'}, key_append = 'pokeball' })
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_basic'}, rarity = false, key_append = 'pokeball' })
         return true end }))
     delay(0.6)
   end
@@ -47,7 +47,7 @@ local greatball = {
     pokermon.set_spoon_item(card)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        SMODS.add_card({ set = 'Joker', attributes = {'stage_one'}, key_append = 'greatball' })
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_one'}, rarity = false, key_append = 'greatball' })
         return true end }))
     delay(0.6)
   end
@@ -75,7 +75,7 @@ local ultraball = {
   use = function(self, card, area, copier)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        SMODS.add_card({ set = 'Joker', attributes = {'stage_two'}, key_append = 'ultraball' })
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_two'}, rarity = false, key_append = 'ultraball' })
         return true end }))
     delay(0.6)
   end
@@ -101,7 +101,7 @@ local masterball = {
   use = function(self, card, area, copier)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        SMODS.add_card({ set = 'Joker', attributes = {'stage_legendary'}, key_append = 'masterball' })
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_legendary'}, allow_legendaries = true, key_append = 'masterball' })
         return true end }))
     delay(0.6)
   end

--- a/consumables/00_mart_balls.lua
+++ b/consumables/00_mart_balls.lua
@@ -12,19 +12,13 @@ local pokeball = {
   unlocked = true,
   discovered = true,
   can_use = function(self, card)
-    if #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers then
-        return true
-    else
-        return false
-    end
+    return #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers
   end,
   use = function(self, card, area, copier)
     pokermon.set_spoon_item(card)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        local _card = pokermon.create_random_poke_joker("pokeball", "Basic")
-        _card:add_to_deck()
-        G.jokers:emplace(_card)
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_basic'}, key_append = 'pokeball' })
         return true end }))
     delay(0.6)
   end
@@ -47,19 +41,13 @@ local greatball = {
   unlocked = true,
   discovered = true,
   can_use = function(self, card)
-    if #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers then
-        return true
-    else
-        return false
-    end
+    return #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers
   end,
   use = function(self, card, area, copier)
     pokermon.set_spoon_item(card)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        local _card = pokermon.create_random_poke_joker("greatball", "One")
-        _card:add_to_deck()
-        G.jokers:emplace(_card)
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_one'}, key_append = 'greatball' })
         return true end }))
     delay(0.6)
   end
@@ -82,18 +70,12 @@ local ultraball = {
   unlocked = true,
   discovered = true,
   can_use = function(self, card)
-    if #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers then
-        return true
-    else
-        return false
-    end
+    return #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers
   end,
   use = function(self, card, area, copier)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        local _card = pokermon.create_random_poke_joker("ultraball", "Two")
-        _card:add_to_deck()
-        G.jokers:emplace(_card)
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_two'}, key_append = 'ultraball' })
         return true end }))
     delay(0.6)
   end
@@ -114,18 +96,12 @@ local masterball = {
   unlocked = true,
   discovered = true,
   can_use = function(self, card)
-    if #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers then
-        return true
-    else
-        return false
-    end
+    return #G.jokers.cards < G.jokers.config.card_limit or self.area == G.jokers
   end,
   use = function(self, card, area, copier)
     G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
         play_sound('timpani')
-        local _card = pokermon.create_random_poke_joker("masterball", "Legendary")
-        _card:add_to_deck()
-        G.jokers:emplace(_card)
+        SMODS.add_card({ set = 'Joker', attributes = {'stage_legendary'}, key_append = 'masterball' })
         return true end }))
     delay(0.6)
   end

--- a/functions/apifunctions.lua
+++ b/functions/apifunctions.lua
@@ -5,16 +5,23 @@ pokermon.load_pokemon = function(item)
   if not item.config then
     item.config = {}
   end
+  if not item.attributes then
+    item.attributes = {}
+  end
   if not item.poke_custom_prefix then
     pokermon.sprites.load_atlas(item)
     pokermon.sprites.load_sprites(item)
   end
   if item.ptype then
+    table.insert(item.attributes, item.ptype:lower() .. '_type')
     if item.config and item.config.extra then
       item.config.extra.ptype = item.ptype
     elseif item.config then
       item.config.extra = {ptype = item.ptype}
     end
+  end
+  if item.stage then
+    table.insert(item.attributes, 'stage_' .. item.stage:lower())
   end
   item.set_badges = pokermon.set_type_badge
   if item.item_req then
@@ -96,5 +103,6 @@ pokermon.Juice = function(item, custom_prefix, set)
 end
 
 pokermon.add_stage = function(stage, prev_stage, next_stage)
+  SMODS.Attribute {key = 'stage_' .. stage:lower() }
   POKE_STAGES[stage] = { prev = prev_stage, next = next_stage }
 end

--- a/functions/apifunctions.lua
+++ b/functions/apifunctions.lua
@@ -22,6 +22,9 @@ pokermon.load_pokemon = function(item)
   end
   if item.stage then
     table.insert(item.attributes, 'stage_' .. item.stage:lower())
+    if item.stage ~= 'Other' then
+      table.insert(item.attributes, 'pokemon')
+    end
   end
   item.set_badges = pokermon.set_type_badge
   if item.item_req then

--- a/functions/pokeconstants.lua
+++ b/functions/pokeconstants.lua
@@ -25,35 +25,46 @@ POKE_EVO_OVERRIDES = {
   { "kubfu", { "urshifu_single_strike", "urshifu_rapid_strike" } },
 }
 
--- Helper functions/getters for accessing constants
+SMODS.Attribute {key = "grass_type"}
+SMODS.Attribute {key = "fire_type"}
+SMODS.Attribute {key = "water_type"}
+SMODS.Attribute {key = "lightning_type"}
+SMODS.Attribute {key = "psychic_type"}
+SMODS.Attribute {key = "fighting_type"}
+SMODS.Attribute {key = "colorless_type"}
+SMODS.Attribute {key = "dark_type"}
+SMODS.Attribute {key = "metal_type"}
+SMODS.Attribute {key = "fairy_type"}
+SMODS.Attribute {key = "dragon_type"}
+SMODS.Attribute {key = "earth_type"}
 
-pokermon.get_previous_stage = function(stage)
-  return (POKE_STAGES[stage] or {}).prev
-end
+SMODS.Attribute {key = "stage_baby"}
+SMODS.Attribute {key = "stage_basic"}
+SMODS.Attribute {key = "stage_one"}
+SMODS.Attribute {key = "stage_two"}
+SMODS.Attribute {key = "stage_legendary"}
+SMODS.Attribute {key = "stage_mega"}
+SMODS.Attribute {key = "stage_other"}
+SMODS.Attribute {key = "stage_???"}
 
-pokermon.get_next_stage = function(stage)
-  return (POKE_STAGES[stage] or {}).next
-end
-
-pokermon.get_evo_overrides = function(name)
-  for _, evo_line in ipairs(POKE_EVO_OVERRIDES) do
-    for i, evo_stage in ipairs(evo_line) do
-      local pokemon_in_stage = type(evo_stage) == 'table'
-          and evo_stage or { evo_stage }
-
-      for _, pokemon in ipairs(pokemon_in_stage) do
-        if pokemon == name then
-          local overrides = {}
-          if i > 1 then
-            overrides.previous_evo = evo_line[i-1]
-          end
-          if i < #evo_line then
-            overrides.highest_evo = evo_line[#evo_line]
-          end
-          return overrides
-        end
-      end
-    end
-  end
-  return {}
-end
+SMODS.Attribute {key = "round_evo"}
+SMODS.Attribute {key = "scaling_evo"}
+SMODS.Attribute {key = "item_evo"}
+SMODS.Attribute {key = "type_evo"}
+SMODS.Attribute {key = "trigger_evo"}
+SMODS.Attribute {key = "condition_evo"}
+SMODS.Attribute {key = "starter"}
+SMODS.Attribute {key = "holding"}
+SMODS.Attribute {key = "item"}
+SMODS.Attribute {key = "types"}
+SMODS.Attribute {key = "volatile"}
+SMODS.Attribute {key = "energy"}
+SMODS.Attribute {key = "energy_count"}
+SMODS.Attribute {key = "energy_limit"}
+SMODS.Attribute {key = "ancient"}
+SMODS.Attribute {key = "foresight"}
+SMODS.Attribute {key = "baby"}
+SMODS.Attribute {key = "nature"}
+SMODS.Attribute {key = "hazards"}
+SMODS.Attribute {key = "applies"}
+SMODS.Attribute {key = "drain"}

--- a/functions/pokeconstants.lua
+++ b/functions/pokeconstants.lua
@@ -25,6 +25,8 @@ POKE_EVO_OVERRIDES = {
   { "kubfu", { "urshifu_single_strike", "urshifu_rapid_strike" } },
 }
 
+SMODS.Attribute {key = "pokemon"}
+
 SMODS.Attribute {key = "grass_type"}
 SMODS.Attribute {key = "fire_type"}
 SMODS.Attribute {key = "water_type"}

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -1493,7 +1493,9 @@ pokermon.remove_from_pool = function(center)
   if center.set == 'Joker' then
     if not center.stage then return config.pokemon_only end
 
-    return (not config.hazards_on and center.hazard_poke)
+    local attributes = center.attributes or {}
+
+    return (not config.hazards_on and attributes['hazards'])
         or not pokermon.get_gen_allowed(center)
         or pokermon.family_present(center)
   end

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -51,6 +51,37 @@ pokermon.get_type = function(card)
   return nil
 end
 
+pokermon.get_previous_stage = function(stage)
+  return (POKE_STAGES[stage] or {}).prev
+end
+
+pokermon.get_next_stage = function(stage)
+  return (POKE_STAGES[stage] or {}).next
+end
+
+pokermon.get_evo_overrides = function(name)
+  for _, evo_line in ipairs(POKE_EVO_OVERRIDES) do
+    for i, evo_stage in ipairs(evo_line) do
+      local pokemon_in_stage = type(evo_stage) == 'table'
+          and evo_stage or { evo_stage }
+
+      for _, pokemon in ipairs(pokemon_in_stage) do
+        if pokemon == name then
+          local overrides = {}
+          if i > 1 then
+            overrides.previous_evo = evo_line[i-1]
+          end
+          if i < #evo_line then
+            overrides.highest_evo = evo_line[#evo_line]
+          end
+          return overrides
+        end
+      end
+    end
+  end
+  return {}
+end
+
 pokermon.copy_scaled_values = function(card)
   local values = {mult = 0, chips = 0, Xmult = 0, Xmult_multi = 0, money = 0}
   if card.ability and card.ability.extra and type(card.ability.extra) == "table" then

--- a/functions/pokeutils.lua
+++ b/functions/pokeutils.lua
@@ -710,6 +710,13 @@ pokermon.has = function(table, element)
   return false
 end
 
+pokermon.any = function(table, func)
+  for _, value in pairs(table) do
+    if func(value) then return true end
+  end
+  return false
+end
+
 pokermon.table_append = function(t1, t2)
   for _, v in ipairs(t2) do
     table.insert(t1, v)

--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -17,7 +17,6 @@ local qwilfish = {
   ptype = "Water",
   atlas = "Pokedex2",
   gen = 2,
-  hazard_poke = true,
   blueprint_compat = true,
   perishable_compat = false,
   calculate = function(self, card, context)
@@ -928,7 +927,6 @@ local skarmory = {
   ptype = "Metal",
   atlas = "Pokedex2",
   gen = 2,
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.cardarea == G.jokers and context.scoring_hand then

--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -696,7 +696,7 @@ local corsola={
           func = function()
             G.GAME.joker_buffer = 0
             play_sound('timpani')
-            SMODS.add_card({ set = 'Joker', key = pokermon.get_random_poke_key('corsola', "Basic", nil, nil, "Water") })
+            SMODS.add_card({set = 'Joker', attributes = {'stage_basic', 'water_type'}, rarity = false, key_append = 'corsola'})
             return true
           end
         }))

--- a/pokemon/pokejokers_12.lua
+++ b/pokemon/pokejokers_12.lua
@@ -17,7 +17,6 @@ local cacnea = {
   ptype = "Grass",
   atlas = "Pokedex3",
   gen = 3,
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.remove_playing_cards then
@@ -55,7 +54,6 @@ local cacturne = {
   ptype = "Grass",
   atlas = "Pokedex3",
   gen = 3,
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.remove_playing_cards then

--- a/pokemon/pokejokers_12.lua
+++ b/pokemon/pokejokers_12.lua
@@ -390,6 +390,7 @@ local baltoy={
   remove_from_deck = function(self, card, from_debuff)
     pokermon.change_hazard_level(-card.ability.extra.hazard_level)
   end,
+  attributes = {"hazards", "discard", "enhancements", "chips", "scaling", "scaling_evo"}
 }
 -- Claydol 344
 local claydol={
@@ -505,6 +506,7 @@ local claydol={
   remove_from_deck = function(self, card, from_debuff)
     pokermon.change_hazard_level(-card.ability.extra.hazard_level)
   end,
+  attributes = {"hazards", "discard", "enhancements", "chips", "scaling", "chance"}
 }
 -- Lileep 345
 local lileep={

--- a/pokemon/pokejokers_18.lua
+++ b/pokemon/pokejokers_18.lua
@@ -337,7 +337,6 @@ local roggenrola = {
   ptype = "Earth",
   atlas = "Pokedex5",
   gen = 5,
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.individual and not context.end_of_round and context.cardarea == G.hand and SMODS.has_no_rank(context.other_card) then
@@ -390,7 +389,6 @@ local boldore = {
   atlas = "Pokedex5",
   gen = 5,
   item_req = "linkcable",
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     if context.individual and not context.end_of_round and context.cardarea == G.hand and SMODS.has_no_rank(context.other_card) then
@@ -437,7 +435,6 @@ local gigalith = {
   atlas = "Pokedex5",
   gen = 5,
   blueprint_compat = true,
-  hazard_poke = true,
   calculate = function(self, card, context)
     if context.individual and not context.end_of_round and context.cardarea == G.hand and SMODS.has_no_rank(context.other_card) then
       if context.other_card.debuff then

--- a/pokemon/pokejokers_21.lua
+++ b/pokemon/pokejokers_21.lua
@@ -529,7 +529,6 @@ local golett={
   perishable_compat = true,
   blueprint_compat = true,
   eternal_compat = true,
-  hazard_poke = true,
   calculate = function(self, card, context)
     if context.individual and not context.end_of_round and context.cardarea == G.hand then
       if SMODS.has_enhancement(context.other_card, "m_poke_hazard") or SMODS.pseudorandom_probability(card, 'golett', card.ability.extra.num, card.ability.extra.dem, 'golett') then
@@ -577,7 +576,6 @@ local golurk={
   ptype = "Psychic",
   atlas = "Pokedex5",
   gen = 5,
-  hazard_poke = true,
   perishable_compat = true,
   blueprint_compat = true,
   eternal_compat = true,

--- a/pokemon/pokejokers_31.lua
+++ b/pokemon/pokejokers_31.lua
@@ -211,7 +211,6 @@ local tarountula = {
   ptype = "Grass",
   atlas = "Pokedex9",
   gen = 9,
-  hazard_poke = true,
   blueprint_compat = true,
   calculate = function(self, card, context)
     return pokermon.level_evo(self, card, context, "j_poke_spidops")
@@ -245,7 +244,6 @@ local spidops = {
   ptype = "Grass",
   atlas = "Pokedex9",
   gen = 9,
-  hazard_poke = true,
   blueprint_compat = false,
   calculate = function(self, card, context)
     if context.playing_card_added and not card.getting_sliced and context.cards and not context.blueprint then

--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -119,27 +119,23 @@ local tall_grass={
   blueprint_compat = true,
   eternal_compat = true,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.scoring_hand then
-      if context.before and (#G.jokers.cards + G.GAME.joker_buffer) < G.jokers.config.card_limit then
-        local has_wild = false
-        for k, v in ipairs(context.scoring_hand) do
-          if v.ability.name == 'Wild Card' then
-            has_wild = true
-            break
-          end
-        end
-        
-        if has_wild or SMODS.pseudorandom_probability(card, 'tall_grass', card.ability.extra.num, card.ability.extra.dem, 'tall_grass') then
-          G.GAME.joker_buffer = G.GAME.joker_buffer + 1
-          G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
+    if context.before and #G.jokers.cards + G.GAME.joker_buffer < G.jokers.config.card_limit then
+      local has_wild = pokermon.any(context.scoring_hand, function(c) return SMODS.has_enhancement(c, 'm_wild') end)
+
+      if has_wild or SMODS.pseudorandom_probability(card, 'tall_grass', card.ability.extra.num, card.ability.extra.dem, 'tall_grass') then
+        G.GAME.joker_buffer = G.GAME.joker_buffer + 1
+
+        G.E_MANAGER:add_event(Event({
+          trigger = 'after',
+          delay = 0.4,
+          func = function()
             G.GAME.joker_buffer = 0
             play_sound('timpani')
-            local _card = pokermon.create_random_poke_joker("tallgrass", nil, "common")
-            _card:add_to_deck()
-            G.jokers:emplace(_card)
-            return true end }))
-          delay(0.6)
-        end
+            SMODS.add_card({set = 'Joker', attributes = {'pokemon'}, rarity = 1, key_append = 'tallgrass'})
+            return true
+          end
+        }))
+        delay(0.6)
       end
     end
   end,

--- a/pokermon.lua
+++ b/pokermon.lua
@@ -68,31 +68,6 @@ SMODS.Rarity{
     end,
 }
 
---Load Custom Attributes
-if SMODS.Attribute then
-  SMODS.Attribute { key = "round_evo" }
-  SMODS.Attribute { key = "scaling_evo" }
-  SMODS.Attribute { key = "item_evo" }
-  SMODS.Attribute { key = "type_evo" }
-  SMODS.Attribute { key = "trigger_evo" }
-  SMODS.Attribute { key = "condition_evo" }
-  SMODS.Attribute { key = "starter" }
-  SMODS.Attribute { key = "holding" }
-  SMODS.Attribute { key = "item" }
-  SMODS.Attribute { key = "types" }
-  SMODS.Attribute { key = "volatile" }
-  SMODS.Attribute { key = "energy" }
-  SMODS.Attribute { key = "energy_count" }
-  SMODS.Attribute { key = "energy_limit" }
-  SMODS.Attribute { key = "ancient" }
-  SMODS.Attribute { key = "foresight" }
-  SMODS.Attribute { key = "baby" }
-  SMODS.Attribute { key = "nature" }
-  SMODS.Attribute { key = "hazards" }
-  SMODS.Attribute { key = "applies" }
-  SMODS.Attribute { key = "drain" }
-end
-
 --Load helper function files
 assert(SMODS.load_file("functions/pokeconstants.lua"))()
 assert(SMODS.load_file("functions/pokefunctions.lua"))()

--- a/tags/tags1.lua
+++ b/tags/tags1.lua
@@ -96,9 +96,7 @@ local stage_one_tag = {
 	end,
 	apply = function(self, tag, context)
     if context and context.type == "store_joker_create" then
-      local card = nil
-      
-      card = pokermon.create_random_poke_joker("stage1tag", "One", nil, context.area)
+      local card = SMODS.create_card({set = 'Joker', attributes = {'stage_one'}, key_append = 'stage1tag'})
       create_shop_card_ui(card, 'Joker', context.area)
       card.states.visible = false
       tag:yep('+', G.C.GREEN,function() 
@@ -107,7 +105,7 @@ local stage_one_tag = {
           card:set_cost()
           return true
       end)
-    
+
       tag.triggered = true
       return card
     end

--- a/tags/tags1.lua
+++ b/tags/tags1.lua
@@ -96,7 +96,7 @@ local stage_one_tag = {
 	end,
 	apply = function(self, tag, context)
     if context and context.type == "store_joker_create" then
-      local card = SMODS.create_card({set = 'Joker', attributes = {'stage_one'}, key_append = 'stage1tag'})
+      local card = SMODS.create_card({set = 'Joker', attributes = {'stage_one'}, rarity = false, key_append = 'stage1tag'})
       create_shop_card_ui(card, 'Joker', context.area)
       card.states.visible = false
       tag:yep('+', G.C.GREEN,function() 


### PR DESCRIPTION
Bit of a hefty change, this Pull Request:
- Adds new (automatically defined) attributes for Stages and Types 
- Refactors everything except Mystery Egg, Zorua Disguise, and Randomizer mode to use attributes for Joker generation
- Changes the Hazards Allowed toggle to instead look for the 'hazards' attribute
- Adds Attributes to Baltoy and Claydol
- Cleans up pokeconstants.lua and pokermon.lua, moving Attribute declarations out of the latter and helper functions out of the former

Example of using this new way of generating specific stage/type jokers:
```lua
SMODS.add_card({
  set = 'Joker', -- important for challenge bans reasons
  attributes = {'stage_basic', 'water_type'}, -- does exactly as you'd expect.
  -- union = true, -- for if you want to get all basic pokes AND all water types, instead of only jokers that are both
  rarity = false, -- turns off rarity polling! this is important for smaller pools or things that generate safari jokers
  -- allow_legendaries = true, -- this *should* be on by default if using the 'stage_legendary' pool, but appears to be bugged 
  key_append = 'custom_rng_seed'
})
```