### PR TITLE
Added Energy & Sell value UI + config (2nd attempt)

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,8 @@ return {
   ["shiny_playing_cards"]=false,
   ["detailed_tooltips"]=true,
   ["precise_energy"]=true,
+  ["energy_count"]=false,
+  ["sell_value"]=false,
   ["pokeballs"]=true,
   ["no_evos"]=false,
   ["pokemon_only"]=true,

--- a/functions/pokefunctions.lua
+++ b/functions/pokefunctions.lua
@@ -728,6 +728,7 @@ pokermon.add_frac_tooltip = function(info_queue, card, frac_var, loc_key)
 end
 
 pokermon.add_energy_tooltip = function(info_queue, card)
+  if pokermon_config.energy_count then return end
   if card.ability and type(card.ability.extra) == 'table' and ( pokermon.energy.get_total_energy(card) ~= 0
       or card.ability.extra.e_limit_up and card.ability.extra.e_limit_up > 0 ) then
     local energy = pokermon.energy.get_total_energy(card)

--- a/functions/uifunctions.lua
+++ b/functions/uifunctions.lua
@@ -496,3 +496,113 @@ G.FUNCS.poke_toggle_pokermon_skins = function()
     end
   end
 end
+
+should_draw_energy_ui = function(card)
+    local center = card.config and card.config.center
+    if not center then return false end
+    if center.set ~= "Joker" then
+        return false
+    end
+    if (not pokermon.energy.is_energizable(card)) and pokermon.energy.get_total_energy(card) == 0 then
+        return false
+    end
+    return pokermon_config.energy_count and 
+    card.ability and card.ability.set and card.ability.set == 'Joker' and
+    (card.area and card.area == G.jokers) and pokermon.energy.get_total_energy(card)
+end
+
+should_draw_energy_inactive_ui = function(card)
+    local center = card.config and card.config.center
+    if not center then return false end
+    if center.set ~= "Joker" then
+        return false
+    end
+    return pokermon_config.energy_count and not pokermon.energy.is_energizable(card) and 
+    card.ability and card.ability.set and card.ability.set == 'Joker' and
+    (card.area and card.area == G.jokers) and pokermon.energy.get_total_energy(card)
+end
+
+should_draw_sell_value_ui = function(card)
+    return pokermon_config.sell_value and 
+    card.ability and card.ability.set and card.ability.set == 'Joker'
+end
+
+
+generate_energy_ui = function(card)
+    return {
+        n = G.UIT.R,
+        config = {
+            align = "cm"
+        },
+        nodes = {
+        {
+            n = G.UIT.T,
+            config = {
+                text = "Energy: ",
+                colour = G.C.WHITE,
+                scale = 0.32
+            }
+        },
+        {
+            n = G.UIT.T,
+            config = {
+                text = pokermon.energy.get_total_energy(card),
+                colour = HEX("FF7ABF"),
+                scale = 0.32
+            }
+        },
+        {
+            n = G.UIT.T,
+            config = {
+                text = "/" .. (pokermon.energy.max + (G.GAME.poke_energy_plus or 0) + (type(card.ability.extra) == "table" and card.ability.extra.e_limit_up or 0)),
+                colour = G.C.WHITE,
+                scale = 0.32
+            }
+        }
+      }}
+end
+
+generate_energy_inactive_ui = function(card)
+    return {
+        n = G.UIT.R,
+        config = {
+            align = "cm"
+        },
+        nodes = {
+            {
+                n = G.UIT.T,
+                config = {
+                    text = not pokermon.energy.is_energizable(card) and " (Can't be energized)" or "",
+                    colour = G.C.UI.TEXT_INACTIVE,
+                    scale = 0.32
+                }
+            }
+        }
+    }
+end
+
+generate_sell_value_ui = function(card)
+    return {
+        n = G.UIT.R,
+        config = {
+            align = "cm"
+        },
+        nodes = { 
+        {
+            n = G.UIT.T,
+            config = {
+                text = "Sell Value: ",
+                colour = G.C.WHITE,
+                scale = 0.32
+            }
+        },
+        {
+            n = G.UIT.T,
+            config = {
+                text = "$" .. card.sell_cost,
+                colour = G.C.MONEY,
+                scale = 0.32
+            }
+        }
+      }}
+end

--- a/functions/uifunctions.lua
+++ b/functions/uifunctions.lua
@@ -497,7 +497,7 @@ G.FUNCS.poke_toggle_pokermon_skins = function()
   end
 end
 
-should_draw_energy_ui = function(card)
+pokermon.should_draw_energy_ui = function(card)
     local center = card.config and card.config.center
     if not center then return false end
     if center.set ~= "Joker" then
@@ -511,7 +511,7 @@ should_draw_energy_ui = function(card)
     (card.area and card.area == G.jokers) and pokermon.energy.get_total_energy(card)
 end
 
-should_draw_energy_inactive_ui = function(card)
+pokermon.should_draw_energy_inactive_ui = function(card)
     local center = card.config and card.config.center
     if not center then return false end
     if center.set ~= "Joker" then
@@ -522,13 +522,13 @@ should_draw_energy_inactive_ui = function(card)
     (card.area and card.area == G.jokers) and pokermon.energy.get_total_energy(card)
 end
 
-should_draw_sell_value_ui = function(card)
+pokermon.should_draw_sell_value_ui = function(card)
     return pokermon_config.sell_value and 
     card.ability and card.ability.set and card.ability.set == 'Joker'
 end
 
 
-generate_energy_ui = function(card)
+pokermon.generate_energy_ui = function(card)
     return {
         n = G.UIT.R,
         config = {
@@ -562,7 +562,7 @@ generate_energy_ui = function(card)
       }}
 end
 
-generate_energy_inactive_ui = function(card)
+pokermon.generate_energy_inactive_ui = function(card)
     return {
         n = G.UIT.R,
         config = {
@@ -581,7 +581,7 @@ generate_energy_inactive_ui = function(card)
     }
 end
 
-generate_sell_value_ui = function(card)
+pokermon.generate_sell_value_ui = function(card)
     return {
         n = G.UIT.R,
         config = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -7322,18 +7322,18 @@ return {
                 "the collection",
               }
             },
-            poke_energy_count_tooltip = {
+            poke_energy_ui_tooltip = {
               name = "Energy Count",
               text = {
                 "Displays a Joker's {C:poke_pink}Energy{}",
-                "count in its description",
+                "count under its description",
               }
             },
-            poke_sell_value_tooltip = {
+            poke_sell_value_ui_tooltip = {
               name = "Sell Value",
               text = {
                 "Displays a Joker's {C:money}sell value{}",
-                "in its description",
+                "under its description",
               }
             },
             legacycontent_tooltip = {
@@ -7713,6 +7713,8 @@ return {
             poke_settings_previous_evo_stickers = "Previous Evo Stickers?",
             poke_settings_order_jokers = "Order Jokers by Dex No.?",
             poke_settings_pokemon_only_collection = "Only Pokermon Jokers in Collection?",
+            poke_settings_pokemon_energy_ui = "Display Energy Count on Jokers?",
+            poke_settings_pokemon_sell_value_ui = "Display Sell Value on Jokers?",
             poke_settings_jokers_only = "Jokers only?",
             poke_settings_no_evolutions = "No Evolutions?",
             poke_settings_pokeballs = "Allow Pokéballs?",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -7326,14 +7326,14 @@ return {
               name = "Energy Count",
               text = {
                 "Displays a Joker's {C:poke_pink}Energy{}",
-                "count in it's description",
+                "count in its description",
               }
             },
             poke_sell_value_tooltip = {
               name = "Sell Value",
               text = {
                 "Displays a Joker's {C:money}sell value{}",
-                "in it's description",
+                "in its description",
               }
             },
             legacycontent_tooltip = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -7322,6 +7322,20 @@ return {
                 "the collection",
               }
             },
+            poke_energy_count_tooltip = {
+              name = "Energy Count",
+              text = {
+                "Displays a Joker's {C:poke_pink}Energy{}",
+                "count in it's description",
+              }
+            },
+            poke_sell_value_tooltip = {
+              name = "Sell Value",
+              text = {
+                "Displays a Joker's {C:money}sell value{}",
+                "in it's description",
+              }
+            },
             legacycontent_tooltip = {
               name = "Legacy Content",
               text = {

--- a/lovely/UI.toml
+++ b/lovely/UI.toml
@@ -78,3 +78,16 @@ pattern = '''if num < 0.01 then return tostring(num) end'''
 position = "at"
 payload = '''if num < 0.01 then return string.format("%.0f", num) end'''
 match_indent = true
+
+# Add energy count and sell value under Joker's description
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = "desc_from_rows(AUT.main),"
+position = "after"
+match_indent = true
+payload = '''
+should_draw_energy_ui(card) and generate_energy_ui(card) or nil,
+should_draw_energy_inactive_ui(card) and generate_energy_inactive_ui(card) or nil,
+should_draw_sell_value_ui(card) and generate_sell_value_ui(card) or nil,
+'''

--- a/lovely/UI.toml
+++ b/lovely/UI.toml
@@ -87,7 +87,7 @@ pattern = "desc_from_rows(AUT.main),"
 position = "after"
 match_indent = true
 payload = '''
-should_draw_energy_ui(card) and generate_energy_ui(card) or nil,
-should_draw_energy_inactive_ui(card) and generate_energy_inactive_ui(card) or nil,
-should_draw_sell_value_ui(card) and generate_sell_value_ui(card) or nil,
+pokermon.should_draw_energy_ui(card) and pokermon.generate_energy_ui(card) or nil,
+pokermon.should_draw_energy_inactive_ui(card) and pokermon.generate_energy_inactive_ui(card) or nil,
+pokermon.should_draw_sell_value_ui(card) and pokermon.generate_sell_value_ui(card) or nil,
 '''

--- a/pokeui.lua
+++ b/pokeui.lua
@@ -27,8 +27,8 @@ local misc_no_restart_toggles = {
   {ref_value = "previous_evo_stickers", label = "poke_settings_previous_evo_stickers", tooltip = {set = 'Other', key = 'previous_evo_stickers_tooltip'}},
   {ref_value = "order_jokers", label = "poke_settings_order_jokers", tooltip = {set = 'Other', key = 'order_jokers_tooltip'}},
   {ref_value = "pokemon_only_collection", label = "poke_settings_pokemon_only_collection", tooltip = {set = 'Other', key = 'pokemon_only_collection_tooltip'}},
-  {ref_value = "energy_count", label = "poke_settings_pokemon_energy_count", tooltip = {set = 'Other', key = 'poke_energy_count_tooltip'}},
-  {ref_value = "sell_value", label = "poke_settings_pokemon_sell_value", tooltip = {set = 'Other', key = 'poke_sell_value_tooltip'}},
+  {ref_value = "energy_count", label = "poke_settings_pokemon_energy_ui", tooltip = {set = 'Other', key = 'poke_energy_ui_tooltip'}},
+  {ref_value = "sell_value", label = "poke_settings_pokemon_sell_value_ui", tooltip = {set = 'Other', key = 'poke_sell_value_ui_tooltip'}},
 }
 
 local content_toggles = {

--- a/pokeui.lua
+++ b/pokeui.lua
@@ -26,7 +26,9 @@ local misc_no_restart_toggles = {
   {ref_value = "detailed_tooltips", label = "poke_settings_pokemon_detailed_tooltips", tooltip = {set = 'Other', key = 'detailed_tooltips_tooltip'}},
   {ref_value = "previous_evo_stickers", label = "poke_settings_previous_evo_stickers", tooltip = {set = 'Other', key = 'previous_evo_stickers_tooltip'}},
   {ref_value = "order_jokers", label = "poke_settings_order_jokers", tooltip = {set = 'Other', key = 'order_jokers_tooltip'}},
-  {ref_value = "pokemon_only_collection", label = "poke_settings_pokemon_only_collection", tooltip = {set = 'Other', key = 'pokemon_only_collection_tooltip'}}
+  {ref_value = "pokemon_only_collection", label = "poke_settings_pokemon_only_collection", tooltip = {set = 'Other', key = 'pokemon_only_collection_tooltip'}},
+  {ref_value = "energy_count", label = "poke_settings_pokemon_energy_count", tooltip = {set = 'Other', key = 'poke_energy_count_tooltip'}},
+  {ref_value = "sell_value", label = "poke_settings_pokemon_sell_value", tooltip = {set = 'Other', key = 'poke_sell_value_tooltip'}},
 }
 
 local content_toggles = {


### PR DESCRIPTION
I had these in a small QOL mod and figured I would share here. Adds 2 toggles which are disabled by default
One to add the current Energy count underneath a Joker's description, the other to add it's sell value there Energy value being displayed underneath the Joker has been quite nice to play with, and the sell value is quite useful with Pokermon

<img width="419" height="459" alt="image" src="https://github.com/user-attachments/assets/2db7dd52-6333-46c7-93a9-c89c2551eada" />
<img width="421" height="491" alt="image" src="https://github.com/user-attachments/assets/aa3ec316-23ee-43ac-85f2-0f4eddcf30c6" />
<img width="353" height="461" alt="image" src="https://github.com/user-attachments/assets/88052b1d-9908-4802-89ef-5c7ce2a81513" />
