### PR TITLE
fix mystery egg crash

### DIFF
--- a/pokemon/zotherjokers.lua
+++ b/pokemon/zotherjokers.lua
@@ -312,7 +312,7 @@ local mystery_egg = {
     end
   end,
   set_ability = function(self, card, initial, delay_sprites)
-    if initial then
+    if initial and G.playing_cards and not pokermon.is_in_collection(card) then
       local poke_key = SMODS.poll_object {
         type = 'Joker',
         attributes = {'stage_baby', 'stage_basic'},


### PR DESCRIPTION
fixes a mystery egg crash from calling `SMODS.poll_object` before the playing cards table is instantiated.

additionally stops RNG from being processed while viewing in the collection (TMJ will still trigger RNG calls)