### PR TITLE
Added support for SilkTouch

### DIFF
--- a/pokermon.lua
+++ b/pokermon.lua
@@ -190,6 +190,11 @@ if (SMODS.Mods["CardSleeves"] or {}).can_load then
   load_directory("sleeves", CardSleeves.Sleeve)
 end
 
+--Load SilkTouch Compatability
+if (SMODS.Mods["SilkTouch"] or {}).can_load then
+  assert(SMODS.load_file("silktouch/silktouch.lua"))()
+end
+
 --Load challenges file
 load_directory("challenges", SMODS.Challenge)
 

--- a/silktouch/silktouch.lua
+++ b/silktouch/silktouch.lua
@@ -1,0 +1,20 @@
+SilkTouch.DragTarget{
+    key = "Pokermon_save_consumable",
+    moveable_t = "S_buy",  -- Standard buy area (overlayed on G.jokers plus G.consumeables).
+    text = function(card)
+        return { "SAVE" }
+    end,
+    colour = pokermon.colours.pink,
+    drag_condition = function(card)
+        -- Show only for consumables in boosters if Pokermon save conditions apply ("Pocket" booster, Super Rod, etc.).
+        return card.area and card.area == G.pack_cards and card.ability.consumeable and pokermon.can_save_consumable(card) 
+    end,
+    active_check = function(card)
+        return #G.consumeables.cards < G.consumeables.config.card_limit
+    end,
+    release_func = function(card)
+        G.FUNCS.poke_reserve_card({config = {ref_table = card}})
+        play_sound('button', 1, 0.4)
+    end
+    }
+    


### PR DESCRIPTION
Imagine not knowing that saving consumables was a feature (totally didn’t happen to me).

[Link to SilkTouch.](https://github.com/HuyTheKiller/SilkTouch/tree/main)

https://github.com/user-attachments/assets/50eb9470-6457-4be9-a058-7f8793aa22d4

