### PR TITLE
Smeargle tooltip adjustment to remove copy_table call

### DIFF
--- a/lovely/poke_utils.toml
+++ b/lovely/poke_utils.toml
@@ -157,19 +157,19 @@ position = "at"
 payload = "colour = part.control.V and args.vars.colours and args.vars.colours[tonumber(part.control.V)] or not part.control.C and args.text_colour or loc_colour(part.control.C or nil, args.default_col),"
 match_indent = true
 
-#Tooltip loc_vars fix
+
+## Smeargle
+# Allow card tables to be used in joker info_queue for sketch
 [[patches]]
 [patches.pattern]
-target = "card.lua"
-pattern = "if vars_only then return loc_vars, main_start, main_end end"
-position = "before"
-payload = '''
-if vars_only and type(self.ability.loc_vars_replacement) == "table" then
-  loc_vars = self.ability.loc_vars_replacement
-end
-'''
+target = 'functions/common_events.lua'
+pattern = '''elseif _c.set == 'Joker' then'''
+position = 'before'
 match_indent = true
-
+payload = '''
+elseif _c.sketch_copy then
+    localize{type = 'descriptions', set = 'Joker', key = _c.key, nodes = desc_nodes, vars = specific_vars or _c.vars, specific_vars = {is_info_queue = true}, AUT = full_UI_table}
+'''
 
 ## Jirachi
 #Jirachi tag fix

--- a/pokemon/pokejokers_08.lua
+++ b/pokemon/pokejokers_08.lua
@@ -1394,18 +1394,14 @@ local smeargle={
       -- Display the description of the copy, instead of the center
       local other_center = copy.config.center
       local other_vars = type(other_center.loc_vars) == 'function'
-        and other_center.key ~= 'j_poke_smeargle'
         and other_center:loc_vars({}, copy)
         or {}
-      local new_config = copy_table(copy.ability)
-      if other_vars.vars then
-        new_config.loc_vars_replacement = other_vars.vars
-      end
       info_queue[#info_queue+1] = {
         set = 'Joker',
         key = other_vars.key or other_center.key,
-        config = new_config,
-        vars = other_vars.vars or {}
+        config = copy.ability,
+        vars = other_vars.vars or {},
+        sketch_copy = true
       }
     end
 
@@ -1430,7 +1426,11 @@ local smeargle={
   blueprint_compat = true,
   eternal_compat = true,
   get_copy = function(self, card)
-    if card.sketched_joker and not card.sketched_joker.removed then return card.sketched_joker end
+    if card.sketched_joker and not card.sketched_joker.removed then
+      if card.sketched_joker.sketched_joker and not card.sketched_joker.sketched_joker.removed then
+        return self:get_copy(card.sketched_joker)
+      else return card.sketched_joker end
+    end
     if card.ability.extra.copy_val then
       -- If we don't have a reference, such as after reloading, we need to find it again
       for _, v in ipairs(G.jokers.cards) do


### PR DESCRIPTION
So Ortalab has a patch like the one I'm replacing the loc_vars_replacement patch with - it lets you use card ui properly in info_queues. The upshot of this is that we now no longer need to call copy_table on the copy's ability table, meaning we can now use smeargle recursion in tooltips, along with all of the other places we couldn't before (theoretically).